### PR TITLE
Amend get_item with list of indices to use ait fusion pass

### DIFF
--- a/fx2ait/fx2ait/test/converters/test_ait_slice_tensor.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_slice_tensor.py
@@ -54,6 +54,18 @@ class TestSliceTensor(AITTestCase):
                 (slice(None, None, None), slice(None, None, None), slice(0, 0, None)),
             ),
             (
+                "slice_start_seq_slice",
+                (slice(0, 1, None), [0, 1, 2], slice(0, 10, None)),
+            ),
+            (
+                "slice_end_seq_slice",
+                (slice(0, 1, None), [0, 6, 7, 8, 9], slice(0, 10, None)),
+            ),
+            (
+                "slice_long_seq_slice",
+                (slice(0, 1, None), [0, 5, 6, 7, 2, 3, 4, 5], slice(0, 10, None)),
+            ),
+            (
                 "slice_list_slice",
                 (slice(0, 1, None), [2], slice(0, 10, None)),
             ),

--- a/python/aitemplate/compiler/ops/tensor/slice_reshape_scatter.py
+++ b/python/aitemplate/compiler/ops/tensor/slice_reshape_scatter.py
@@ -15,6 +15,8 @@
 """
 Slice_reshape_scatter.
 """
+from typing import Optional
+
 from aitemplate.compiler.tensor_accessor import TensorAccessor
 
 from .... import backend
@@ -138,29 +140,33 @@ class slice_reshape_scatter(Operator):
             y._attrs["src_ops"] = StableSet()
             y._attrs["dst_ops"] = StableSet()
 
-    def __init__(
-        self, cat_op: Operator, reshape_op: Operator, cat_op_2: Operator
-    ) -> None:
+    def __init__(self, scatter_dim: int, element_func: Optional[str] = None) -> None:
         super().__init__()
-        if cat_op_2._attrs["op"] == "concatenate_tanh":
-            self._attrs["element_func"] = "fast_tanh"
-        else:
-            self._attrs["element_func"] = None
-        assert slice_reshape_scatter.is_valid(cat_op, reshape_op, cat_op_2)
-
+        self._attrs["element_func"] = element_func
         self._attrs["op"] = "slice_reshape_scatter"
         self._attrs["has_profiler"] = False
-        self._attrs["scatter_dim"] = cat_op._attrs["concat_dim"]
+        self._attrs["scatter_dim"] = scatter_dim
+
+    @staticmethod
+    def make_op(cat_op: Operator, reshape_op: Operator, cat_op_2: Operator) -> Operator:
+        assert slice_reshape_scatter.is_valid(cat_op, reshape_op, cat_op_2)
+        element_func = None
+        if cat_op_2._attrs["op"] == "concatenate_tanh":
+            element_func = "fast_tanh"
+        scatter_dim = cat_op._attrs["concat_dim"]
+        new_op = slice_reshape_scatter(scatter_dim, element_func)
+
         slice_ops = []
         for x in cat_op._attrs["inputs"]:
             src_ops = x.src_ops()
             assert len(src_ops) == 1
             slice_op = list(src_ops)[0]
             slice_ops.append(slice_op)
-        self._attrs["slice_ops"] = slice_ops
+        new_op._attrs["slice_ops"] = slice_ops
 
-        self._update_inputs_outputs(cat_op, reshape_op, cat_op_2)
-        self._set_depth()
+        new_op._update_inputs_outputs(cat_op, reshape_op, cat_op_2)
+        new_op._set_depth()
+        return new_op
 
     def __call__(self):
         raise RuntimeError("op {} cannot be called directly".format(self._attrs["op"]))

--- a/python/aitemplate/compiler/transform/optimize_graph.py
+++ b/python/aitemplate/compiler/transform/optimize_graph.py
@@ -29,6 +29,7 @@ from .fuse_ops import fuse_ops
 from .fuse_parallel_gemms import fuse_parallel_gemms
 from .fuse_permute_bmm_and_gemm import fuse_permute_bmm_and_gemm
 from .split_large_concat_ops import split_large_concat_ops
+from .split_large_slice_scatter_ops import split_large_slice_scatter_ops
 from .split_large_split_ops import split_large_split_ops
 from .transform_memory_ops import transform_memory_ops
 from .transform_odd_alignment import transform_odd_alignment
@@ -82,6 +83,7 @@ def optimize_graph(sorted_graph: List[Tensor], workdir: str) -> List[Tensor]:
         transform_special_ops,
         apply_padding,
         transform_strided_ops,
+        split_large_slice_scatter_ops,
         split_large_concat_ops,
         split_large_split_ops,
         transform_memory_ops,

--- a/python/aitemplate/compiler/transform/split_large_slice_scatter_ops.py
+++ b/python/aitemplate/compiler/transform/split_large_slice_scatter_ops.py
@@ -1,0 +1,160 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+This transformation splits a slice_scatter or slice_reshape_scatter with a large
+number of inputs into multiple slice_scatter or slice_reshape_scatter ops.
+"""
+import copy
+import logging
+
+from typing import List
+
+from aitemplate.compiler.ops.tensor.dynamic_slice import dynamic_slice
+
+from ...utils import graph_utils, shape_utils
+from .. import ops
+from ..base import Operator, Tensor
+from . import transform_utils
+
+
+_LOGGER = logging.getLogger(__name__)
+
+# slice_scatter and slice_reshape_scatter use the same kernel implementation
+SLICE_SCATTER_INPUT_META_SIZE = 64  # bytes per input
+SLICE_SCATTER_OUTPUT_META_SIZE = 16  # bytes per rank
+MAX_CUDA_PARAM_BYTES = 4096  # bytes
+
+
+def _slice_scatter_kernel_single_input_output_param_size(op: Operator):
+    """
+    Return the total size (in bytes) of the slice_scatter's params.
+    We need to adjust this if we change its params.
+    """
+    inputs = op._attrs["inputs"]
+    rank = inputs[0]._rank()
+    size_of_output_meta = SLICE_SCATTER_OUTPUT_META_SIZE * rank
+    # There are one more params, which takes 8 bytes.
+    total_params_size = SLICE_SCATTER_INPUT_META_SIZE + size_of_output_meta + 8
+    _LOGGER.debug(f'slice_scatter op {op._attrs["name"]}: {total_params_size=}')
+    return total_params_size
+
+
+def split_large_slice_scatter_ops(sorted_graph: List[Tensor], _: str) -> List[Tensor]:
+    """
+    Our slice_scatter CUDA kernel takes an input meta argument whose size
+    is proportional to the number of inputs. In extreme cases, the total size
+    of the kernel function params may exceed the limit imposed by the CUDA
+    compiler. In such cases, we split the slice_scatter op into separate
+    ones, each of which takes the original output and inputs with correct
+    input_masks values.
+    """
+    sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+    for op in sorted_ops:
+        # TODO: enable slice_scatter later
+        if not op._attrs["op"].startswith("slice_reshape_scatter"):
+            continue
+        slice_scatter_op = op
+        # We create InputMeta for inputs that need to copy data.
+        inputs = slice_scatter_op._attrs["inputs"]
+        num_inputs = len(inputs)
+        if num_inputs == 0:
+            continue
+        params_size = _slice_scatter_kernel_single_input_output_param_size(
+            slice_scatter_op
+        )
+        if params_size > MAX_CUDA_PARAM_BYTES:
+            raise RuntimeError(
+                f"cannot handle cases: {params_size=} > {MAX_CUDA_PARAM_BYTES=}"
+            )
+        total_params_size = params_size * num_inputs
+        if total_params_size <= MAX_CUDA_PARAM_BYTES:
+            continue
+        num_inputs_per_split = MAX_CUDA_PARAM_BYTES // params_size
+        num_splits = (num_inputs + num_inputs_per_split - 1) // num_inputs_per_split
+        split_sizes = [num_inputs_per_split] * num_splits
+        if num_inputs % num_inputs_per_split:
+            split_sizes[num_splits - 1] = num_inputs % num_inputs_per_split
+
+        inputs_offset = 0
+        all_new_slice_scatter_ops = []
+        outputs = slice_scatter_op._attrs["outputs"]
+        output_accessors = slice_scatter_op._attrs["output_accessors"]
+        scatter_dim = slice_scatter_op._attrs["scatter_dim"]
+        has_profiler = slice_scatter_op._attrs["has_profiler"]
+        local_output_offset = 0
+        orig_name = slice_scatter_op._attrs["name"]
+        element_func = slice_scatter_op._attrs["element_func"]
+        slice_ops = slice_scatter_op._attrs["slice_ops"]
+        for split_idx, new_inputs_size in enumerate(split_sizes):
+            new_slice_scatter_op = ops.slice_reshape_scatter(scatter_dim, element_func)
+            new_name = f"{orig_name}_split_{split_idx}"
+            new_slice_scatter_op._attrs["name"] = new_name
+            new_slice_scatter_op._attrs["original_name"] = new_name
+            new_slice_scatter_op._attrs["has_profiler"] = has_profiler
+            new_slice_scatter_op._attrs["outputs"] = outputs
+            new_slice_scatter_op._attrs["output_accessors"] = copy.deepcopy(
+                output_accessors
+            )
+            new_slice_scatter_op._set_depth()
+
+            # import pdb; pdb.set_trace()
+            new_inputs = list(inputs[inputs_offset : (inputs_offset + new_inputs_size)])
+            new_slice_scatter_op._attrs["inputs"] = new_inputs
+            new_slice_ops = slice_ops[inputs_offset : (inputs_offset + new_inputs_size)]
+            new_slice_scatter_op._attrs["slice_ops"] = new_slice_ops
+
+            # We also need to update the offset of the output tensor accessor.
+            # Note that the strided information remains the same because the output
+            # remains the same and we just shift the head offset for each new
+            # slice scatter op.
+            new_slice_scatter_op._attrs["output_accessors"][
+                0
+            ].offset += local_output_offset
+            for input_tensor, slice_op in zip(new_inputs, new_slice_ops):
+                input_tensor_shape = input_tensor._attrs["shape"]
+                # This is enforced by slice_scatter op. Just ensure we didn't
+                # violate the assumption somewhere.
+                assert shape_utils.all_static_dimensions(
+                    input_tensor_shape, scatter_dim
+                ), (
+                    f"Expected input_tensor_shape[{scatter_dim}:] are all static dimensions, "
+                    f"but got: {input_tensor_shape}"
+                )
+                start_indices = slice_op._attrs["start_indices"]
+                end_indices = slice_op._attrs["end_indices"]
+                strided_dim_offset = 1
+                for dim, start, end in zip(
+                    input_tensor_shape[scatter_dim:],
+                    start_indices[scatter_dim:],
+                    end_indices[scatter_dim:],
+                ):
+                    n_start, n_end = dynamic_slice.normalize_start_end_indices(
+                        dim.value(), start, end
+                    )
+                    assert n_start <= n_end, (
+                        f"expected normalized {n_start=} <= {n_end=} for "
+                        f"{dim=}, {start=}, {end=}"
+                    )
+                    strided_dim_offset *= n_end - n_start
+                local_output_offset += strided_dim_offset
+                input_tensor._attrs["dst_ops"].update([new_slice_scatter_op])
+                input_tensor._attrs["dst_ops"].discard(slice_scatter_op)
+            all_new_slice_scatter_ops.append(new_slice_scatter_op)
+            inputs_offset += new_inputs_size
+        output = outputs[0]
+        output._attrs["src_ops"].update(all_new_slice_scatter_ops)
+        output._attrs["src_ops"].remove(slice_scatter_op)
+    sorted_graph = transform_utils.sanitize_sorted_graph(sorted_graph)
+    return sorted_graph

--- a/python/aitemplate/compiler/transform/transform_strided_ops.py
+++ b/python/aitemplate/compiler/transform/transform_strided_ops.py
@@ -80,7 +80,7 @@ def _fuse_slices_concat_reshape_concat(sorted_graph: List[Tensor]) -> List[Tenso
 
         concat_op_2 = next_op
         if slice_reshape_scatter.is_valid(concat_op, reshape_op, concat_op_2):
-            slice_reshape_scatter(concat_op, reshape_op, concat_op_2)
+            slice_reshape_scatter.make_op(concat_op, reshape_op, concat_op_2)
 
     return transform_utils.sanitize_sorted_graph(sorted_graph)
 

--- a/tests/unittest/compiler/test_split_large_slice_scatter.py
+++ b/tests/unittest/compiler/test_split_large_slice_scatter.py
@@ -1,0 +1,111 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import unittest
+
+import torch
+
+from aitemplate.compiler import compile_model, ops
+from aitemplate.frontend import Tensor
+from aitemplate.testing import detect_target
+from aitemplate.testing.test_utils import (
+    get_random_torch_tensor,
+    get_torch_empty_tensor,
+)
+
+
+class SliceScatterLargeInputsTestCase(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(SliceScatterLargeInputsTestCase, self).__init__(*args, **kwargs)
+        self.test_count = 1
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        torch.manual_seed(0)
+
+    def _test_slice_scatter_reshape_float16(
+        self,
+        input0_shape,
+        input1_shape,
+        start_indices,
+        end_indices,
+    ):
+        dtype = "float16"
+
+        input0 = Tensor(shape=input0_shape, dtype=dtype, name="input0", is_input=True)
+        input1 = Tensor(shape=input1_shape, dtype=dtype, name="input1", is_input=True)
+
+        num_slices = 139
+        slice_outputs = [
+            ops.dynamic_slice()(
+                input0, start_indices=start_indices, end_indices=end_indices
+            )
+            for _ in range(num_slices)
+        ]
+
+        concat_dim = 1
+        concat_2 = ops.concatenate()(slice_outputs, concat_dim)
+        reshape_to = [-1, num_slices, 2]
+        reshape_3 = ops.reshape()(concat_2, reshape_to)
+
+        Y = ops.concatenate()([reshape_3, input1], concat_dim)
+        Y._attrs["name"] = "y"
+        Y._attrs["is_output"] = True
+
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        test_name = "slice_scatter_large_inputs"
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        Y_src_ops = Y._attrs["src_ops"]
+        # We have a single concat op. All the rest are slice_reshape_scatter ops
+        concat_cnt = 0
+        for op in Y_src_ops:
+            if op._attrs["op"] == "concatenate":
+                concat_cnt += 1
+                continue
+            self.assertEqual(op._attrs["op"], "slice_reshape_scatter")
+        self.assertEqual(concat_cnt, 1)
+
+        input0_pt = get_random_torch_tensor(input0_shape, dtype)
+        input1_pt = get_random_torch_tensor(input1_shape, dtype)
+        slice_indices = [slice(i, j) for i, j in zip(start_indices, end_indices)]
+
+        slice_outputs_pt = [input0_pt[slice_indices] for _ in range(num_slices)]
+        concat_2_pt = torch.cat(slice_outputs_pt, concat_dim)
+        reshape_3_pt = torch.reshape(concat_2_pt, reshape_to)
+        y_pt = torch.cat([reshape_3_pt, input1_pt], concat_dim)
+
+        inputs = {"input0": input0_pt, "input1": input1_pt}
+        y = get_torch_empty_tensor(y_pt.size(), dtype)
+        module.run_with_tensors(inputs, [y])
+        self.assertTrue(torch.allclose(y_pt, y, atol=1e-2, rtol=1e-2))
+
+    def test_slice_scatter_reshape_float16(self):
+        self._test_slice_scatter_reshape_float16(
+            input0_shape=[6, 2],
+            input1_shape=[2, 4, 2],
+            start_indices=[1, 0],
+            end_indices=[3, None],
+        )
+        self._test_slice_scatter_reshape_float16(
+            input0_shape=[2, 6],
+            input1_shape=[2, 4, 2],
+            start_indices=[0, 0],
+            end_indices=[None, 2],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Current implementation of get_item over a list of indices first perform tensor_slice on pieces of index, squeeze, unsqueeze, amd then concatenate.
This is because tensor_slice will squeeze tensor when encounter int, while it cannot handle list of int.

It doesn't work well with AIT's fusion pass because of extra squeeze and unsqueeze.

To avoid this, we want tensor_slice to skip squeeze when inputs is
```
a=torch.randn([10,8])
a[:, [2]]
```
This diff change tensor_slice to be able to handle list of index when `len(list)==1`. It does the same thing as non index version; the only difference is instead of giving a `int`, now we get a `slice(2,3,None).`
Then AIT fusion pass can handle this dynamic shape issue.

Another thing is, in practice, there are quite some dynamic_slice context that can be merged
e.g. `a[0, 2, 3, 4]`, we want to slice twice, one with `slice(0,1,None)`, the other with `slice(2,5,None)`. This fix the issue of subsequent large slices, e.g. https://fburl.com/phabricator/t26ylhbw

Reviewed By: wushirong

Differential Revision: D43071233

