### PR TITLE
Quality of life improvements for Stable Diffusion Example

### DIFF
--- a/examples/05_stable_diffusion/modeling/unet_2d_condition.py
+++ b/examples/05_stable_diffusion/modeling/unet_2d_condition.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-from typing import Optional, Tuple
+from typing import Tuple
 
 from aitemplate.frontend import nn
 

--- a/examples/05_stable_diffusion/modeling/unet_2d_condition.py
+++ b/examples/05_stable_diffusion/modeling/unet_2d_condition.py
@@ -29,7 +29,6 @@ class UNet2DConditionModel(nn.Module):
     implements for all the model (such as downloading or saving, etc.)
 
     Parameters:
-        sample_size (`int`, *optional*): The size of the input sample.
         in_channels (`int`, *optional*, defaults to 4): The number of channels in the input sample.
         out_channels (`int`, *optional*, defaults to 4): The number of channels in the output.
         center_input_sample (`bool`, *optional*, defaults to `False`): Whether to center the input sample.
@@ -54,7 +53,6 @@ class UNet2DConditionModel(nn.Module):
 
     def __init__(
         self,
-        sample_size: Optional[int] = None,
         in_channels: int = 4,
         out_channels: int = 4,
         center_input_sample: bool = False,
@@ -84,7 +82,6 @@ class UNet2DConditionModel(nn.Module):
     ):
         super().__init__()
         self.center_input_sample = center_input_sample
-        self.sample_size = sample_size
         time_embed_dim = block_out_channels[0] * 4
 
         # input

--- a/examples/05_stable_diffusion/modeling/vae.py
+++ b/examples/05_stable_diffusion/modeling/vae.py
@@ -124,7 +124,7 @@ class AutoencoderKL(nn.Module):
         layers_per_block: int = 1,
         act_fn: str = "silu",
         latent_channels: int = 4,
-        sample_size: int = 32,
+        #sample_size: int = 32,
     ):
         super().__init__()
         self.decoder = Decoder(

--- a/examples/05_stable_diffusion/pipeline_stable_diffusion_ait.py
+++ b/examples/05_stable_diffusion/pipeline_stable_diffusion_ait.py
@@ -124,7 +124,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
         noise_pred = ys[0].permute((0, 3, 1, 2)).float()
         return noise_pred
 
-    def clip_inference(self, input_ids, seqlen=64):
+    def clip_inference(self, input_ids, seqlen=77):
         exe_module = self.clip_ait_exe
         bs = input_ids.shape[0]
         position_ids = torch.arange(seqlen).expand((bs, -1)).cuda()
@@ -245,7 +245,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
         text_input = self.tokenizer(
             prompt,
             padding="max_length",
-            max_length=64,  # self.tokenizer.model_max_length,
+            max_length=77, #64,  # self.tokenizer.model_max_length,
             truncation=True,
             return_tensors="pt",
         )
@@ -279,7 +279,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
             uncond_input = self.tokenizer(
                 uncond_tokens,
                 padding="max_length",
-                max_length=max_length,
+                max_length=77,#max_length,
                 return_tensors="pt",
             )
             uncond_embeddings = self.clip_inference(
@@ -379,9 +379,11 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
         safety_cheker_input = self.feature_extractor(
             self.numpy_to_pil(image), return_tensors="pt"
         ).to(self.device)
-        image, has_nsfw_concept = self.safety_checker(
-            images=image, clip_input=safety_cheker_input.pixel_values
-        )
+        
+        #image, has_nsfw_concept = self.safety_checker(
+        #    images=image, clip_input=safety_cheker_input.pixel_values
+        #)
+        has_nsfw_concept = False
 
         if output_type == "pil":
             image = self.numpy_to_pil(image)

--- a/examples/05_stable_diffusion/pipeline_stable_diffusion_ait.py
+++ b/examples/05_stable_diffusion/pipeline_stable_diffusion_ait.py
@@ -95,6 +95,8 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
         self.vae_ait_exe = self.init_ait_module(
             model_name="AutoencoderKL", workdir=workdir
         )
+        
+        self.del_pt_models()
 
     def init_ait_module(
         self,
@@ -245,7 +247,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
         text_input = self.tokenizer(
             prompt,
             padding="max_length",
-            max_length=77, #64,  # self.tokenizer.model_max_length,
+            max_length=self.tokenizer.model_max_length,
             truncation=True,
             return_tensors="pt",
         )
@@ -279,7 +281,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
             uncond_input = self.tokenizer(
                 uncond_tokens,
                 padding="max_length",
-                max_length=77,#max_length,
+                max_length=max_length,
                 return_tensors="pt",
             )
             uncond_embeddings = self.clip_inference(
@@ -375,14 +377,6 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
         image = (image / 2 + 0.5).clamp(0, 1)
         image = image.cpu().permute(0, 2, 3, 1).numpy()
 
-        # run safety checker
-        safety_cheker_input = self.feature_extractor(
-            self.numpy_to_pil(image), return_tensors="pt"
-        ).to(self.device)
-        
-        #image, has_nsfw_concept = self.safety_checker(
-        #    images=image, clip_input=safety_cheker_input.pixel_values
-        #)
         has_nsfw_concept = False
 
         if output_type == "pil":

--- a/python/aitemplate/testing/detect_target.py
+++ b/python/aitemplate/testing/detect_target.py
@@ -45,8 +45,10 @@ def _detect_cuda():
         elif "NVIDIA" in stdout:
             # default to "80" if unknown NVIDIA device
             return "80"
-        return None
+        print("Fall back to 80...")
+        return "80"
     except Exception:
+        print("Fall back to 80...")
         return "80"
 
 

--- a/python/aitemplate/testing/detect_target.py
+++ b/python/aitemplate/testing/detect_target.py
@@ -47,7 +47,7 @@ def _detect_cuda():
             return "80"
         return None
     except Exception:
-        return None
+        return "80"
 
 
 def _detect_rocm():

--- a/python/aitemplate/testing/detect_target.py
+++ b/python/aitemplate/testing/detect_target.py
@@ -38,10 +38,13 @@ def _detect_cuda():
         stdout = stdout.decode("utf-8")
         if "A100" in stdout or "RTX 30" in stdout or "A30" in stdout or "RTX 40" in stdout:
             return "80"
-        if "V100" in stdout:
+        elif "V100" in stdout:
             return "70"
-        if "T4" in stdout:
+        elif "T4" in stdout:
             return "75"
+        elif "NVIDIA" in stdout:
+            # default to "80" if unknown NVIDIA device
+            return "80"
         return None
     except Exception:
         return None

--- a/python/aitemplate/testing/detect_target.py
+++ b/python/aitemplate/testing/detect_target.py
@@ -36,7 +36,7 @@ def _detect_cuda():
         )
         stdout, stderr = proc.communicate()
         stdout = stdout.decode("utf-8")
-        if "A100" in stdout or "RTX 30" in stdout or "A30" in stdout:
+        if "A100" in stdout or "RTX 30" in stdout or "A30" in stdout or "RTX 40" in stdout:
             return "80"
         if "V100" in stdout:
             return "70"


### PR DESCRIPTION
Hi,

For my own use case, I extended the stabled diffusion example:

- Made the `compile_diffusers()` function importable from outside
- Made the `compile_diffusers()` function run smoothly with different width, heights, and seqlen (number of tokens for CLIP)
- Set the default max token from 64 to 77. This allows for longer contexts and does not lead to a significant reduction in speed
- Added torch.inference_mode to the benchmarking to avoid some OOM problems for larger width and heights
- Deleted some unnecessary parameters
- Disabled the safety checker for benchmarking
- Adjusted the `detect_target`function in `testing` to work with 4090 too (See #95). This solution is very likely not ideal and should be adjusted