### PR TITLE
make a number of ops with respect to PyTorch tensor layouts

### DIFF
--- a/fx2ait/fx2ait/converters/utils.py
+++ b/fx2ait/fx2ait/converters/utils.py
@@ -18,7 +18,12 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 
 from aitemplate.compiler.base import IntImm, IntVar, IntVarTensor
 
-from aitemplate.compiler.public import elementwise, FuncEnum, Tensor as AITTensor
+from aitemplate.compiler.public import (
+    elementwise,
+    FuncEnum,
+    permute,
+    Tensor as AITTensor,
+)
 from torch.fx.node import Argument
 
 
@@ -140,6 +145,40 @@ def nchw2nhwc(shape: List[Union[int, IntVar]]) -> List[Union[int, IntVar]]:
 
 def ncdhw2ndhwc(shape: List[Union[int, IntVar]]) -> List[Union[int, IntVar]]:
     return [shape[0], shape[2], shape[3], shape[4], shape[1]]
+
+
+def weight_nchw2nhwc(weight: AITTensor) -> None:
+    weight._attrs["data"].tensor = weight._attrs["data"].tensor.permute(0, 2, 3, 1)
+    return weight
+
+
+def weight_ncdhw2ndhwc(weight: AITTensor) -> None:
+    weight._attrs["data"].tensor = weight._attrs["data"].tensor.permute(0, 2, 3, 4, 1)
+    return weight
+
+
+def ait_ncl2nlc(ait_tensor: AITTensor) -> AITTensor:
+    return permute()(ait_tensor, [0, 2, 1])
+
+
+def ait_nlc2ncl(ait_tensor: AITTensor) -> AITTensor:
+    return permute()(ait_tensor, [0, 2, 1])
+
+
+def ait_nchw2nhwc(ait_tensor: AITTensor) -> AITTensor:
+    return permute()(ait_tensor, [0, 2, 3, 1])
+
+
+def ait_nhwc2nchw(ait_tensor: AITTensor) -> AITTensor:
+    return permute()(ait_tensor, [0, 3, 1, 2])
+
+
+def ait_ncdhw2ndhwc(ait_tensor: AITTensor) -> AITTensor:
+    return permute()(ait_tensor, [0, 2, 3, 4, 1])
+
+
+def ait_ndhwc2ncdhw(ait_tensor: AITTensor) -> AITTensor:
+    return permute()(ait_tensor, [0, 4, 1, 2, 3])
 
 
 # TODO:  This is a hack to workaround AIT's dynamic shape requirement.

--- a/fx2ait/fx2ait/test/converters/converters_model/test_ait_vision_model.py
+++ b/fx2ait/fx2ait/test/converters/converters_model/test_ait_vision_model.py
@@ -35,6 +35,5 @@ class TestVisionModelConverter(AITTestCase):
             model,
             inputs,
             expected_ops={},
-            permute_inputs=[0, 2, 3, 1],
             permute_outputs=None,
         )

--- a/fx2ait/fx2ait/test/converters/test_ait_adaptive_avg_pool2d.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_adaptive_avg_pool2d.py
@@ -47,6 +47,4 @@ class TestAdaptiveAvgPool2dConverter(AITTestCase):
             model,
             inputs,
             expected_ops={acc_ops.adaptive_avg_pool2d},
-            permute_inputs=[0, 2, 3, 1],
-            permute_outputs=[0, 3, 1, 2],
         )

--- a/fx2ait/fx2ait/test/converters/test_ait_avg_pool2d.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_avg_pool2d.py
@@ -42,6 +42,4 @@ class TestAvgPool2dConverter(AITTestCase):
             model,
             inputs,
             expected_ops={acc_ops.avg_pool2d},
-            permute_inputs=[0, 2, 3, 1],
-            permute_outputs=[0, 3, 1, 2],
         )

--- a/fx2ait/fx2ait/test/converters/test_ait_batch_norm.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_batch_norm.py
@@ -19,8 +19,32 @@ from fx2ait.acc_tracer import acc_ops
 from fx2ait.tools.common_fx2ait import AITTestCase
 
 
-class TestAdaptiveAvgPool2dConverter(AITTestCase):
-    def test_batch_norm(self):
+class TestBatchNormConverter(AITTestCase):
+    def test_batch_norm1d(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.bn = torch.nn.BatchNorm1d(3)
+
+            def forward(self, x):
+                return self.bn(x)
+
+        model = TestModule().half().cuda()
+        inputs1 = [torch.randn(5, 3).cuda().half()]
+        self.run_test(
+            model,
+            inputs1,
+            expected_ops={acc_ops.batch_norm},
+        )
+
+        inputs2 = [torch.randn(5, 3, 234).cuda().half()]
+        self.run_test(
+            model,
+            inputs2,
+            expected_ops={acc_ops.batch_norm},
+        )
+
+    def test_batch_norm2d(self):
         class TestModule(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -35,6 +59,21 @@ class TestAdaptiveAvgPool2dConverter(AITTestCase):
             model,
             inputs,
             expected_ops={acc_ops.batch_norm},
-            permute_inputs=[0, 2, 3, 1],
-            permute_outputs=[0, 3, 1, 2],
+        )
+
+    def test_batch_norm3d(self):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.bn = torch.nn.BatchNorm3d(6)
+
+            def forward(self, x):
+                return self.bn(x)
+
+        model = TestModule().half().cuda()
+        inputs = [torch.randn(4, 6, 24, 24, 11).cuda().half()]
+        self.run_test(
+            model,
+            inputs,
+            expected_ops={acc_ops.batch_norm},
         )

--- a/fx2ait/fx2ait/test/converters/test_ait_conv2d.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_conv2d.py
@@ -59,6 +59,4 @@ class TestConv2dConverter(AITTestCase):
             model,
             inputs,
             expected_ops={acc_ops.conv2d},
-            permute_inputs=[0, 2, 3, 1],
-            permute_outputs=[0, 3, 1, 2],
         )

--- a/fx2ait/fx2ait/test/converters/test_ait_conv3d.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_conv3d.py
@@ -173,6 +173,4 @@ class TestAitConv3d(AITTestCase):
             model,
             inputs,
             expected_ops={acc_ops.conv3d},
-            permute_inputs=[0, 2, 3, 4, 1],  # inputs should be NDHWC
-            permute_outputs=[0, 4, 1, 2, 3],
         )

--- a/fx2ait/fx2ait/test/converters/test_ait_conv3d_depthwise.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_conv3d_depthwise.py
@@ -109,6 +109,4 @@ class TestAitDepthwiseConv3d(AITTestCase):
             model,
             inputs,
             expected_ops={acc_ops.conv3d},
-            permute_inputs=[0, 2, 3, 4, 1],  # inputs should be NDHWC
-            permute_outputs=[0, 4, 1, 2, 3],
         )

--- a/fx2ait/fx2ait/test/converters/test_ait_convtranspose2d.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_convtranspose2d.py
@@ -65,8 +65,6 @@ class TestConvtTranspose2dConverter(AITTestCase):
             model,
             inputs,
             expected_ops={acc_ops.conv_transpose2d},
-            permute_inputs=[0, 2, 3, 1],
-            permute_outputs=[0, 3, 1, 2],
         )
 
     # only works when in_ch == out_ch
@@ -105,6 +103,4 @@ class TestConvtTranspose2dConverter(AITTestCase):
             model,
             inputs,
             expected_ops={acc_ops.conv_transpose2d},
-            permute_inputs=[0, 2, 3, 1],
-            permute_outputs=[0, 3, 1, 2],
         )

--- a/fx2ait/fx2ait/test/converters/test_ait_max_pool2d.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_max_pool2d.py
@@ -42,6 +42,4 @@ class TestMaxPool2dConverter(AITTestCase):
             model,
             inputs,
             expected_ops={acc_ops.max_pool2d},
-            permute_inputs=[0, 2, 3, 1],
-            permute_outputs=[0, 3, 1, 2],
         )


### PR DESCRIPTION
Summary:
PyTorch takes channel-first tensors for a number of ops such as conv/pooling/batch_norm, whereas AIT assumes channel-last tensors.
This change unified how we convert tensor layouts back and forth between PyTorch and AIT by applying permute ops to input values, weights and results appropriately.
Later, we will add a pass to remove redundant permute op pairs, e.g. permute([0, 3, 1, 2]) followed by permute([0, 2, 3, 1]), to improve performance.
We may need similar changes to the aten2ait converter.

Reviewed By: frank-wei, qxy11

Differential Revision: D43135925

