### PR TITLE
Relaunch add passes as option to AITTestCase.run_test

### DIFF
--- a/fx2ait/fx2ait/tools/common_fx2ait.py
+++ b/fx2ait/fx2ait/tools/common_fx2ait.py
@@ -82,6 +82,7 @@ class AITTestCase(TestCase):
         permute_inputs: Optional[List[int]] = None,
         permute_outputs: Optional[List[int]] = None,
         transformer_mode: Optional[bool] = False,
+        passes: List[Callable] = [],  # noqa: B006
     ):
         # TODO: add precision to interpreter once AIT supports multiple precision level
         # TODO: @qxy11 remove permute options once AIT supports channels-first format
@@ -93,6 +94,9 @@ class AITTestCase(TestCase):
                 torch.nn.MultiheadAttention if transformer_mode else None
             ],
         )
+        for p in passes:
+            mod = p(mod, inputs)
+
         print(mod.graph)
 
         original_inputs = inputs


### PR DESCRIPTION
Summary:
We had issues with dper pass
like we encountered in D42983806, but currently AITTestCase.run_test does not support taking in dper passes.
This diff add passes as input to AITTestCase.run_test to test the correctness of dper passes.

Previous diff D42984527 (https://github.com/facebookincubator/AITemplate/commit/e02d03ab3d20258e47589095ba20a4a950950ef6) has the issue that OSS don't know deeplearning

Differential Revision: D43019947

