### PR TITLE
Fix python lint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -52,8 +52,6 @@ ignore =
   W293, # Blank line contains whitespace.
   W391, # Blank line at end of file.
   W504, # Line break occurred after a binary operator.
-
-  # Too opinionated.
   E265, # Block comment should start with '# '.
   E266, # Too many leading '#' for block comment.
   E402, # Module level import not at top of file. (Use cases like demandimport https://fburl.com/demandimport require statements before imports)

--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,8 @@ select = B,C,E,F,P,W,B9
 max-line-length = 80
 # Main Explanation Docs: https://github.com/grantmcconnaughey/Flake8Rules
 ignore =
+  # Black conflicts and overlaps.
+  # Found in https://github.com/psf/black/issues/429
   # Line too long.
   B950,
   # Indentation is not a multiple of four. 
@@ -97,6 +99,8 @@ ignore =
   W391,
   # Line break occurred after a binary operator. 
   W504, 
+
+  # Too opinionated.
   # Block comment should start with '# '.
   E265,
   # Too many leading '#' for block comment. 

--- a/.flake8
+++ b/.flake8
@@ -3,8 +3,6 @@ select = B,C,E,F,P,W,B9
 max-line-length = 80
 # Main Explanation Docs: https://github.com/grantmcconnaughey/Flake8Rules
 ignore =
-  # Black conflicts and overlaps.
-  # Found in https://github.com/psf/black/issues/429
   B950, # Line too long.
   E111, # Indentation is not a multiple of four.
   E115, # Expected an indented block (comment).

--- a/.flake8
+++ b/.flake8
@@ -3,57 +3,111 @@ select = B,C,E,F,P,W,B9
 max-line-length = 80
 # Main Explanation Docs: https://github.com/grantmcconnaughey/Flake8Rules
 ignore =
-  B950, # Line too long.
-  E111, # Indentation is not a multiple of four.
-  E115, # Expected an indented block (comment).
-  E117, # Over-indented.
-  E121, # Continuation line under-indented for hanging indent.
-  E122, # Continuation line missing indentation or outdented.
-  E123, # Closing bracket does not match indentation of opening bracket's line.
-  E124, # Closing bracket does not match visual indentation.
-  E125, # Continuation line with same indent as next logical line.
-  E126, # Continuation line over-indented for hanging indent.
-  E127, # Continuation line over-indented for visual indent.
-  E128, # Continuation line under-indented for visual indent.
-  E129, # Visually indented line with same indent as next logical line.
-  E131, # Continuation line unaligned for hanging indent.
-  E201, # Whitespace after '('.
-  E202, # Whitespace before ')'.
-  E203, # Whitespace before ':'.
-  E221, # Multiple spaces before operator.
-  E222, # Multiple spaces after operator.
-  E225, # Missing whitespace around operator.
-  E226, # Missing whitespace around arithmetic operator.
-  E227, # Missing whitespace around bitwise or shift operator.
-  E231, # Missing whitespace after ',', ';', or ':'.
-  E241, # Multiple spaces after ','.
-  E251, # Unexpected spaces around keyword / parameter equals.
-  E252, # Missing whitespace around parameter equals.
-  E261, # At least two spaces before inline comment.
-  E262, # Inline comment should start with '# '.
-  E265, # Block comment should start with '# '.
-  E271, # Multiple spaces after keyword.
-  E272, # Multiple spaces before keyword.
-  E301, # Expected 1 blank line, found 0.
-  E302, # Expected 2 blank lines, found 0.
-  E303, # Too many blank lines (3).
-  E305, # Expected 2 blank lines after end of function or class.
-  E306, # Expected 1 blank line before a nested definition.
-  E501, # Line too long (82 > 79 characters).
-  E502, # The backslash is redundant between brackets.
-  E701, # Multiple statements on one line (colon).
-  E702, # Multiple statements on one line (semicolon).
-  E703, # Statement ends with a semicolon.
-  E704, # Multiple statements on one line (def).
-  W291, # Trailing whitespace.
-  W292, # No newline at end of file.
-  W293, # Blank line contains whitespace.
-  W391, # Blank line at end of file.
-  W504, # Line break occurred after a binary operator.
-  E265, # Block comment should start with '# '.
-  E266, # Too many leading '#' for block comment.
-  E402, # Module level import not at top of file. (Use cases like demandimport https://fburl.com/demandimport require statements before imports)
-  E722, # Do not use bare except, specify exception instead. (Duplicate of B001)
-  P207, # (Duplicate of B003)
-  P208, # (Duplicate of C403)
-  W503  # Line break occurred before a binary operator.
+  # Line too long.
+  B950,
+  # Indentation is not a multiple of four. 
+  E111, 
+  # Expected an indented block (comment).
+  E115, 
+  # Over-indented.
+  E117,
+  # Continuation line under-indented for hanging indent. 
+  E121,
+  # Continuation line missing indentation or outdented. 
+  E122,
+  # Closing bracket does not match indentation of opening bracket's line. 
+  E123,
+  # Closing bracket does not match visual indentation. 
+  E124,
+  # Continuation line with same indent as next logical line. 
+  E125,
+  # Continuation line over-indented for hanging indent. 
+  E126,
+  # Continuation line over-indented for visual indent. 
+  E127,
+  # Continuation line under-indented for visual indent. 
+  E128,
+  # Visually indented line with same indent as next logical line. 
+  E129,
+  # Continuation line unaligned for hanging indent. 
+  E131,
+  # Whitespace after '('. 
+  E201,
+  # Whitespace before ')'. 
+  E202,
+  # Whitespace before ':'. 
+  E203,
+  # Multiple spaces before operator. 
+  E221,
+  # Multiple spaces after operator. 
+  E222,
+  # Missing whitespace around operator. 
+  E225,
+  # Missing whitespace around arithmetic operator. 
+  E226,
+  # Missing whitespace around bitwise or shift operator. 
+  E227,
+  # Missing whitespace after ',', ';', or ':'. 
+  E231,
+  # Multiple spaces after ','. 
+  E241,
+  # Unexpected spaces around keyword / parameter equals. 
+  E251,
+  # Missing whitespace around parameter equals. 
+  E252,
+  # At least two spaces before inline comment. 
+  E261, 
+  # Inline comment should start with '# '.
+  E262, 
+  # Block comment should start with '# '.
+  E265,
+  # Multiple spaces after keyword. 
+  E271,
+  # Multiple spaces before keyword. 
+  E272,
+  # Expected 1 blank line, found 0. 
+  E301,
+  # Expected 2 blank lines, found 0. 
+  E302,
+  # Too many blank lines (3). 
+  E303,
+  # Expected 2 blank lines after end of function or class. 
+  E305,
+  # Expected 1 blank line before a nested definition. 
+  E306,
+  # Line too long (82 > 79 characters). 
+  E501,
+  # The backslash is redundant between brackets. 
+  E502,
+  # Multiple statements on one line (colon). 
+  E701,
+  # Multiple statements on one line (semicolon). 
+  E702,
+  # Statement ends with a semicolon. 
+  E703,
+  # Multiple statements on one line (def). 
+  E704,
+  # Trailing whitespace. 
+  W291,
+  # No newline at end of file. 
+  W292,
+  # Blank line contains whitespace. 
+  W293,
+  # Blank line at end of file. 
+  W391,
+  # Line break occurred after a binary operator. 
+  W504, 
+  # Block comment should start with '# '.
+  E265,
+  # Too many leading '#' for block comment. 
+  E266,
+  # Module level import not at top of file. (Use cases like demandimport https://fburl.com/demandimport require statements before imports) 
+  E402, 
+  # Do not use bare except, specify exception instead. (Duplicate of B001)
+  E722, 
+  # (Duplicate of B003)
+  P207, 
+  # (Duplicate of C403)
+  P208,
+  # Line break occurred before a binary operator.
+  W503  


### PR DESCRIPTION
att

ref: https://stackoverflow.com/questions/74558565/flake8-error-code-supplied-to-ignore-option-does-not-match-a-z1-30