### PR TITLE
print the device features on model container initialization

### DIFF
--- a/static/csrc/model_container.cpp
+++ b/static/csrc/model_container.cpp
@@ -19,6 +19,185 @@
 
 namespace ait {
 
+std::string uuid_to_string(const char bytes[16]) {
+  std::vector<std::tuple<int, int>> groups = {
+      {0, 4}, {4, 6}, {6, 8}, {8, 10}, {10, 16}};
+  char const hex_chars[16] = {
+      '0',
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+      'a',
+      'b',
+      'c',
+      'd',
+      'e',
+      'f'};
+
+  std::string result;
+  bool first = true;
+  for (auto g : groups) {
+    if (!first) {
+      result += "-";
+    } else {
+      first = false;
+    }
+    for (size_t i = std::get<0>(g); i < std::get<1>(g); ++i) {
+      result += hex_chars[(bytes[i] & 0xF0) >> 4];
+      result += hex_chars[(bytes[i] & 0x0F)];
+    }
+  }
+  return result;
+}
+
+void print_device_properties(const DevicePropertyType& prop) {
+  LOG(INFO)
+      << "Hardware accelerator device properties: "
+      << "\n  Device: "
+      << "\n     ASCII string identifying device: " << prop.name
+      << "\n     Major compute capability: " << prop.major
+      << "\n     Minor compute capability: " << prop.minor
+      << "\n     UUID: " << uuid_to_string(prop.uuid.bytes)
+      << "\n     Unique identifier for a group of devices on the same multi-GPU board: "
+      << prop.multiGpuBoardGroupID
+      << "\n     PCI bus ID of the device: " << prop.pciBusID
+      << "\n     PCI device ID of the device: " << prop.pciDeviceID
+      << "\n     PCI domain ID of the device: " << prop.pciDomainID
+
+      << "\n  Memory limits: "
+      << "\n     Constant memory available on device in bytes: "
+      << prop.totalConstMem
+      << "\n     Global memory available on device in bytes: "
+      << prop.totalGlobalMem
+      << "\n     Global memory bus width in bits: " << prop.memoryBusWidth
+      << "\n     Size of L2 cache in bytes: " << prop.l2CacheSize
+      << "\n     Device's maximum L2 persisting lines capacity in bytes: "
+      << prop.persistingL2CacheMaxSize
+      << "\n     Shared memory reserved by CUDA driver per block in bytes: "
+      << prop.reservedSharedMemPerBlock
+      << "\n     Shared memory available per block in bytes: "
+      << prop.sharedMemPerBlock
+      << "\n     Per device maximum shared memory per block usable by special opt in: "
+      << prop.sharedMemPerBlockOptin
+      << "\n     Shared memory available per multiprocessor in bytes: "
+      << prop.sharedMemPerMultiprocessor
+      << "\n     The maximum value of cudaAccessPolicyWindow::num_bytes: "
+      << prop.accessPolicyMaxWindowSize
+
+      << "\n  Thread limits: "
+      << "\n     Warp size in threads: " << prop.warpSize
+      << "\n     Maximum size of each dimension of a grid: "
+      << prop.maxGridSize[0] << " " << prop.maxGridSize[1] << " "
+      << prop.maxGridSize[2]
+      << "\n     Maximum size of each dimension of a block: "
+      << prop.maxThreadsDim[0] << " " << prop.maxThreadsDim[1] << " "
+      << prop.maxThreadsDim[2]
+      << "\n     Number of asynchronous engines: " << prop.asyncEngineCount
+      << "\n     Maximum number of resident blocks per multiprocessor: "
+      << prop.maxBlocksPerMultiProcessor
+      << "\n     Maximum number of threads per block: "
+      << prop.maxThreadsPerBlock
+      << "\n     Maximum resident threads per multiprocessor: "
+      << prop.maxThreadsPerMultiProcessor
+      << "\n     Maximum pitch in bytes allowed by memory copies: "
+      << prop.memPitch << "\n     Number of multiprocessors on device: "
+      << prop.multiProcessorCount
+      << "\n     32-bit registers available per block: " << prop.regsPerBlock
+      << "\n     32-bit registers available per multiprocessor: "
+      << prop.regsPerMultiprocessor
+
+      << "\n  Device features: "
+      << "\n     Device has ECC support enabled: "
+      << (prop.ECCEnabled ? "yes" : "no")
+      << "\n     Device can map host memory with cudaHostAlloc/cudaHostGetDevicePointer: "
+      << (prop.canMapHostMemory ? "yes" : "no")
+      << "\n     Device can access host registered memory at the same virtual address as the CPU: "
+      << (prop.canUseHostPointerForRegisteredMem ? "yes" : "no")
+      << "\n     Device supports Compute Preemption: "
+      << (prop.computePreemptionSupported ? "yes" : "no")
+      << "\n     Device can possibly execute multiple kernels concurrently: "
+      << (prop.concurrentKernels ? "yes" : "no")
+      << "\n     Device can coherently access managed memory concurrently with the CPU: "
+      << (prop.concurrentManagedAccess ? "yes" : "no")
+      << "\n     Device supports launching cooperative kernels via cudaLaunchCooperativeKernel: "
+      << (prop.cooperativeLaunch ? "yes" : "no")
+      << "\n     Host can directly access managed memory on the device without migration: "
+      << (prop.directManagedMemAccessFromHost ? "yes" : "no")
+      << "\n     Device supports caching globals in L1: "
+      << (prop.globalL1CacheSupported ? "yes" : "no")
+      << "\n     Link between the device and the host supports native atomic operations: "
+      << (prop.hostNativeAtomicSupported ? "yes" : "no")
+      << "\n     Device is integrated as opposed to discrete: "
+      << (prop.integrated ? "yes" : "no")
+      << "\n     Device is on a multi-GPU board: "
+      << (prop.isMultiGpuBoard ? "yes" : "no")
+      << "\n     Device supports caching locals in L1: "
+      << (prop.localL1CacheSupported ? "yes" : "no")
+      << "\n     Device supports allocating managed memory on this system: "
+      << (prop.managedMemory ? "yes" : "no")
+      << "\n     Device supports coherently accessing pageable memory without calling cudaHostRegister on it: "
+      << (prop.pageableMemoryAccess ? "yes" : "no")
+      << "\n     Device accesses pageable memory via the host's page tables: "
+      << (prop.pageableMemoryAccessUsesHostPageTables ? "yes" : "no")
+      << "\n     Device supports stream priorities: "
+      << (prop.streamPrioritiesSupported ? "yes" : "no")
+      << "\n     Device is a Tesla device using TCC driver: "
+      << (prop.tccDriver ? "yes" : "no")
+      << "\n     Device shares a unified address space with the host: "
+      << (prop.unifiedAddressing ? "yes" : "no")
+
+      << "\n  Texture limits: "
+      << "\n     Maximum 1D surface size: " << prop.maxSurface1D
+      << "\n     Maximum 1D layered surface dimensions: "
+      << prop.maxSurface1DLayered[0] << " " << prop.maxSurface1DLayered[1]
+      << "\n     Maximum 2D surface dimensions: " << prop.maxSurface2D[0] << " "
+      << prop.maxSurface2D[1]
+      << "\n     Maximum 2D layered surface dimensions: "
+      << prop.maxSurface2DLayered[0] << " " << prop.maxSurface2DLayered[1]
+      << " " << prop.maxSurface2DLayered[2]
+      << "\n     Maximum 3D surface dimensions: " << prop.maxSurface3D[0] << " "
+      << prop.maxSurface3D[1] << " " << prop.maxSurface3D[2]
+      << "\n     Maximum Cubemap surface dimensions: " << prop.maxSurfaceCubemap
+      << "\n     Maximum Cubemap layered surface dimensions: "
+      << prop.maxSurfaceCubemapLayered[0] << " "
+      << prop.maxSurfaceCubemapLayered[1]
+      << "\n     Maximum 1D texture size: " << prop.maxTexture1D
+      << "\n     Maximum 1D layered texture dimensions "
+      << prop.maxTexture1DLayered[0] << " " << prop.maxTexture1DLayered[1]
+      << "\n     Maximum 1D mipmapped texture size: " << prop.maxTexture1DMipmap
+      << "\n     Maximum 2D texture dimensions: " << prop.maxTexture2D[0] << " "
+      << prop.maxTexture2D[1]
+      << "\n     Maximum 2D texture dimensions if texture gather operations have to be performed: "
+      << prop.maxTexture2DGather[0] << " " << prop.maxTexture2DGather[1]
+      << "\n     Maximum 2D layered texture dimensions: "
+      << prop.maxTexture2DLayered[0] << " " << prop.maxTexture2DLayered[1]
+      << " " << prop.maxTexture2DLayered[2]
+      << "\n     Maximum dimensions (width, height, pitch) for 2D textures bound to pitched memory: "
+      << prop.maxTexture2DLinear[0] << " " << prop.maxTexture2DLinear[1] << " "
+      << prop.maxTexture2DLinear[2]
+      << "\n     Maximum 2D mipmapped texture dimensions: "
+      << prop.maxTexture2DMipmap[0] << " " << prop.maxTexture2DMipmap[1]
+      << "\n     Maximum 3D texture dimensions: " << prop.maxTexture3D[0] << " "
+      << prop.maxTexture3D[1] << " " << prop.maxTexture3D[2]
+      << "\n     Maximum alternate 3D texture dimensions: "
+      << prop.maxTexture3DAlt[0] << " " << prop.maxTexture3DAlt[1] << " "
+      << prop.maxTexture3DAlt[2]
+      << "\n     Maximum Cubemap texture dimensions: " << prop.maxTextureCubemap
+      << "\n     Maximum Cubemap layered texture dimensions: "
+      << prop.maxTextureCubemapLayered[0] << " "
+      << prop.maxTextureCubemapLayered[1]
+      << "\n     Alignment requirements for surfaces: " << prop.surfaceAlignment
+      << "\n     Alignment requirement for textures: " << prop.textureAlignment
+      << "\n     Pitch alignment requirement for texture references bound to pitched memory: "
+      << prop.texturePitchAlignment;
+}
+
 ModelContainer::ModelContainer(
     size_t num_models,
     size_t num_inputs,
@@ -45,6 +224,14 @@ ModelContainer::ModelContainer(
   DEVICE_CHECK(GetRuntimeVersion(&runtime_version));
   LOG(INFO) << "Device Runtime Version: " << runtime_version
             << "; Driver Version: " << driver_version;
+
+  int dev_id;
+  DevicePropertyType prop;
+  DEVICE_CHECK(GetDevice(&dev_id));
+  DEVICE_CHECK(GetDeviceProperties(&prop, dev_id));
+
+  print_device_properties(prop);
+
   LOG(INFO) << "Init AITemplate Runtime with " << num_models << " concurrency";
   models_.reserve(num_models);
   available_models_.reserve(num_models);


### PR DESCRIPTION
Summary:
retrieve and parse cudaDeviceProp

the motivation comes from accidentally hitting the device's shared memory limit without realizing it

more info in logs should help in future with debugging

it follows the struct doc for cuda 12 at https://docs.nvidia.com/cuda/cuda-runtime-api/structcudaDeviceProp.html#structcudaDeviceProp_1d5909d1563000146dd3f12646f3c98c7

removing (1) deprecated fields and (2) fields causing compilation error with nvcc 11.4

and reordering so that similar properties appear together

Differential Revision: D42913584

