### PR TITLE
place slice_reshape_scatter's output with a suitable offset

### DIFF
--- a/python/aitemplate/backend/common/tensor/slice_common.py
+++ b/python/aitemplate/backend/common/tensor/slice_common.py
@@ -369,6 +369,7 @@ template <typename ELEM_T, {{index_type}}  Rank, {{index_type}}  NumInputs,
           {{index_type}}  ElemsPerThread, {{index_type}}  ThreadsPerBlock>
 void slice_scatter_kernel_launcher(
     ELEM_T *output,
+    {{index_type}} output_offset,
     const int64_t *output_shape,
     const ELEM_T *inputs[],
     const int64_t *input_shapes[],
@@ -400,7 +401,7 @@ void slice_scatter_kernel_launcher(
     scatter_dim_offset += slice_meta_data.dim_sizes[i];
   }
 
-  LoadVecType min_vec_type = LoadVecType::VT_FLOAT4;
+  LoadVecType min_vec_type = get_vec_type<ELEM_T>(output_offset);
   for ({{index_type}}  i = 0; i < NumInputs; i++) {
     LoadVecType vec_type = get_input_vec_type<ELEM_T, Rank>(
         scatter_meta_data.output_strides,
@@ -435,7 +436,7 @@ void slice_scatter_kernel_launcher(
       }                                                                       \\
       slice_scatter_kernel<vec_type, ELEM_T, Rank, NumInputs, ElemsPerThread> \\
         <<<grid_config, ThreadsPerBlock, 0, stream>>>(                        \\
-            output,                                                           \\
+            output + output_offset,                                           \\
             slice_meta_data,                                                  \\
             scatter_meta_data);                                               \\
       LAUNCH_CHECK_SLICE();                                                   \\
@@ -516,7 +517,8 @@ EXEC_COND_TEMPLATE = jinja2.Template(
 {{indent}}                                {{num_inputs}}/*NumInputs*/,
 {{indent}}                                {{elems_per_thread}}/*ElemsPerThread*/,
 {{indent}}                                {{threads_per_block}}/*ThreadsPerBlock*/>(
-{{indent}}      static_cast<{{elem_type}}*>(output), local_output_shape, reinterpret_cast<const {{elem_type}}**>(inputs), input_shapes,
+{{indent}}      static_cast<{{elem_type}}*>(output), {{output_offset}}, local_output_shape,
+{{indent}}      reinterpret_cast<const {{elem_type}}**>(inputs), input_shapes,
 {{indent}}      slice_start_indices, slice_end_indices, scatter_dim, stream);
 {{indent}}  return;
 {{indent}}}
@@ -698,6 +700,7 @@ def gen_function(
     func_attrs,
     backend_spec,
     elems_per_thread=8,
+    output_offset=0,
     update_output_shape=True,
     element_func=None,
     element_func_def=None,
@@ -748,6 +751,7 @@ def gen_function(
         elem_type=input_type,
         elems_per_thread=elems_per_thread,
         threads_per_block=128,
+        output_offset=output_offset,
     )
 
     shape_func = SHAPE_UPDATE_FUNC.render(

--- a/python/aitemplate/compiler/ops/tensor/slice_reshape_scatter.py
+++ b/python/aitemplate/compiler/ops/tensor/slice_reshape_scatter.py
@@ -100,7 +100,7 @@ class slice_reshape_scatter(Operator):
         cat_op_2_outputs = cat_op_2._attrs["outputs"]
         assert len(cat_op_2_outputs) == 1, (
             f'{cat_op_2._attrs["name"]=} may only have one output, but got more '
-            f"{outputs=}"
+            f"{cat_op_2_outputs=}"
         )
         self._attrs["outputs"] = cat_op_2_outputs
 

--- a/tests/unittest/compiler/test_slice_reshape_scatter.py
+++ b/tests/unittest/compiler/test_slice_reshape_scatter.py
@@ -63,7 +63,7 @@ class SliceScatterReshapeCatTestCase(unittest.TestCase):
             Ys_pt.append(Y_pt)
         Y1_pt = torch.cat(Ys_pt, dim)
         Y2_pt = torch.reshape(Y1_pt, reshape_to)
-        Y_pt = torch.cat([Y2_pt, input_X_pt], dim=dim)
+        Y_pt = torch.cat([input_X_pt, Y2_pt, input_X_pt], dim=dim)
         if add_tanh:
             Y_pt = torch.tanh(Y_pt)
 
@@ -85,7 +85,7 @@ class SliceScatterReshapeCatTestCase(unittest.TestCase):
         concat_op_2 = ops.concatenate()
         if add_tanh:
             concat_op_2 = ops.concatenate_tanh()
-        Y = concat_op_2([Y2, input_X], dim)
+        Y = concat_op_2([input_X, Y2, input_X], dim)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
@@ -102,7 +102,7 @@ class SliceScatterReshapeCatTestCase(unittest.TestCase):
         Y_src_ops = Y._attrs["src_ops"]
         np.testing.assert_equal(len(Y_src_ops), 2)
         np.testing.assert_equal(concat_op_2 in Y_src_ops, True)
-        np.testing.assert_equal(concat_op_2._attrs["input_masks"], [False, True])
+        np.testing.assert_equal(concat_op_2._attrs["input_masks"], [True, False, True])
         Y_src_ops_list = list(Y_src_ops)
         slice_reshape_scatter_op = (
             Y_src_ops_list[1] if concat_op_2 == Y_src_ops_list[0] else Y_src_ops_list[0]
@@ -122,6 +122,22 @@ class SliceScatterReshapeCatTestCase(unittest.TestCase):
         self.test_count += 1
 
     def test_slice_scatter_reshape(self):
+        self._run_one_test(
+            input_shapes=[[1, 2], [1, 2]],
+            input_start_indices=[[0, 0], [0, 0]],
+            input_end_indices=[[1, 2], [1, 2]],
+            reshape_to=[1, 2, 2],
+            input_x_shape=[1, 1, 2],
+            dim=1,
+        )
+        self._run_one_test(
+            input_shapes=[[10, 20], [15, 44]],
+            input_start_indices=[[1, 5], [2, 10]],
+            input_end_indices=[[4, 15], [5, 22]],
+            reshape_to=[3, 2, 11],
+            input_x_shape=[3, 1, 11],
+            dim=1,
+        )
         self._run_one_test(
             input_shapes=[[8, 16], [20, 30]],
             input_start_indices=[[0, 4], [12, 2]],
@@ -151,6 +167,74 @@ class SliceScatterReshapeCatTestCase(unittest.TestCase):
             dim=1,
             dtype="float",
         )
+
+    def test_slice_scatter_reshape_float16_2(self):
+        dtype = "float16"
+        input_shape = [2, 6]
+        input0 = Tensor(shape=input_shape, dtype=dtype, name="input0", is_input=True)
+        input1 = Tensor(shape=input_shape, dtype=dtype, name="input1", is_input=True)
+        input2_shape = [2, 3, 2]
+        input2 = Tensor(shape=input2_shape, dtype=dtype, name="input2", is_input=True)
+
+        start_indices = [0, 0]
+        end_indices = [None, 2]
+        slice_0 = ops.dynamic_slice()(
+            input0, start_indices=start_indices, end_indices=end_indices
+        )
+        slice_1 = ops.dynamic_slice()(
+            input0, start_indices=start_indices, end_indices=end_indices
+        )
+        concat_dim = 1
+        concat_2 = ops.concatenate()([slice_0, slice_1], concat_dim)
+        reshape_to = [-1, 2, 2]
+        reshape_3 = ops.reshape()(concat_2, reshape_to)
+
+        slice_4 = ops.dynamic_slice()(
+            input1, start_indices=start_indices, end_indices=end_indices
+        )
+        slice_5 = ops.dynamic_slice()(
+            input1, start_indices=start_indices, end_indices=end_indices
+        )
+        concat_6 = ops.concatenate()([slice_4, slice_5], concat_dim)
+        reshape_7 = ops.reshape()(concat_6, reshape_to)
+
+        Y = ops.concatenate()([input2, reshape_3, reshape_7], concat_dim)
+        Y._attrs["name"] = "y"
+        Y._attrs["is_output"] = True
+
+        target = detect_target()
+        dll_name = f"test.so"
+        test_name = "slice_scatter_reshape_cat_float16_2"
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        Y_src_ops = Y._attrs["src_ops"]
+        self.assertEqual(len(Y_src_ops), 3)
+        slice_reshape_scatter_cnt = 0
+        for op in Y_src_ops:
+            if op._attrs["op"] == "slice_reshape_scatter":
+                slice_reshape_scatter_cnt += 1
+        self.assertEqual(slice_reshape_scatter_cnt, 2)
+
+        slice_indices = [slice(i, j) for i, j in zip(start_indices, end_indices)]
+
+        input0_pt = get_random_torch_tensor(input_shape, dtype)
+        slice_0_pt = input0_pt[slice_indices]
+        slice_1_pt = input0_pt[slice_indices]
+        concat_2_pt = torch.cat([slice_0_pt, slice_1_pt], concat_dim)
+        reshape_3_pt = torch.reshape(concat_2_pt, reshape_to)
+
+        input1_pt = get_random_torch_tensor(input_shape, dtype)
+        slice_4_pt = input1_pt[slice_indices]
+        slice_5_pt = input1_pt[slice_indices]
+        concat_6_pt = torch.cat([slice_4_pt, slice_5_pt], concat_dim)
+        reshape_7_pt = torch.reshape(concat_6_pt, reshape_to)
+
+        input2_pt = get_random_torch_tensor(input2_shape, dtype)
+        y_pt = torch.cat([input2_pt, reshape_3_pt, reshape_7_pt], concat_dim)
+
+        inputs = {"input0": input0_pt, "input1": input1_pt, "input2": input2_pt}
+        y = get_torch_empty_tensor(y_pt.size(), dtype)
+        module.run_with_tensors(inputs, [y])
+        self.assertTrue(torch.allclose(y_pt, y, atol=1e-2, rtol=1e-2))
 
 
 if __name__ == "__main__":

--- a/tests/unittest/compiler/test_slice_reshape_scatter.py
+++ b/tests/unittest/compiler/test_slice_reshape_scatter.py
@@ -203,7 +203,7 @@ class SliceScatterReshapeCatTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        dll_name = f"test.so"
+        dll_name = "test.so"
         test_name = "slice_scatter_reshape_cat_float16_2"
         module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         Y_src_ops = Y._attrs["src_ops"]


### PR DESCRIPTION
This PR actually fixed two issues:

(1) Previously, there was an issue related to place the generated slice_reshape_scatter into a wrong postion in the output, because we did not take the relevant offset into account. This PR fixed the problem by simply introducing an output_offset argument to the relevant kernel. Please check the comment in the gen_function body of slice_reshape_scatter_common for the rationales.

(2) When we update the newly-created slice_reshape_scatter op, we should add it into the "dst_ops" set of its "inputs" rather than overwriting the entire set.