### PR TITLE
allow users to pick the optimization level for the host code

### DIFF
--- a/python/aitemplate/backend/cuda/target_def.py
+++ b/python/aitemplate/backend/cuda/target_def.py
@@ -31,6 +31,7 @@ from aitemplate.backend.profiler_cache import ProfileCacheDB
 
 from aitemplate.backend.target import TargetType
 
+from ...utils import environ
 from ...utils.misc import is_debug
 
 from .. import registry
@@ -103,6 +104,7 @@ class CUDA(Target):
             ),
             os.path.join(self._template_path, "../cub"),
         ]
+
         options = [
             "-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1",
             "-DCUTLASS_USE_TANH_FOR_SIGMOID=1",
@@ -113,7 +115,7 @@ class CUDA(Target):
             "-Xcompiler=-Wconversion",
             "-Xcompiler=-fno-strict-aliasing",
             "-Xcompiler -fvisibility=hidden",
-            "-O3",
+            environ.get_compiler_opt_level(),
             "-std=c++17",
             "--expt-relaxed-constexpr",
             "--use_fast_math",
@@ -252,6 +254,7 @@ class FBCUDA(CUDA):
             with open(fb_include_path, "w") as fb_include:
                 for arg in pp_args:
                     fb_include.write(pipes.quote(arg) + "\n")
+
             options = self.nvcc_options_json["args"] + [
                 "-I" + cutlass_path[0],
                 "-I" + cutlass_path[1],
@@ -276,7 +279,7 @@ class FBCUDA(CUDA):
                 "-gencode=arch=compute_%s,code=[sm_%s,compute_%s]"
                 % (self._arch, self._arch, self._arch),
                 "-Xcompiler=-Wconversion",
-                "-O3",
+                environ.get_compiler_opt_level(),
                 "-std=c++17",
             ]
             if self._ndebug == 1:

--- a/python/aitemplate/backend/rocm/target_def.py
+++ b/python/aitemplate/backend/rocm/target_def.py
@@ -27,6 +27,8 @@ from typing import List
 
 from aitemplate.backend.target import AIT_STATIC_FILES_PATH
 
+from ...utils import environ
+
 from .. import registry
 from ..target import COMPOSABLE_KERNEL_PATH, Target
 
@@ -154,7 +156,7 @@ class ROCM(Target):
 
         ck_paths = self._get_ck_paths()
         options = [
-            "-O3",
+            environ.get_compiler_opt_level(),
             "-fPIC",
             "-fvisibility=hidden",
             "-std=c++17",
@@ -329,7 +331,7 @@ class FBROCM(ROCM):
 
         ck_paths = self._get_ck_paths()
         options = self.hipcc_options_json["args"] + [
-            "-O3",
+            environ.get_compiler_opt_level(),
             "-fPIC",
             "-fvisibility=hidden",
             "-std=c++17",

--- a/python/aitemplate/utils/environ.py
+++ b/python/aitemplate/utils/environ.py
@@ -13,17 +13,17 @@
 #  limitations under the License.
 #
 
-# flake8: noqa
+import os
 
-from . import (
-    alignment,
-    environ,
-    graph_utils,
-    import_path,
-    markdown_table,
-    misc,
-    shape_utils,
-    tensor_utils,
-    torch_utils,
-    visualization,
-)
+
+def get_compiler_opt_level() -> str:
+    # The reason: it is typical in our situation that an option
+    # --optimize <level> (-Ox) is for a HOST compiler. And -O3 does
+    # literally nothing except for the enormous compilation time.
+    #
+    # So, it is safe to allow users to override this option in order
+    # to significantly speedup the computations / testing, especially
+    # for very large models.
+    compiler_opt = os.getenv("AIT_COMPILER_OPT", "-O3")
+
+    return compiler_opt


### PR DESCRIPTION
Summary:
It is typical in our situation that an option --optimize <level> (-Ox) in a Makefile is for a HOST compiler. And the default -O3 does literally nothing except for the enormous compilation time.

So, it is safe to allow users to override this option in order to significantly speedup the computations / testing, especially for very large models.

Differential Revision: D43189546

