### PR TITLE
Added a facility to generate a standalone executable for the model

### DIFF
--- a/python/aitemplate/backend/builder.py
+++ b/python/aitemplate/backend/builder.py
@@ -32,6 +32,8 @@ from typing import Optional
 
 import jinja2
 
+from aitemplate.utils.debug_settings import AITDebugSettings
+
 from ..utils.misc import is_debug
 from .target import Target
 from .task_runner import BaseRunner, Task
@@ -40,6 +42,7 @@ from .task_runner import BaseRunner, Task
 
 
 _LOGGER = logging.getLogger(__name__)
+_DEBUG_SETTINGS = AITDebugSettings()
 
 
 def _augment_for_trace(cmd):
@@ -769,7 +772,14 @@ clean:
         cmds = [make_clean_cmd, make_all_cmd]
         _run_make_cmds(cmds, self._timeout, build_dir)
 
-    def make(self, file_pairs, dll_name, workdir, test_name, debug_settings):
+    def make(
+        self,
+        file_pairs,
+        dll_name,
+        workdir,
+        test_name,
+        debug_settings=_DEBUG_SETTINGS
+    ):
         self.gen_makefile(file_pairs, dll_name, workdir, test_name, debug_settings)
         make_path = shlex.quote(Target.current().make())
         build_dir = shlex.quote(os.path.join(workdir, test_name))

--- a/python/aitemplate/backend/builder.py
+++ b/python/aitemplate/backend/builder.py
@@ -32,6 +32,8 @@ from typing import Optional
 
 import jinja2
 
+from aitemplate.utils.debug_settings import AITDebugSettings
+
 from ..utils.misc import is_debug
 from .target import Target
 from .task_runner import BaseRunner, Task
@@ -358,7 +360,7 @@ class Builder(object):
         self._runner.join()
         self._runner.pull()
 
-    def gen_makefile(self, file_pairs, dll_name, workdir, test_name):
+    def gen_makefile(self, file_pairs, dll_name, workdir, test_name, debug_settings):
 
         makefile_template = jinja2.Template(
             """
@@ -374,20 +376,43 @@ obj_files = {{obj_files}}
     {{bfile_cmd}}
 
 .PHONY: all clean clean_constants
-all: {{target}}
+all: {{targets}}
 
-{{target}}: $(obj_files)
+{{dll_target}}: $(obj_files)
     {{build_so_cmd}}
 
+{{build_standalone_rules}}
+
 clean:
-    rm -f *.obj {{target}} test.so
+    rm -f *.obj {{targets}}
 
 clean_constants:
     rm -f constants.bin
 """
         )
+
+        standalone_rules_template = jinja2.Template(
+            """
+{{standalone_src}}: {{standalone_obj}}
+    {{cfile_cmd}}
+
+{{exe_target}}: {{exe_target_deps}}
+    {{build_exe_cmd}}
+"""
+        )
+
         build_so_cmd = "$(CC) -shared $(fPIC_flag) $(CFLAGS) -o $@ $(obj_files)"
-        obj_files = [pair[1].split("/")[-1] for pair in file_pairs]
+        standalone_src = "standalone.cu"
+        standalone_obj = "standalone.obj"
+        obj_files = []
+        # standalone.cu is an AITemplate internal file that is used for generating
+        # standalone executables. We only want to compile it when the relevant
+        # debug option is enabled.
+        obj_files = [
+            pair[1].split("/")[-1]
+            for pair in file_pairs
+            if not pair[1].endswith(standalone_obj)
+        ]
         obj_files = " ".join(obj_files)
 
         cc = Target.current().cc()
@@ -410,16 +435,36 @@ clean_constants:
             bfile_cmd = _augment_for_trace(bfile_cmd)
             build_so_cmd = _augment_for_trace(build_so_cmd)
 
+        build_exe_cmd = "$(CC) $(CFLAGS) -o $@ $(obj_files)"
+        targets = f"{dll_name}"
+
+        build_standalone_rules = ""
+        if debug_settings.gen_standalone:
+            build_exe_cmd = f"$(CC) $(CFLAGS) -o $@ {standalone_obj} {dll_name}"
+            exe_name = os.path.splitext(dll_name)[0] + ".exe"
+            exe_target_deps = f"{dll_name} {standalone_obj}"
+            build_standalone_rules = standalone_rules_template.render(
+                standalone_src=standalone_src,
+                standalone_obj=standalone_obj,
+                cfile_cmd=cfile_cmd,
+                exe_target=exe_name,
+                exe_target_deps=exe_target_deps,
+                build_exe_cmd=build_exe_cmd,
+            )
+            targets += f" {exe_name}"
+
         makefile_str = makefile_template.render(
             cc=cc,
             cpp=cpp,
             CFLAGS=compile_options,
             fPIC=fpic,
             obj_files=obj_files,
-            target=dll_name,
+            dll_target=dll_name,
+            targets=targets,
             cfile_cmd=cfile_cmd,
             bfile_cmd=bfile_cmd,
             build_so_cmd=build_so_cmd,
+            build_standalone_rules=build_standalone_rules,
         )
 
         dumpfile = os.path.join(workdir, test_name, "Makefile")
@@ -726,8 +771,8 @@ clean:
         cmds = [make_clean_cmd, make_all_cmd]
         _run_make_cmds(cmds, self._timeout, build_dir)
 
-    def make(self, file_pairs, dll_name, workdir, test_name):
-        self.gen_makefile(file_pairs, dll_name, workdir, test_name)
+    def make(self, file_pairs, dll_name, workdir, test_name, debug_settings):
+        self.gen_makefile(file_pairs, dll_name, workdir, test_name, debug_settings)
         make_path = shlex.quote(Target.current().make())
         build_dir = shlex.quote(os.path.join(workdir, test_name))
         make_flags = " ".join(

--- a/python/aitemplate/backend/builder.py
+++ b/python/aitemplate/backend/builder.py
@@ -32,8 +32,6 @@ from typing import Optional
 
 import jinja2
 
-from aitemplate.utils.debug_settings import AITDebugSettings
-
 from ..utils.misc import is_debug
 from .target import Target
 from .task_runner import BaseRunner, Task

--- a/python/aitemplate/backend/builder.py
+++ b/python/aitemplate/backend/builder.py
@@ -773,12 +773,7 @@ clean:
         _run_make_cmds(cmds, self._timeout, build_dir)
 
     def make(
-        self,
-        file_pairs,
-        dll_name,
-        workdir,
-        test_name,
-        debug_settings=_DEBUG_SETTINGS
+        self, file_pairs, dll_name, workdir, test_name, debug_settings=_DEBUG_SETTINGS
     ):
         self.gen_makefile(file_pairs, dll_name, workdir, test_name, debug_settings)
         make_path = shlex.quote(Target.current().make())

--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -248,7 +248,9 @@ def compile_model(
 
             start_t = datetime.now()
             compile_engine = backend.builder.Builder()
-            compile_engine.make(file_pairs, dll_name, workdir, test_name)
+            compile_engine.make(
+                file_pairs, dll_name, workdir, test_name, debug_settings
+            )
             _LOGGER.info(
                 f"compiled the final .so file elapsed time: {elapsed_dt_sec(start_t)}",
             )

--- a/python/aitemplate/utils/debug_settings.py
+++ b/python/aitemplate/utils/debug_settings.py
@@ -34,9 +34,12 @@ class AITDebugSettings:
         (e.g. NVTX for CUDA and rocTX for AMD) Currently only supports NVIDIA.
     dump_ait_to_py: str, optional
         The path where the AIT graph is dumped into a .py file.
+    gen_standalone : bool (default: False)
+        Generate a standalone executable for the model
     """
 
     check_all_nan_and_inf: bool = False
     check_all_outputs: bool = False
     gen_profiler_annotation: bool = False
     dump_ait_to_py: Optional[str] = None
+    gen_standalone: bool = False

--- a/static/csrc/model_container.cpp
+++ b/static/csrc/model_container.cpp
@@ -324,8 +324,22 @@ size_t ModelContainer::NumInputs() const {
 }
 
 const char* ModelContainer::InputName(size_t input_idx) const {
+  CHECK(input_idx < num_inputs_);
   CHECK_VECTOR_ACCESS(param_names_, input_idx)
   return param_names_[input_idx];
+}
+
+AITemplateParamShape ModelContainer::MaxInputShape(size_t input_idx) const {
+  CHECK(input_idx < num_inputs_);
+  CHECK_VECTOR_ACCESS(max_param_shapes_, input_idx)
+  auto& input_shape = max_param_shapes_[input_idx];
+  return AITemplateParamShape{input_shape.data(), input_shape.size()};
+}
+
+AITemplateDtype ModelContainer::InputDtype(size_t input_idx) const {
+  CHECK(input_idx < num_inputs_);
+  CHECK_VECTOR_ACCESS(param_dtypes_, input_idx)
+  return param_dtypes_[input_idx];
 }
 
 size_t ModelContainer::NumOutputs() const {

--- a/static/csrc/model_interface.cpp
+++ b/static/csrc/model_interface.cpp
@@ -233,6 +233,26 @@ AITemplateError AITemplateModelContainerGetInputName(
       { *input_name_out = m->InputName(input_idx); })
 }
 
+AITemplateError AITemplateModelContainerGetMaximumInputShape(
+    AITemplateModelHandle handle,
+    size_t input_idx,
+    AITemplateParamShape* shape) {
+  RETURN_ERROR_IF_NULL(handle)
+  RETURN_ERROR_IF_NULL(shape)
+  auto* m = reinterpret_cast<ait::ModelContainer*>(handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE({ *shape = m->MaxInputShape(input_idx); })
+}
+
+AITemplateError AITemplateModelContainerGetInputDtype(
+    AITemplateModelHandle handle,
+    size_t input_idx,
+    AITemplateDtype* input_dtype) {
+  RETURN_ERROR_IF_NULL(handle)
+  RETURN_ERROR_IF_NULL(input_dtype)
+  auto* m = reinterpret_cast<ait::ModelContainer*>(handle);
+  CONVERT_EXCEPTION_TO_ERROR_CODE({ *input_dtype = m->InputDtype(input_idx); })
+}
+
 AITemplateError AITemplateModelContainerGetNumOutputs(
     AITemplateModelHandle handle,
     size_t* num_outputs_out) {

--- a/static/csrc/standalone.cpp
+++ b/static/csrc/standalone.cpp
@@ -1,0 +1,298 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+// This file is used for generating a standalone executable for a model.
+// It only invokes the C++ model interface. We can directly invoke the
+// generated executable without going through Python bindings. Because it
+// aims for assisting debugging, we make a number of simplifications:
+//   * we use the maximum input shapes;
+//   * we only generate random inputs with a fixed seed;
+//   * we assume that outputs exist on the host;
+//   * we disable graph_mode;
+//   * etc...
+// Once the file is copied into the intemediate working dir (e.g.,
+// ./tmp/test_gemm_rcr) along with other files, users are free to make any
+// changes to the code. We do not try to predict users' actions.
+
+#include <functional>
+#include <iostream>
+#include <map>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "macros.h"
+#include "model_interface.h"
+#include "raii_wrapper.h"
+
+using namespace ait;
+
+template <typename T>
+static void make_random_integer_values(
+    std::mt19937& rnd_generator,
+    T* h_data,
+    size_t numel,
+    T lb,
+    T ub) {
+  std::uniform_int_distribution<> dist(lb, ub);
+  for (size_t i = 0; i < numel; i++) {
+    h_data[i] = static_cast<T>(dist(rnd_generator));
+  }
+}
+
+static void make_random_float_values(
+    std::mt19937& rnd_generator,
+    float* h_data,
+    size_t numel,
+    float lb,
+    float ub) {
+  std::uniform_real_distribution<> dist(lb, ub);
+  for (size_t i = 0; i < numel; i++) {
+    h_data[i] = static_cast<float>(dist(rnd_generator));
+  }
+}
+
+static void make_random_float16_values(
+    std::mt19937& rnd_generator,
+    half* h_data,
+    size_t numel,
+    float lb,
+    float ub) {
+  std::uniform_real_distribution<> dist(lb, ub);
+  for (size_t i = 0; i < numel; i++) {
+    float v = static_cast<float>(dist(rnd_generator));
+    h_data[i] = __float2half_rn(v);
+  }
+}
+
+static void make_random_bfloat16_values(
+    std::mt19937& rnd_generator,
+    bfloat16* h_data,
+    size_t numel,
+    float lb,
+    float ub) {
+  std::uniform_real_distribution<> dist(lb, ub);
+  for (size_t i = 0; i < numel; i++) {
+    float v = static_cast<float>(dist(rnd_generator));
+    h_data[i] = __float2bfloat16_rn(v);
+  }
+}
+
+static GPUPtr make_random_data(
+    AITemplateAllocator& allocator,
+    std::mt19937& rnd_generator,
+    const AITemplateParamShape& shape,
+    const AITemplateDtype& dtype) {
+  size_t numel = shape.Numel();
+  size_t num_bytes = numel * AITemplateDtypeSizeBytes(dtype);
+  void* h_data;
+  DEVICE_CHECK(DeviceMallocHost(&h_data, num_bytes));
+  switch (dtype) {
+    case AITemplateDtype::kInt:
+      make_random_integer_values<int>(
+          rnd_generator,
+          static_cast<int*>(h_data),
+          numel,
+          /*lb*/ -10,
+          /*ub*/ 10);
+      break;
+    case AITemplateDtype::kLong:
+      make_random_integer_values<int64_t>(
+          rnd_generator,
+          static_cast<int64_t*>(h_data),
+          numel,
+          /*lb*/ -10,
+          /*ub*/ 10);
+      break;
+    case AITemplateDtype::kFloat:
+      make_random_float_values(
+          rnd_generator,
+          static_cast<float*>(h_data),
+          numel,
+          /*lb*/ 1.0,
+          /*ub*/ 2.0);
+      break;
+    case AITemplateDtype::kBFloat16:
+      make_random_bfloat16_values(
+          rnd_generator,
+          static_cast<bfloat16*>(h_data),
+          numel,
+          /*lb*/ 1.0,
+          /*ub*/ 2.0);
+      break;
+    case AITemplateDtype::kHalf:
+      make_random_float16_values(
+          rnd_generator,
+          static_cast<half*>(h_data),
+          numel,
+          /*lb*/ 1.0,
+          /*ub*/ 2.0);
+      break;
+    case AITemplateDtype::kBool:
+      make_random_integer_values<bool>(
+          rnd_generator, static_cast<bool*>(h_data), numel, /*lb*/ 0, /*ub*/ 1);
+      break;
+    default:
+      throw std::runtime_error("unsupported dtype for making random data");
+  }
+
+  GPUPtr d_ptr = RAII_DeviceMalloc(num_bytes, allocator);
+  DEVICE_CHECK(CopyToDevice(d_ptr.get(), h_data, num_bytes));
+
+  // free memory
+  DEVICE_CHECK(FreeDeviceHostMemory(h_data));
+
+  return d_ptr;
+}
+
+using OutputDataPtr = std::unique_ptr<void, std::function<void(void*)>>;
+
+struct OutputData {
+  OutputData(
+      OutputDataPtr& data_in,
+      std::unique_ptr<int64_t[]>& shape_ptr_in,
+      int shape_size_in,
+      int index_in,
+      AITemplateDtype dtype_in,
+      const char* name_in)
+      : data(std::move(data_in)),
+        shape_ptr(std::move(shape_ptr_in)),
+        shape_size(shape_size_in),
+        index(index_in),
+        dtype(dtype_in),
+        name(name_in) {}
+
+  OutputData(OutputData&& other) noexcept
+      : data(std::move(other.data)),
+        shape_ptr(std::move(other.shape_ptr)),
+        shape_size(other.shape_size),
+        index(other.index),
+        dtype(other.dtype),
+        name(std::move(other.name)) {}
+
+  OutputDataPtr data;
+  std::unique_ptr<int64_t[]> shape_ptr;
+  int shape_size;
+  int index;
+  AITemplateDtype dtype;
+  std::string name;
+};
+
+static AITemplateError run(
+    AITemplateModelHandle handle,
+    AITemplateAllocator& allocator,
+    std::vector<OutputData>& outputs) {
+  size_t num_outputs = 0;
+  AITemplateModelContainerGetNumOutputs(handle, &num_outputs);
+
+  outputs.reserve(num_outputs);
+  std::vector<AITData> ait_outputs;
+  ait_outputs.reserve(num_outputs);
+  std::vector<int64_t*> ait_output_shapes_out;
+  ait_output_shapes_out.reserve(num_outputs);
+
+  for (unsigned i = 0; i < num_outputs; i++) {
+    const char* name;
+    AITemplateModelContainerGetOutputName(handle, i, &name);
+    AITemplateParamShape shape;
+    AITemplateModelContainerGetMaximumOutputShape(handle, i, &shape);
+    AITemplateDtype dtype;
+    AITemplateModelContainerGetOutputDtype(handle, i, &dtype);
+
+    std::unique_ptr<int64_t[]> shape_ptr =
+        std::make_unique<int64_t[]>(shape.size);
+    ait_output_shapes_out.push_back(shape_ptr.get());
+    size_t num_bytes = shape.Numel() * AITemplateDtypeSizeBytes(dtype);
+    void* h_data;
+    DEVICE_CHECK(DeviceMallocHost(&h_data, num_bytes));
+    ait_outputs.emplace_back(h_data, shape, dtype);
+    auto deleter = [](void* data) { FreeDeviceHostMemory(data); };
+    OutputDataPtr h_output_ptr(h_data, deleter);
+    outputs.emplace_back(
+        h_output_ptr, shape_ptr, (int)shape.size, (int)i, dtype, name);
+  }
+
+  size_t num_inputs = 0;
+  AITemplateModelContainerGetNumInputs(handle, &num_inputs);
+  // Holding unique_ptr(s) that will be auto-released.
+  std::vector<GPUPtr> input_ptrs;
+  input_ptrs.reserve(num_inputs);
+
+  std::map<std::string, unsigned> input_name_to_index;
+  std::vector<AITData> inputs(num_inputs);
+  std::mt19937 rnd_generator(1234);
+  // set up the name-to-index map each input
+  for (unsigned i = 0; i < num_inputs; i++) {
+    const char* name;
+    AITemplateModelContainerGetInputName(handle, i, &name);
+    input_name_to_index.insert({name, i});
+    std::cout << "input: " << name << ", at idx: " << i << "\n";
+
+    AITemplateParamShape shape;
+    AITemplateModelContainerGetMaximumInputShape(handle, i, &shape);
+    AITemplateDtype dtype;
+    AITemplateModelContainerGetInputDtype(handle, i, &dtype);
+    // This file aims for helping debugging so we make the code logic
+    // simple. Instead of asking the user to pass input names along with
+    // shapes, we just use the shape with the largest dimension values
+    // to make a random input. Once this code is copied into the test's
+    // tmp folder, the person who will be diagnosing the issue could make any
+    // changes to the code. We don't force us to predict the user's behavior.
+    input_ptrs.emplace_back(
+        make_random_data(allocator, rnd_generator, shape, dtype));
+    inputs[i] = AITData(input_ptrs.back().get(), shape, dtype);
+  }
+
+  bool graph_mode = false;
+  auto stream = RAII_StreamCreate(/*non_blocking=*/true);
+  return AITemplateModelContainerRunWithOutputsOnHost(
+      handle,
+      inputs.data(),
+      num_inputs,
+      ait_outputs.data(),
+      num_outputs,
+      reinterpret_cast<AITemplateStreamHandle>(stream.get()),
+      graph_mode,
+      ait_output_shapes_out.data());
+}
+
+int main() {
+  AITemplateModelHandle handle;
+  AITemplateModelContainerCreate(&handle, /*num_runtimes*/ 1);
+  AITemplateAllocator* allocator;
+  AIT_ERROR_CHECK(
+      AITemplateAllocatorCreate(&allocator, AITemplateAllocatorType::kDefault));
+
+  auto deleter = [](void* data) { FreeDeviceHostMemory(data); };
+
+  std::vector<OutputData> outputs;
+  AIT_ERROR_CHECK(run(handle, *allocator, outputs));
+
+  // print out something
+  for (const auto& output : outputs) {
+    std::cout << "output: " << output.name << " at idx: " << output.index
+              << " with shape: ";
+    for (int i = 0; i < output.shape_size; i++) {
+      std::cout << output.shape_ptr[i] << ",";
+    }
+    std::cout << "\n";
+  }
+
+  AIT_ERROR_CHECK(AITemplateAllocatorDelete(allocator));
+  // We are done and delete the handle.
+  AITemplateModelContainerDelete(handle);
+  return 0;
+}

--- a/static/include/cuda_device_functions.h
+++ b/static/include/cuda_device_functions.h
@@ -37,6 +37,8 @@ using GraphType = cudaGraph_t;
 using GraphExecType = cudaGraphExec_t;
 using Handle = void*;
 
+using bfloat16 = __nv_bfloat16;
+
 inline DeviceError GetDevice(int* device_idx) {
   return cudaGetDevice(device_idx);
 }
@@ -119,12 +121,20 @@ inline DeviceError FreeDeviceMemory(Handle src) {
   return cudaFree(src);
 }
 
+inline DeviceError FreeDeviceHostMemory(Handle src) {
+  return cudaFreeHost(src);
+}
+
 inline DeviceError FreeDeviceMemoryAsync(Handle src, StreamType stream = 0) {
   return cudaFreeAsync(src, stream);
 }
 
 inline DeviceError DeviceMalloc(Handle* dst, size_t size) {
   return cudaMalloc(dst, size);
+}
+
+inline DeviceError DeviceMallocHost(Handle* dst, size_t size) {
+  return cudaMallocHost(dst, size);
 }
 
 inline DeviceError DeviceMallocAsync(

--- a/static/include/model_container.h
+++ b/static/include/model_container.h
@@ -162,8 +162,12 @@ class ModelContainer : ModelContainerBase {
   const char* InputName(size_t input_idx) const;
   const char* OutputName(size_t output_idx) const;
 
+  AITemplateParamShape MaxInputShape(size_t input_idx) const;
   AITemplateParamShape MaxOutputShape(size_t output_idx) const;
+
+  AITemplateDtype InputDtype(size_t input_idx) const;
   AITemplateDtype OutputDtype(size_t output_idx) const;
+
   size_t MaxOutputStorageBytes(size_t output_idx) const;
 
   size_t GetNumRuntimes() const {

--- a/static/include/model_interface.h
+++ b/static/include/model_interface.h
@@ -43,6 +43,13 @@ enum class AITemplateError : int {
   AITemplateFailure = 1,
 };
 
+#define AIT_ERROR_CHECK(call)                                             \
+  if ((call) != AITemplateError::AITemplateSuccess) {                     \
+    throw std::runtime_error(                                             \
+        std::string(#call " API call failed at ") + __FILE__ + ", line" + \
+        std::to_string(__LINE__));                                        \
+  }
+
 struct AITemplateParamShape {
   AITemplateParamShape() : shape_data(nullptr), size(0) {}
   AITemplateParamShape(const int64_t* shape_data_in, size_t size_in)
@@ -200,6 +207,16 @@ AIT_EXPORT AITemplateError AITemplateModelContainerGetInputName(
     AITemplateModelHandle handle,
     size_t input_idx,
     const char** input_name_out);
+
+AIT_EXPORT AITemplateError AITemplateModelContainerGetMaximumInputShape(
+    AITemplateModelHandle handle,
+    size_t input_idx,
+    AITemplateParamShape* shape);
+
+AIT_EXPORT AITemplateError AITemplateModelContainerGetInputDtype(
+    AITemplateModelHandle handle,
+    size_t input_idx,
+    AITemplateDtype* input_dtype);
 
 AIT_EXPORT AITemplateError AITemplateModelContainerGetNumOutputs(
     AITemplateModelHandle handle,

--- a/static/include/rocm_device_functions.h
+++ b/static/include/rocm_device_functions.h
@@ -120,6 +120,10 @@ inline DeviceError FreeDeviceMemory(Handle src) {
   return hipFree(src);
 }
 
+inline DeviceError FreeDeviceHostMemory(Handle src) {
+  return hipHostFree(src);
+}
+
 inline DeviceError FreeDeviceMemoryAsync(
     Handle src,
     StreamType /*stream*/ = 0) {
@@ -129,6 +133,10 @@ inline DeviceError FreeDeviceMemoryAsync(
 
 inline DeviceError DeviceMalloc(Handle* dst, size_t size) {
   return hipMalloc(dst, size);
+}
+
+inline DeviceError DeviceMallocHost(Handle* dst, size_t size) {
+  return hipHostMalloc(dst, size, hipHostMallocDefault);
 }
 
 inline DeviceError DeviceMallocAsync(

--- a/tests/unittest/backend/test_gen_standalone.py
+++ b/tests/unittest/backend/test_gen_standalone.py
@@ -1,0 +1,169 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import logging
+import os
+import re
+import subprocess
+import unittest
+
+import torch
+
+from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler.ops.common.epilogue import FuncEnum
+from aitemplate.frontend import IntImm, Tensor
+from aitemplate.testing import detect_target
+from aitemplate.testing.test_utils import (
+    get_random_torch_tensor,
+    get_torch_empty_tensor,
+)
+from aitemplate.utils.debug_settings import AITDebugSettings
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class StridedOpCatPatternTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        torch.manual_seed(0)
+
+    def _test_gen_standalone(self, test_name, dtype):
+        M = 8
+        N = 16
+        K = 32
+        X1 = Tensor(
+            shape=[IntImm(M), IntImm(K)],
+            dtype=dtype,
+            name="X1",
+            is_input=True,
+        )
+        W1 = Tensor(
+            shape=[IntImm(N), IntImm(K)],
+            dtype=dtype,
+            name="W1",
+            is_input=True,
+        )
+        B1 = Tensor(
+            shape=[IntImm(N)],
+            dtype=dtype,
+            name="B1",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[IntImm(M), IntImm(N)],
+            dtype=dtype,
+            name="X2",
+            is_input=True,
+        )
+        X3 = Tensor(
+            shape=[IntImm(M), IntImm(N)],
+            dtype=dtype,
+            name="X3",
+            is_input=True,
+        )
+        Y1 = ops.gemm_rcr_bias()(X1, W1, B1)
+        Y2 = ops.elementwise(FuncEnum.ADD)(Y1, X2)
+        cat_dim = 1
+        Y = ops.concatenate()([X3, Y2], dim=cat_dim)
+        Y._attrs["name"] = "output_0"
+        Y._attrs["is_output"] = True
+
+        target = detect_target()
+        debug_settings = AITDebugSettings(gen_standalone=True)
+        dll_name = f"test.so"
+        module = compile_model(
+            Y,
+            target,
+            "./tmp",
+            test_name,
+            dll_name=dll_name,
+            debug_settings=debug_settings,
+        )
+
+        x1_pt = get_random_torch_tensor([M, K], dtype)
+        w1_pt = get_random_torch_tensor([N, K], dtype)
+        b1_pt = get_random_torch_tensor([N], dtype)
+        x2_pt = get_random_torch_tensor([M, N], dtype)
+        x3_pt = get_random_torch_tensor([M, N], dtype)
+
+        y1_pt = torch.nn.functional.linear(x1_pt, w1_pt, b1_pt)
+        y2_pt = y1_pt + x2_pt
+        y_pt = torch.cat([x3_pt, y2_pt], dim=cat_dim)
+        y = get_torch_empty_tensor(y_pt.shape, dtype)
+
+        module.run_with_tensors(
+            {
+                "X1": x1_pt,
+                "W1": w1_pt,
+                "B1": b1_pt,
+                "X2": x2_pt,
+                "X3": x3_pt,
+            },
+            [y],
+        )
+        self.assertTrue(torch.allclose(y, y_pt, atol=1e-2, rtol=1e-2))
+
+        # Now we run the generate executable
+        cwd = os.getcwd()
+        workdir = os.path.join(cwd, "tmp", test_name)
+        _LOGGER.info(f"work dir: {workdir}")
+        with subprocess.Popen(
+            ["./test.exe"],
+            shell=True,
+            cwd=workdir,
+            env=os.environ.copy(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ) as proc:
+            try:
+                timeout = 10
+                out, err = proc.communicate(timeout)
+            except subprocess.TimeoutExpired as e:
+                proc.kill()
+                out, err = proc.communicate()
+                raise e
+            finally:
+                stdout = out.decode()
+                stderr = err.decode()
+                if proc.returncode != 0:
+                    _LOGGER.info(f"stdout:\n\n{stdout}")
+                    _LOGGER.info(f"stderr:\n\n{stderr}")
+                    raise RuntimeError(f"failed to execute test.exe")
+                else:
+                    _LOGGER.info(f"stdout:\n\n{stdout}")
+                    all_output_lines = stdout.split("\n")
+                    output_lines = [
+                        line for line in all_output_lines if "output_0" in line
+                    ]
+                    self.assertTrue(len(output_lines) == 1)
+                    m = re.search("with shape:\s+([0-9,]+)", output_lines[0])
+                    self.assertTrue(m is not None)
+                    shape = m.group(1).split(",")
+                    self.assertTrue(int(shape[0]) == 8)
+                    self.assertTrue(int(shape[1]) == 32)
+
+    def test_gen_standalone_f16(self):
+        self._test_gen_standalone("gen_standalone_f16", "float16")
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    @unittest.skipIf(
+        detect_target().name() == "cuda" and int(detect_target()._arch) < 80,
+        "Not supported by CUDA < SM80.",
+    )
+    def test_gen_standalone_f32(self):
+        self._test_gen_standalone("gen_standalone_f32", "float32")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/backend/test_gen_standalone.py
+++ b/tests/unittest/backend/test_gen_standalone.py
@@ -117,12 +117,17 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
         # Now we run the generate executable
         cwd = os.getcwd()
         workdir = os.path.join(cwd, "tmp", test_name)
+        working_env = os.environ.copy()
+        if "LD_LIBRARY_PATH" in working_env:
+            working_env["LD_LIBRARY_PATH"] = working_env["LD_LIBRARY_PATH"] + ":" + workdir
+        else:
+            working_env["LD_LIBRARY_PATH"] = workdir
         _LOGGER.info(f"work dir: {workdir}")
         with subprocess.Popen(
             ["./test.exe"],
             shell=True,
             cwd=workdir,
-            env=os.environ.copy(),
+            env=working_env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         ) as proc:

--- a/tests/unittest/backend/test_gen_standalone.py
+++ b/tests/unittest/backend/test_gen_standalone.py
@@ -81,7 +81,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
 
         target = detect_target()
         debug_settings = AITDebugSettings(gen_standalone=True)
-        dll_name = f"test.so"
+        dll_name = "test.so"
         module = compile_model(
             Y,
             target,
@@ -139,7 +139,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
                 if proc.returncode != 0:
                     _LOGGER.info(f"stdout:\n\n{stdout}")
                     _LOGGER.info(f"stderr:\n\n{stderr}")
-                    raise RuntimeError(f"failed to execute test.exe")
+                    raise RuntimeError("failed to execute test.exe")
                 else:
                     _LOGGER.info(f"stdout:\n\n{stdout}")
                     all_output_lines = stdout.split("\n")
@@ -147,7 +147,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
                         line for line in all_output_lines if "output_0" in line
                     ]
                     self.assertTrue(len(output_lines) == 1)
-                    m = re.search("with shape:\s+([0-9,]+)", output_lines[0])
+                    m = re.search("with shape: +([0-9,]+)", output_lines[0])
                     self.assertTrue(m is not None)
                     shape = m.group(1).split(",")
                     self.assertTrue(int(shape[0]) == 8)

--- a/tests/unittest/backend/test_gen_standalone.py
+++ b/tests/unittest/backend/test_gen_standalone.py
@@ -119,7 +119,9 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
         workdir = os.path.join(cwd, "tmp", test_name)
         working_env = os.environ.copy()
         if "LD_LIBRARY_PATH" in working_env:
-            working_env["LD_LIBRARY_PATH"] = working_env["LD_LIBRARY_PATH"] + ":" + workdir
+            working_env["LD_LIBRARY_PATH"] = (
+                working_env["LD_LIBRARY_PATH"] + ":" + workdir
+            )
         else:
             working_env["LD_LIBRARY_PATH"] = workdir
         _LOGGER.info(f"work dir: {workdir}")


### PR DESCRIPTION
Sometimes, it would be more convenient to debug with a standalone executable without going through the python world.

This change added an option, gen_standalone, to AITDebugSettings, which can be passed to compile_model method. When gen_standalone is True, a standalone executable will be generated in the same folder as test.so, along with suitable changes to the Makefile.

Note that because we aim for assisting debugging, we make a number of simplifications to the entry standalone.cpp:
  * we use the maximum input shapes;
  * we only generate random inputs with a fixed seed;
  * we assume that outputs exist on the host;
  * we disable graph_mode;
  * etc... Once the file is copied into the intemediate working dir (e.g., ./tmp/gen_standalone_fp16) along with other files, users are free to make any changes to the code and run "make" to re-generate the executable.