### PR TITLE
Set ProfilerRunner timeout to default value 300

### DIFF
--- a/python/aitemplate/backend/profiler_runner.py
+++ b/python/aitemplate/backend/profiler_runner.py
@@ -236,16 +236,16 @@ class ProfilerRunner:
     however, the results are empirically better compared to the previous runner.
     """
 
-    def __init__(self, devices: List[str], timeout: int, postprocessing_delegate):
+    def __init__(self, devices: List[str], postprocessing_delegate, timeout: int = 300):
         """
         Parameters
         ----------
         devices : List[str]
             device identifiers (contents of {CUDA,HIP}_VISIBLE_DEVICES)
-        timeout : int
-            timeout to wait for all profilers completion in seconds
         postprocessing_delegate :
             object responsible for postprocessing results after futures completion
+        timeout : int
+            timeout to wait for all profilers completion in seconds
         """
         if devices is None:
             devices = [0]

--- a/python/aitemplate/compiler/transform/profile.py
+++ b/python/aitemplate/compiler/transform/profile.py
@@ -107,7 +107,6 @@ def profile(
         )
     profiler_runner = ProfilerRunner(
         devices,
-        timeout=240,
         postprocessing_delegate=GemmProfilerPostprocessingDelegate(),
     )
     for f in gemms:


### PR DESCRIPTION
Summary:
This is the first diff to refactor timeout parameters in ProfilerRunner.

1/ Remove the hardcode 240 input argument and add a default value 300 in ProfilerRunner.
2/ Remove the hardcode 180 value by reusing the self._timeout value in backend/profiler_runner.py: https://fburl.com/code/u4vevwwx
3/ Add an env valuable to control the default timeout value

Differential Revision: D43204970

