### PR TITLE
call depthwise_conv3d with bias instead of use it in the initializer

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -1184,8 +1184,8 @@ def _choose_conv3d_op(
             groups == weight._attrs["shape"][0]
         ), "Currently only support channel == groups"
         return depthwise_conv3d(
-            stride=stride, pad=pad, dilate=dilate, group=groups, bias=bias
-        )(x, weight)
+            stride=stride, pad=pad, dilate=dilate, group=groups, bias=True
+        )(x, weight, bias)
     else:
         assert (
             groups is None or groups == 1

--- a/python/aitemplate/compiler/ops/conv/depthwise_conv3d.py
+++ b/python/aitemplate/compiler/ops/conv/depthwise_conv3d.py
@@ -266,8 +266,6 @@ class depthwise_conv3d(Operator):
         self._attrs["inputs"] = [x, w]
         if bias:
             self._attrs["inputs"].append(bias)
-        elif self._attrs["bias"]:
-            self._attrs["inputs"].append(self._attrs["bias"])
         self._set_depth()
         output_shape = self._infer_shapes(x, w)
         self._extract_exec_path(x)


### PR DESCRIPTION
Summary: depthwise_conv3d should accpet bias in the call function instead of in the initializer. Fix the issue in this diff.

Differential Revision: D43152843

