### PR TITLE
Check head dim for flash attention

### DIFF
--- a/python/aitemplate/frontend/nn/attention.py
+++ b/python/aitemplate/frontend/nn/attention.py
@@ -123,8 +123,10 @@ class MultiheadAttention(Module):
 
         # simple heuristic, may need refinement
         self.use_flash = (
-            not (seq_len >= 512 and batch_size <= 2)
-        ) and head_dim % 8 == 0 and head_dim <= 128
+            (not (seq_len >= 512 and batch_size <= 2))
+            and head_dim % 8 == 0
+            and head_dim <= 128
+        )
         # odd seq try use flash
         if seq_len % 2 == 1:
             self.use_flash = True

--- a/python/aitemplate/frontend/nn/attention.py
+++ b/python/aitemplate/frontend/nn/attention.py
@@ -121,11 +121,10 @@ class MultiheadAttention(Module):
         self.mask_seq = mask_seq
         self.use_mem_eff = use_mem_eff
 
-        flash_head_dims = {8, 16, 32, 64, 128}
         # simple heuristic, may need refinement
         self.use_flash = (
             not (seq_len >= 512 and batch_size <= 2)
-        ) and head_dim in flash_head_dims
+        ) and head_dim % 8 == 0 and head_dim <= 128
         # odd seq try use flash
         if seq_len % 2 == 1:
             self.use_flash = True


### PR DESCRIPTION
What original flash attention checked: `head_dim % 8 == 0 and head_dim <= 128` but ait `head_dim in {8, 16, 32, 64, 128}`.
It should get aligned with flash attention. Some head dim like `88` or others should be supported.