### PR TITLE
fix negative prompt error

### DIFF
--- a/examples/05_stable_diffusion/src/pipeline_stable_diffusion_ait.py
+++ b/examples/05_stable_diffusion/src/pipeline_stable_diffusion_ait.py
@@ -293,6 +293,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
                 uncond_tokens,
                 padding="max_length",
                 max_length=max_length,
+                truncation=True,
                 return_tensors="pt",
             )
             uncond_embeddings = self.clip_inference(


### PR DESCRIPTION
In the current code, if negative prompt comes in more than the set maximum length, there is no truncation option, causing errors in subsequent pipelines. Modify that part.