### PR TITLE
add linear projection to Unet for supporting SD2.0

### DIFF
--- a/examples/05_stable_diffusion/compile.py
+++ b/examples/05_stable_diffusion/compile.py
@@ -189,6 +189,7 @@ def compile_unet(
         sample_size=64,
         cross_attention_dim=hidden_dim,
         attention_head_dim=[5, 10, 20, 20],
+        use_linear_projection=True,
     )
     ait_mod.name_parameter_tensor()
 

--- a/examples/05_stable_diffusion/modeling/unet_2d_condition.py
+++ b/examples/05_stable_diffusion/modeling/unet_2d_condition.py
@@ -81,6 +81,7 @@ class UNet2DConditionModel(nn.Module):
         norm_eps: float = 1e-5,
         cross_attention_dim: int = 1280,
         attention_head_dim: Union[int, Tuple[int]] = 8,
+        use_linear_projection: bool = False
     ):
         super().__init__()
         self.center_input_sample = center_input_sample
@@ -120,6 +121,7 @@ class UNet2DConditionModel(nn.Module):
                 cross_attention_dim=cross_attention_dim,
                 attn_num_head_channels=attention_head_dim[i],
                 downsample_padding=downsample_padding,
+                use_linear_projection=use_linear_projection
             )
             self.down_blocks.append(down_block)
 
@@ -134,6 +136,7 @@ class UNet2DConditionModel(nn.Module):
             cross_attention_dim=cross_attention_dim,
             attn_num_head_channels=attention_head_dim[-1],
             resnet_groups=norm_num_groups,
+            use_linear_projection=use_linear_projection
         )
 
         # up
@@ -162,6 +165,7 @@ class UNet2DConditionModel(nn.Module):
                 resnet_act_fn=act_fn,
                 cross_attention_dim=cross_attention_dim,
                 attn_num_head_channels=reversed_attention_head_dim[i],
+                use_linear_projection=use_linear_projection
             )
             self.up_blocks.append(up_block)
             prev_output_channel = output_channel

--- a/examples/05_stable_diffusion/modeling/unet_blocks.py
+++ b/examples/05_stable_diffusion/modeling/unet_blocks.py
@@ -50,6 +50,7 @@ def get_down_block(
     attn_num_head_channels,
     cross_attention_dim=None,
     downsample_padding=None,
+    use_linear_projection=False,
 ):
     down_block_type = (
         down_block_type[7:]
@@ -95,6 +96,7 @@ def get_down_block(
             downsample_padding=downsample_padding,
             cross_attention_dim=cross_attention_dim,
             attn_num_head_channels=attn_num_head_channels,
+            use_linear_projection=use_linear_projection
         )
     elif down_block_type == "SkipDownBlock2D":
         return SkipDownBlock2D(
@@ -143,6 +145,7 @@ def get_up_block(
     resnet_act_fn,
     attn_num_head_channels,
     cross_attention_dim=None,
+    use_linear_projection=False,
 ):
     up_block_type = (
         up_block_type[7:] if up_block_type.startswith("UNetRes") else up_block_type
@@ -174,6 +177,7 @@ def get_up_block(
             resnet_act_fn=resnet_act_fn,
             cross_attention_dim=cross_attention_dim,
             attn_num_head_channels=attn_num_head_channels,
+            use_linear_projection=use_linear_projection,
         )
     elif up_block_type == "AttnUpBlock2D":
         return AttnUpBlock2D(
@@ -238,6 +242,7 @@ class UNetMidBlock2DCrossAttn(nn.Module):
         attention_type="default",
         output_scale_factor=1.0,
         cross_attention_dim=1280,
+        use_linear_projection=False,
         **kwargs,
     ):
         super().__init__()
@@ -273,6 +278,7 @@ class UNetMidBlock2DCrossAttn(nn.Module):
                     in_channels // attn_num_head_channels,
                     depth=1,
                     context_dim=cross_attention_dim,
+                    use_linear_projection=use_linear_projection,
                 )
             )
             resnets.append(
@@ -321,6 +327,7 @@ class CrossAttnDownBlock2D(nn.Module):
         output_scale_factor=1.0,
         downsample_padding=1,
         add_downsample=True,
+        use_linear_projection=False,
     ):
         super().__init__()
 
@@ -353,6 +360,7 @@ class CrossAttnDownBlock2D(nn.Module):
                     out_channels // attn_num_head_channels,
                     depth=1,
                     context_dim=cross_attention_dim,
+                    use_linear_projection=use_linear_projection,
                 )
             )
         self.attentions = nn.ModuleList(attentions)
@@ -480,6 +488,7 @@ class CrossAttnUpBlock2D(nn.Module):
         output_scale_factor=1.0,
         downsample_padding=1,
         add_upsample=True,
+        use_linear_projection=False,
     ):
         super().__init__()
 
@@ -514,6 +523,7 @@ class CrossAttnUpBlock2D(nn.Module):
                     out_channels // attn_num_head_channels,
                     depth=1,
                     context_dim=cross_attention_dim,
+                    use_linear_projection=use_linear_projection,
                 )
             )
         self.attentions = nn.ModuleList(attentions)


### PR DESCRIPTION
For SD 2, SpatialTransformer is using `linear_projection`
Config - https://huggingface.co/stabilityai/stable-diffusion-2/blob/main/unet/config.json
HF Code -https://github.com/huggingface/diffusers/blob/6b02323a602a66841729c3a5d60844b24aa81ff2/src/diffusers/models/attention.py#L49

@terrychenism 