### PR TITLE
support pipeline at 768x768 resolution

### DIFF
--- a/examples/05_stable_diffusion/demo.py
+++ b/examples/05_stable_diffusion/demo.py
@@ -44,7 +44,7 @@ def run(token, width, height, prompt, benchmark):
     with torch.autocast("cuda"):
         image = pipe(prompt, height, width).images[0]
         if benchmark:
-            t = benchmark_torch_function(10, pipe, prompt)
+            t = benchmark_torch_function(10, pipe, prompt, height=height, width=width)
             print(f"sd e2e: {t} ms")
 
     image.save("example_ait.png")


### PR DESCRIPTION
The pipeline default image size = 512x512, but when using the Stable Diffusion 2.0-v  (768x768) model for benchmark (--benchmark=True) evaluation, after compiled model in 768x768 image size,  the demo script will error in image size.