### PR TITLE
Generate name strings for NoneType

### DIFF
--- a/python/aitemplate/utils/visualization/plot.py
+++ b/python/aitemplate/utils/visualization/plot.py
@@ -71,8 +71,8 @@ def _gen_tensor_modal(tensor) -> str:
     content["dtype"] = str(tensor._attrs["dtype"])
     table_src = TABLE_TEMPLATE.render(table_data=content)
     modal_src = MODAL_TEMPLATE.render(
-        modal_id=tensor._attrs["name"] + "_modal",
-        modal_label=tensor._attrs["name"] + "_label",
+        modal_id=f'{tensor._attrs["name"]}_modal',
+        modal_label=f'{tensor._attrs["name"]}_label',
         modal_title=tensor._attrs["name"],
         modal_content=table_src,
     )
@@ -83,8 +83,8 @@ def _gen_op_modal(op) -> str:
     content = op_attr_factory.op_to_content(op)
     table_src = TABLE_TEMPLATE.render(table_data=content)
     modal_src = MODAL_TEMPLATE.render(
-        modal_id=op._attrs["name"] + "_modal",
-        modal_label=op._attrs["name"] + "_label",
+        modal_id=f'{op._attrs["name"]}_modal',
+        modal_label=f'{op._attrs["name"]}_label',
         modal_title=op._attrs["name"],
         modal_content=table_src,
     )

--- a/python/aitemplate/utils/visualization/pydot.py
+++ b/python/aitemplate/utils/visualization/pydot.py
@@ -439,6 +439,9 @@ def quote_if_necessary(s):
             return "True"
         return "False"
 
+    if s is None:
+        return f"{s}"
+
     if not isinstance(s, str):
         return s
 
@@ -451,7 +454,7 @@ def quote_if_necessary(s):
             "\n": r"\n",
             "\r": r"\r",
         }
-        for (a, b) in replace.items():
+        for a, b in replace.items():
             s = s.replace(a, b)
 
         return '"' + s + '"'
@@ -505,7 +508,6 @@ def graph_from_edges(edge_list, node_prefix="", directed=False):
         graph = Dot(graph_type="graph")
 
     for edge in edge_list:
-
         if isinstance(edge[0], str):
             src = node_prefix + edge[0]
         else:
@@ -729,11 +731,9 @@ class Node(Common):
         # as if they were Node definitions
         #
         if obj_dict is not None:
-
             self.obj_dict = obj_dict
 
         else:
-
             self.obj_dict = dict()
 
             # Copy the attributes
@@ -893,7 +893,6 @@ class Edge(Common):
             raise pydot.Error("Can not compare an edge to a non-edge object.")
 
         if self.get_parent_graph().get_top_graph_type() == "graph":
-
             # If the graph is undirected, the edge has neither
             # source nor destination.
             #
@@ -920,7 +919,6 @@ class Edge(Common):
             return node_str
 
         if node_str.startswith('"') and node_str.endswith('"'):
-
             return node_str
 
         node_port_idx = node_str.rfind(":")
@@ -1041,7 +1039,6 @@ class Graph(Common):
             self.obj_dict = obj_dict
 
         else:
-
             self.obj_dict = dict()
 
             self.obj_dict["attributes"] = dict(attrs)
@@ -1236,7 +1233,6 @@ class Graph(Common):
             name = name.get_name()
 
         if name in self.obj_dict["nodes"]:
-
             if index is not None and index < len(self.obj_dict["nodes"][name]):
                 del self.obj_dict["nodes"][name][index]
                 return True
@@ -1259,7 +1255,6 @@ class Graph(Common):
         match = list()
 
         if name in self.obj_dict["nodes"]:
-
             match.extend(
                 [Node(obj_dict=obj_dict) for obj_dict in self.obj_dict["nodes"][name]]
             )
@@ -1409,7 +1404,6 @@ class Graph(Common):
             )
 
         if sgraph.get_name() in self.obj_dict["subgraphs"]:
-
             sgraph_list = self.obj_dict["subgraphs"][sgraph.get_name()]
             sgraph_list.append(sgraph.obj_dict)
 
@@ -1432,7 +1426,6 @@ class Graph(Common):
         match = list()
 
         if name in self.obj_dict["subgraphs"]:
-
             sgraphs_obj_dict = self.obj_dict["subgraphs"].get(name)
 
             for obj_dict_list in sgraphs_obj_dict:
@@ -1484,9 +1477,7 @@ class Graph(Common):
         graph = list()
 
         if self.obj_dict.get("strict", None) is not None:
-
             if self == self.get_parent_graph() and self.obj_dict["strict"]:
-
                 graph.append("strict ")
 
         graph_type = self.obj_dict["type"]
@@ -1496,9 +1487,7 @@ class Graph(Common):
         graph.append(s)
 
         for attr in sorted(self.obj_dict["attributes"]):
-
             if self.obj_dict["attributes"].get(attr, None) is not None:
-
                 val = self.obj_dict["attributes"].get(attr)
                 if val == "":
                     val = '""'
@@ -1538,12 +1527,10 @@ class Graph(Common):
         obj_list.sort(key=lambda x: x[0])
 
         for idx, obj in obj_list:
-
             if obj["type"] == "node":
                 node = Node(obj_dict=obj)
 
                 if self.obj_dict.get("suppress_disconnected", False):
-
                     if (
                         node.get_name() not in edge_src_set
                         and node.get_name() not in edge_dst_set
@@ -1623,7 +1610,6 @@ class Subgraph(Graph):
         )
 
         if obj_dict is None:
-
             self.obj_dict["type"] = "subgraph"
 
 
@@ -1677,7 +1663,6 @@ class Cluster(Graph):
         )
 
         if obj_dict is None:
-
             self.obj_dict["type"] = "subgraph"
             self.obj_dict["name"] = quote_if_necessary("cluster_" + graph_name)
 


### PR DESCRIPTION
We enabled to dump a virtual graph after each transformation with LOGLEVEL=debug. One side-effect of this change was that we may encounter cases where nodes haven't been assigned any names, e.g. for transformations before the naming pass. When we plot such a graph, we would hit assertion failures if we "add" NoneType names to another string.

This PR fixed the issue by forcing NoneType names to have string representation.