### PR TITLE
Disable T4 support

### DIFF
--- a/python/aitemplate/testing/detect_target.py
+++ b/python/aitemplate/testing/detect_target.py
@@ -36,12 +36,13 @@ def _detect_cuda():
         )
         stdout, stderr = proc.communicate()
         stdout = stdout.decode("utf-8")
-        if "A100" in stdout or "RTX 30" in stdout or "A30" in stdout:
+        if "A100" in stdout or "RTX 30" in stdout or "A30" in stdout or "A10" in stdout:
             return "80"
-        if "V100" in stdout:
-            return "70"
         if "T4" in stdout:
-            return "75"
+            if os.environ.get("CI_FLAG", None) == "CIRCLECI":
+                return "75"
+            else:
+                return None
         return None
     except Exception:
         return None


### PR DESCRIPTION
Many users are confused on T4 although we list in README

```
Hardware requirement:
NVIDIA: AIT is only tested on SM80+ GPUs (Ampere etc). Not all kernels work with old SM75/SM70 (T4/V100) GPUs.
```
We will directly disable T4 support in code to avoid confusion.