### PR TITLE
add conv3d support in fx2ait

### DIFF
--- a/fx2ait/fx2ait/converters/utils.py
+++ b/fx2ait/fx2ait/converters/utils.py
@@ -138,6 +138,9 @@ def nchw2nhwc(shape: List[Union[int, IntVar]]) -> List[Union[int, IntVar]]:
     return [shape[0], shape[2], shape[3], shape[1]]
 
 
+def ncdhw2ndhwc(shape: List[Union[int, IntVar]]) -> List[Union[int, IntVar]]:
+    return [shape[0], shape[2], shape[3], shape[4], shape[1]]
+
 # TODO:  This is a hack to workaround AIT's dynamic shape requirement.
 # Detailed explanation can be found in D41743385 (aten2ait) D41974191(fx2ait).
 # We will throw this one after AIT provides vanilla support.

--- a/fx2ait/fx2ait/test/converters/test_ait_conv3d.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_conv3d.py
@@ -1,0 +1,112 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import torch
+from fx2ait.acc_tracer import acc_ops
+from fx2ait.tools.common_fx2ait import AITTestCase
+from parameterized import param, parameterized
+
+
+class TestAitConv3d(AITTestCase):
+    @parameterized.expand(
+        [
+            param("conv3d", 3, bias=False),
+            param(
+                name="conv3d_tuple_parameters",
+                kernel_size=3,
+                stride=(4, 4, 4),
+                padding=(2, 2, 2),
+                dilation=2,
+                ci=8,
+                co=96,
+                groups=1,
+                d=4,
+                h=224,
+                w=224,
+                bias=False,
+            ),
+            param(
+                name="depthwise_conv3d",
+                kernel_size=(1, 1, 1),
+                stride=(1, 1, 1),
+                padding=0,
+                dilation=1,
+                ci=96,
+                co=96,
+                groups=96,
+                d=2,
+                h=56,
+                w=56,
+                bias=True,
+            ),
+            param(
+                name="depthwise_conv3d_2",
+                kernel_size=(1, 1, 1),
+                stride=(1, 1, 1),
+                padding=0,
+                dilation=1,
+                ci=96,
+                co=96,
+                groups=96,
+                d=2,
+                h=28,
+                w=28,
+                bias=True,
+            ),
+            param(
+                name="depthwise_conv3d_3",
+                kernel_size=(1, 1, 1),
+                stride=(1, 1, 1),
+                padding=0,
+                dilation=1,
+                ci=96,
+                co=96,
+                groups=96,
+                d=2,
+                h=7,
+                w=7,
+                bias=True,
+            ),
+        ]
+    )
+    def test_conv3d(
+        self,
+        name,
+        kernel_size,
+        stride=1,
+        padding=0,
+        dilation=1,
+        ci=8,
+        co=8,
+        groups=1,
+        d=4,
+        h=224,
+        w=224,
+        bias=False,
+    ):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = torch.nn.Conv3d(
+                    ci,
+                    co,
+                    kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                    groups,
+                    bias,
+                )
+                self.relu = torch.nn.ReLU()
+
+            def forward(self, x):
+                return self.relu(self.conv(x))
+        model = TestModule().cuda().half()
+        inputs = [torch.randn(4, ci, d, h, w).cuda().half()]
+
+        self.run_test(
+            model,
+            inputs,
+            expected_ops={acc_ops.conv3d},
+            permute_inputs=[0, 2, 3, 4, 1],  # inputs should be NDHWC
+            permute_outputs=[0, 4, 1, 2, 3],
+        )

--- a/python/aitemplate/compiler/ops/conv/conv3d.py
+++ b/python/aitemplate/compiler/ops/conv/conv3d.py
@@ -555,7 +555,7 @@ class conv3d(Operator):
 
         workloads = list(self._attrs["exec_path"].keys())
         profiler_prefix = os.path.join(workdir, "profiler", self._attrs["op"])
-        if "op_instance" not in self._attrs:
+        if "op_instance" not in self._attrs or len(self._attrs["op_instance"]) == 0:
             target = backend.target.Target.current()
             # init candidate ops
             func_key = "{target}.{op}.config".format(

--- a/python/aitemplate/compiler/ops/conv/depthwise_conv3d.py
+++ b/python/aitemplate/compiler/ops/conv/depthwise_conv3d.py
@@ -264,8 +264,10 @@ class depthwise_conv3d(Operator):
             includes the output tensor in shape (N, T_out, H_out, W_out, C_out)
         """
         self._attrs["inputs"] = [x, w]
-        if self._attrs["bias"]:
+        if bias:
             self._attrs["inputs"].append(bias)
+        elif self._attrs["bias"]:
+            self._attrs["inputs"].append(self._attrs["bias"])
         self._set_depth()
         output_shape = self._infer_shapes(x, w)
         self._extract_exec_path(x)

--- a/python/aitemplate/compiler/public/__init__.py
+++ b/python/aitemplate/compiler/public/__init__.py
@@ -57,6 +57,8 @@ from aitemplate.compiler.ops.common.view_ops import flatten, reshape, squeeze, u
 from aitemplate.compiler.ops.conv.conv2d import conv2d
 from aitemplate.compiler.ops.conv.conv2d_bias import conv2d_bias
 from aitemplate.compiler.ops.conv.conv2d_bias_relu import conv2d_bias_relu
+from aitemplate.compiler.ops.conv.conv3d import conv3d
+from aitemplate.compiler.ops.conv.depthwise_conv3d import depthwise_conv3d
 from aitemplate.compiler.ops.conv.transposed_conv2d import transposed_conv2d
 from aitemplate.compiler.ops.conv.transposed_conv2d_bias import transposed_conv2d_bias
 from aitemplate.compiler.ops.layernorm.group_layernorm import group_layernorm


### PR DESCRIPTION
Summary:
Add the conv3d support in fx2ait, so we can use it to transform the xrayvideo model.
Add unit tests to make sure the support is good.

Reviewed By: wushirong

Differential Revision: D43079351

