### PR TITLE
Updated init params for sd pipelines examples

### DIFF
--- a/examples/05_stable_diffusion/pipeline_stable_diffusion_ait.py
+++ b/examples/05_stable_diffusion/pipeline_stable_diffusion_ait.py
@@ -85,6 +85,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
         ],
         safety_checker: StableDiffusionSafetyChecker,
         feature_extractor: CLIPFeatureExtractor,
+        requires_safety_checker: bool = True,
     ):
         super().__init__(
             vae=vae,
@@ -94,6 +95,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
             scheduler=scheduler,
             safety_checker=safety_checker,
             feature_extractor=feature_extractor,
+            requires_safety_checker=requires_safety_checker,
         )
 
         workdir = "tmp/"

--- a/examples/05_stable_diffusion/pipeline_stable_diffusion_img2img_ait.py
+++ b/examples/05_stable_diffusion/pipeline_stable_diffusion_img2img_ait.py
@@ -86,6 +86,7 @@ class StableDiffusionImg2ImgAITPipeline(StableDiffusionImg2ImgPipeline):
         scheduler: Union[DDIMScheduler, PNDMScheduler, LMSDiscreteScheduler],
         safety_checker: StableDiffusionSafetyChecker,
         feature_extractor: CLIPFeatureExtractor,
+        requires_safety_checker: bool = True,
     ):
         # super().__init__()
         super().__init__(
@@ -96,6 +97,7 @@ class StableDiffusionImg2ImgAITPipeline(StableDiffusionImg2ImgPipeline):
             scheduler=scheduler,
             safety_checker=safety_checker,
             feature_extractor=feature_extractor,
+            requires_safety_checker=requires_safety_checker,
         )
         scheduler = scheduler.set_format("pt")
         self.register_modules(


### PR DESCRIPTION
Added requires_safety_checker param for stable diffusion pipelines examples following newer versions of diffusers pipelines: for [txt2img](https://github.com/huggingface/diffusers/blob/e01d6cf295043d5e98612d836ae2a281adcdf242/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py#L88) and [img2img](https://github.com/huggingface/diffusers/blob/e01d6cf295043d5e98612d836ae2a281adcdf242/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion_img2img.py#L112)

Otherwise the warning below is in stdout all the time during init and inference:

> The config attributes {'requires_safety_checker': True} were passed to StableDiffusionAITPipeline, but are not expected and will be ignored. Please verify your model_index.json configuration file.

