### PR TITLE
bump gemm/conv2/conv3 cache versions to 2

### DIFF
--- a/python/aitemplate/backend/profiler_cache.py
+++ b/python/aitemplate/backend/profiler_cache.py
@@ -492,9 +492,9 @@ class ProfileCacheDB(object):
         #     leave some content from the failing version in the db. How are we
         #     going to update the db if we update the version again, and so on.
         # TODO: add similar version control for norm
-        self._gemm_cache_version = 1
-        self._conv_cache_version = 1
-        self._conv3d_cache_version = 1
+        self._gemm_cache_version = 2
+        self._conv_cache_version = 2
+        self._conv3d_cache_version = 2
         if uri is not None:
             self._mode = CacheMode.REMOTE
         if self._mode == CacheMode.LOCAL:


### PR DESCRIPTION
We upgraded to cutlass 3 recently, which introduced cache conflicts. Let's bump our cache versions to 2.