### PR TITLE
add back 2 group norm instances on rocm backend

### DIFF
--- a/python/aitemplate/utils/mk_ck_lib/generator.py
+++ b/python/aitemplate/utils/mk_ck_lib/generator.py
@@ -2015,6 +2015,8 @@ def CreateGroupNormOperator(manifest, rank=5):
         groupnorm.TileDesc(256, 1, 256, 1, 8, 1, 8, 1, 8, 1, 8, 8),
         groupnorm.TileDesc(256, 1, 256, 1, 16, 1, 8, 1, 8, 1, 8, 8),
         groupnorm.TileDesc(256, 1, 256, 1, 32, 1, 8, 1, 8, 1, 8, 8),
+        groupnorm.TileDesc(1024, 1, 1024, 1, 32, 1, 8, 1, 8, 1, 8, 8),
+        groupnorm.TileDesc(1024, 1, 1024, 1, 8, 1, 2, 1, 2, 1, 2, 2),
     ]
 
     operations = []


### PR DESCRIPTION
@terrychenism @antinucleon Could we add back 2 group norm instances on rocm backend? Did they cause some issues?