### PR TITLE
Make Stable Diffusion Example dynamic to support both 1.x and 2.x versions

### DIFF
--- a/examples/05_stable_diffusion/scripts/compile.py
+++ b/examples/05_stable_diffusion/scripts/compile.py
@@ -64,10 +64,12 @@ def compile_diffusers(
     compile_clip(
         pipe.text_encoder,
         batch_size=batch_size,
-        dim=1024,
-        num_heads=16,
         use_fp16_acc=use_fp16_acc,
         convert_conv_to_gemm=convert_conv_to_gemm,
+        depth=pipe.text_encoder.config.num_hidden_layers,
+        num_heads=pipe.text_encoder.config.num_attention_heads,
+        dim=pipe.text_encoder.config.hidden_size,
+        act_layer=pipe.text_encoder.config.hidden_act,
     )
     # UNet
     compile_unet(
@@ -77,6 +79,8 @@ def compile_diffusers(
         height=hh,
         use_fp16_acc=use_fp16_acc,
         convert_conv_to_gemm=convert_conv_to_gemm,
+        hidden_dim=pipe.unet.config.cross_attention_dim,
+        attention_head_dim=pipe.unet.config.attention_head_dim,
     )
     # VAE
     compile_vae(

--- a/examples/05_stable_diffusion/src/benchmark.py
+++ b/examples/05_stable_diffusion/src/benchmark.py
@@ -297,7 +297,11 @@ def benchmark_diffusers(local_dir, batch_size, verify, benchmark_pt):
     )
     # UNet
     benchmark_unet(
-        pipe.unet, batch_size=batch_size * 2, benchmark_pt=benchmark_pt, verify=verify
+        pipe.unet,
+        batch_size=batch_size * 2,
+        benchmark_pt=benchmark_pt,
+        verify=verify,
+        hidden_dim=pipe.text_encoder.config.hidden_size,
     )
     # VAE
     benchmark_vae(

--- a/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
@@ -82,12 +82,13 @@ def compile_clip(
     seqlen=64,
     dim=768,
     num_heads=12,
+    depth=12,
     use_fp16_acc=False,
     convert_conv_to_gemm=False,
+    act_layer="gelu",
 ):
     mask_seq = 0
     causal = True
-    depth = 23
 
     ait_mod = ait_CLIPTextTransformer(
         num_hidden_layers=depth,
@@ -97,6 +98,7 @@ def compile_clip(
         seq_len=seqlen,
         causal=causal,
         mask_seq=mask_seq,
+        act_layer=act_layer,
     )
     ait_mod.name_parameter_tensor()
 

--- a/examples/05_stable_diffusion/src/compile_lib/compile_unet.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_unet.py
@@ -57,12 +57,13 @@ def compile_unet(
     hidden_dim=1024,
     use_fp16_acc=False,
     convert_conv_to_gemm=False,
+    attention_head_dim=[5, 10, 20, 20],
 ):
 
     ait_mod = ait_UNet2DConditionModel(
         sample_size=64,
         cross_attention_dim=hidden_dim,
-        attention_head_dim=[5, 10, 20, 20],
+        attention_head_dim=attention_head_dim,
     )
     ait_mod.name_parameter_tensor()
 

--- a/examples/05_stable_diffusion/src/test_correctness.py
+++ b/examples/05_stable_diffusion/src/test_correctness.py
@@ -77,9 +77,13 @@ class StableDiffusionVerification(unittest.TestCase):
         self.unet_config = {
             "batch_size": 2,
             "dim": 320,
-            "hidden_dim": 1024,
+            "hidden_dim": pipe.unet.config.cross_attention_dim,
             "width": 64,
             "height": 64,
+        }
+
+        self.unet_compile_extra_config = {
+            "attention_head_dim": pipe.unet.config.attention_head_dim,
         }
 
         self.clip_config = {
@@ -88,8 +92,10 @@ class StableDiffusionVerification(unittest.TestCase):
         }
 
         self.clip_compile_extra_config = {
-            "dim": 1024,
-            "num_heads": 16,
+            "depth": pipe.text_encoder.config.num_hidden_layers,
+            "num_heads": pipe.text_encoder.config.num_attention_heads,
+            "dim": pipe.text_encoder.config.hidden_size,
+            "act_layer": pipe.text_encoder.config.hidden_act,
         }
 
     def test_vae(self):
@@ -112,6 +118,7 @@ class StableDiffusionVerification(unittest.TestCase):
             use_fp16_acc=False,
             convert_conv_to_gemm=True,
             **self.unet_config,
+            **self.unet_compile_extra_config,
         )
         benchmark_unet(
             self.pt_unet,


### PR DESCRIPTION
Currently, the stable diffusion example only supports version 2.0 and above. This change adds support for both 1.x and 2.x versions, and dynamically compiles according to the provided pre-trained pipeline.

Tested with both version 2, 1.5 and a custom trained 1.5 version on 3090. Let me know if there are any other tests to run.