### PR TITLE
Added an environment variable AIT_FORCE_PROFILER_CACHE

### DIFF
--- a/python/aitemplate/compiler/ops/conv/conv3d.py
+++ b/python/aitemplate/compiler/ops/conv/conv3d.py
@@ -30,7 +30,7 @@ import jinja2
 from .... import backend
 from ....backend import registry
 from ....backend.target import Target
-from ....utils import alignment, shape_utils
+from ....utils import alignment, environ, shape_utils
 from ...base import DynamicProfileStrategy, IntImm, IntVar, Operator, Tensor
 from .cache_entry import Conv3dQueryEntry, Conv3dRecordEntry
 from .conv_common import (
@@ -303,10 +303,19 @@ class conv3d(Operator):
         entry for this gemm instance, we update this gemm op's
         relevant attributes with the cached result and return False.
         """
+        force_cache = environ.force_profiler_cache()
         if self._has_dynamic_input_dims():
+            if force_cache:
+                raise RuntimeError(
+                    "We cannot force to use the cache as dynamic dims require "
+                    "us to generate and build the profilers"
+                )
             # If there are dynamic dims, we'll have to generate and build the
             # profilers, as the binaries will be needed for dynamic profiling.
             return True
+        # We are forced to use the cache so we skip building profilers.
+        if force_cache:
+            return False
 
         target = backend.target.Target.current()
         workloads = list(self._attrs["exec_path"].keys())
@@ -428,7 +437,7 @@ class conv3d(Operator):
         command = [str(x) for x in cmd]
         return command
 
-    def _profile_single_workload(self, profiler_prefix, exec_key, devices):
+    def _profile_single_workload(self, profiler_prefix, exec_key, devices, force_cache):
         target = backend.target.Target.current()
         # query cache
         tmp_key = next(iter(self._attrs["op_instance"].keys()))
@@ -466,6 +475,12 @@ class conv3d(Operator):
         if cache_value is not None and not target.force_profile():
             _LOGGER.info("Load profiling result from cache.")
             return cache_value
+        if cache_value is None and force_cache:
+            op_type = self._attrs["op"]
+            raise RuntimeError(
+                "force_cache is enabled but we could not find the following cache ",
+                f"available on device {target._arch=}, {op_type=}, {exec_entry_sha1=}",
+            )
         if target.use_dummy_profiling_results():
             op_type = self._attrs["op"]
             raise Exception(
@@ -555,8 +570,8 @@ class conv3d(Operator):
 
         workloads = list(self._attrs["exec_path"].keys())
         profiler_prefix = os.path.join(workdir, "profiler", self._attrs["op"])
+        target = backend.target.Target.current()
         if "op_instance" not in self._attrs or len(self._attrs["op_instance"]) == 0:
-            target = backend.target.Target.current()
             # init candidate ops
             func_key = "{target}.{op}.config".format(
                 target=target.name(), op=self._attrs["op"]
@@ -564,14 +579,14 @@ class conv3d(Operator):
             func = registry.get(func_key)
             func(self._attrs, dtype=self._attrs["inputs"][0]._attrs["dtype"])
 
+        force_cache = environ.force_profiler_cache()
         for wkl in workloads:
             _LOGGER.info(
                 "Profile: {name}: {wkl}".format(name=self._attrs["name"], wkl=wkl),
             )
-            target = backend.target.Target.current()
             # if in CI just choose minimal configs
             # workspace is a hack just provides 102400 Byte
-            if target.use_dummy_profiling_results():
+            if target.use_dummy_profiling_results() and not force_cache:
                 algo = target.select_minimal_algo(
                     list(self._attrs["op_instance"].keys())
                 )
@@ -580,7 +595,7 @@ class conv3d(Operator):
                 self._attrs["workspace"] = 102400
             elif self._attrs["exec_path"][wkl] == "":
                 best_algo, workspace = self._profile_single_workload(
-                    profiler_prefix, wkl, devices
+                    profiler_prefix, wkl, devices, force_cache
                 )
                 self._attrs["exec_path"][wkl] = best_algo
                 self._attrs["workspace"] = max(self._attrs["workspace"], workspace)

--- a/python/aitemplate/compiler/ops/conv/conv3d_bias.py
+++ b/python/aitemplate/compiler/ops/conv/conv3d_bias.py
@@ -30,7 +30,7 @@ import jinja2
 from .... import backend
 from ....backend import registry
 from ....backend.target import Target
-from ....utils import alignment, shape_utils
+from ....utils import alignment, environ, shape_utils
 from ...base import DynamicProfileStrategy, IntImm, IntVar, Operator, Tensor
 from .cache_entry import Conv3dQueryEntry, Conv3dRecordEntry
 from .conv_common import (
@@ -303,10 +303,19 @@ class conv3d_bias(Operator):
         entry for this gemm instance, we update this gemm op's
         relevant attributes with the cached result and return False.
         """
+        force_cache = environ.force_to_use_cache()
         if self._has_dynamic_input_dims():
+            if force_cache:
+                raise RuntimeError(
+                    "We cannot force to use the cache as dynamic dims require "
+                    "us to generate and build the profilers"
+                )
             # If there are dynamic dims, we'll have to generate and build the
             # profilers, as the binaries will be needed for dynamic profiling.
             return True
+        # We are forced to use the cache so we skip building profilers.
+        if force_cache:
+            return False
 
         target = backend.target.Target.current()
         workloads = list(self._attrs["exec_path"].keys())
@@ -428,7 +437,7 @@ class conv3d_bias(Operator):
         command = [str(x) for x in cmd]
         return command
 
-    def _profile_single_workload(self, profiler_prefix, exec_key, devices):
+    def _profile_single_workload(self, profiler_prefix, exec_key, devices, force_cache):
         target = backend.target.Target.current()
         # query cache
         tmp_key = next(iter(self._attrs["op_instance"].keys()))
@@ -466,6 +475,12 @@ class conv3d_bias(Operator):
         if cache_value is not None and not target.force_profile():
             _LOGGER.info("Load profiling result from cache.")
             return cache_value
+        if cache_value is None and force_cache:
+            op_type = self._attrs["op"]
+            raise RuntimeError(
+                "force_cache is enabled but we could not find the following cache ",
+                f"available on device {target._arch=}, {op_type=}, {exec_entry_sha1=}",
+            )
         if target.use_dummy_profiling_results():
             op_type = self._attrs["op"]
             raise Exception(
@@ -555,8 +570,8 @@ class conv3d_bias(Operator):
 
         workloads = list(self._attrs["exec_path"].keys())
         profiler_prefix = os.path.join(workdir, "profiler", self._attrs["op"])
+        target = backend.target.Target.current()
         if "op_instance" not in self._attrs or len(self._attrs["op_instance"]) == 0:
-            target = backend.target.Target.current()
             # init candidate ops
             func_key = "{target}.{op}.config".format(
                 target=target.name(), op=self._attrs["op"]
@@ -564,14 +579,14 @@ class conv3d_bias(Operator):
             func = registry.get(func_key)
             func(self._attrs, dtype=self._attrs["inputs"][0]._attrs["dtype"])
 
+        force_cache = environ.force_to_use_cache()
         for wkl in workloads:
             _LOGGER.info(
                 "Profile: {name}: {wkl}".format(name=self._attrs["name"], wkl=wkl),
             )
-            target = backend.target.Target.current()
             # if in CI just choose minimal configs
             # workspace is a hack just provides 102400 Byte
-            if target.use_dummy_profiling_results():
+            if target.use_dummy_profiling_results() and not force_cache:
                 algo = target.select_minimal_algo(
                     list(self._attrs["op_instance"].keys())
                 )
@@ -580,7 +595,7 @@ class conv3d_bias(Operator):
                 self._attrs["workspace"] = 102400
             elif self._attrs["exec_path"][wkl] == "":
                 best_algo, workspace = self._profile_single_workload(
-                    profiler_prefix, wkl, devices
+                    profiler_prefix, wkl, devices, force_cache
                 )
                 self._attrs["exec_path"][wkl] = best_algo
                 self._attrs["workspace"] = max(self._attrs["workspace"], workspace)

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_common.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_common.py
@@ -33,7 +33,7 @@ from aitemplate.backend.profiler_runner import ProfileResult
 
 from .... import backend
 from ....backend import registry
-from ....utils import alignment
+from ....utils import alignment, environ
 from ...base import DynamicProfileStrategy, ExecItem, IntImm, IntVar, Operator, Tensor
 from ...dtype import is_same_dtype
 from ...tensor_accessor import TensorAccessor
@@ -399,6 +399,9 @@ class gemm(Operator):
         entry for this gemm instance, we update this gemm op's
         relevant attributes with the cached result and return False.
         """
+        # We are forced to use the cache so we skip building profilers.
+        if environ.force_profiler_cache():
+            return False
         target = backend.target.Target.current()
 
         build_profiler = True
@@ -568,7 +571,9 @@ class gemm(Operator):
                 )
         return ab_alignment
 
-    def _profile_single_workload(self, profiler_prefix, exec_key, profiler_runner):
+    def _profile_single_workload(
+        self, profiler_prefix, exec_key, profiler_runner, force_cache
+    ):
         """
         Schedule profilers for given profiler path and gemm shape (exec_key)
         or get the result from cache
@@ -611,14 +616,21 @@ class gemm(Operator):
             self._attrs["workspace"] = max(self._attrs["workspace"], cache_value[1])
             self._attrs["split_k"] = cache_value[2]
             return
+        if cache_value is None and force_cache:
+            op_type = self._attrs["op"]
+            raise RuntimeError(
+                "force_cache is enabled but we could not find the following cache ",
+                f"available on device {target._arch=}, {op_type=}, {exec_entry_sha1=}",
+            )
         if target.use_dummy_profiling_results():
             op_type = self._attrs["op"]
             raise Exception(
                 "This is a CI run but we could not find the following cache ",
                 f"available on device {target._arch}\n",
                 f"{op_type} {exec_entry_sha1}.\n",
-                "To bypass, you need to make it available in the db table.",
+                "Please adjust target.select_minimal_algo function.",
             )
+
         profiler_filename = self._get_profiler_filename()
 
         def _gen_callback(split_k):
@@ -671,14 +683,15 @@ class gemm(Operator):
             )
             func = registry.get(func_key)
             func(self._attrs, dtype=self._attrs["inputs"][0]._attrs["dtype"])
+        target = backend.target.Target.current()
+        force_cache = environ.force_profiler_cache()
         for wkl in workloads:
             _LOGGER.info(
                 "Profile: {name}: {wkl}".format(name=self._attrs["name"], wkl=wkl),
             )
-            target = backend.target.Target.current()
             # if in CI just choose minimal configs
             # workspace is a hack just provides 102400 Byte
-            if target.use_dummy_profiling_results():
+            if target.use_dummy_profiling_results() and not force_cache:
                 algo = target.select_minimal_algo(
                     list(self._attrs["op_instance"].keys())
                 )
@@ -689,7 +702,9 @@ class gemm(Operator):
                 # we have cached best algo
                 return
             else:
-                self._profile_single_workload(profiler_prefix, wkl, profiler_runner)
+                self._profile_single_workload(
+                    profiler_prefix, wkl, profiler_runner, force_cache
+                )
 
     def gen_function(self) -> str:
         """Generates the function code for the gemm op for the current target.

--- a/python/aitemplate/utils/environ.py
+++ b/python/aitemplate/utils/environ.py
@@ -12,8 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-
+"""
+A common place for holding AIT-related env control variables
+"""
+import logging
 import os
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def get_compiler_opt_level() -> str:
@@ -27,3 +33,19 @@ def get_compiler_opt_level() -> str:
     compiler_opt = os.getenv("AIT_COMPILER_OPT", "-O3")
 
     return compiler_opt
+
+
+def force_profiler_cache() -> bool:
+    """
+    Force the profiler to use the cached results. The profiler will throw
+    a runtime exception if it cannot find cached results. This env may be
+    useful to capture any cache misses due to cache version updates or
+    other relevant code changes.
+    """
+    force_cache = os.environ.get("AIT_FORCE_PROFILER_CACHE", None) == "1"
+    if force_cache:
+        assert (
+            os.environ.get("FORCE_PROFILE", None) != "1"
+        ), "cannot specify both AIT_FORCE_PROFILER_CACHE and FORCE_PROFILE"
+    _LOGGER.info(f"{force_cache=}")
+    return force_cache

--- a/tests/unittest/ops/test_conv3d_profiler_cache.py
+++ b/tests/unittest/ops/test_conv3d_profiler_cache.py
@@ -12,7 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import logging
 import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -22,6 +24,9 @@ from aitemplate.compiler import compile_model, ops
 from aitemplate.compiler.base import DynamicProfileStrategy
 from aitemplate.frontend import IntImm, IntVar, Tensor
 from aitemplate.testing import detect_target
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @unittest.skipIf(detect_target()._arch == "75", "Conv3d not supported on sm75.")
@@ -80,12 +85,13 @@ class Conv3DProfilerCacheTestCase(unittest.TestCase):
         first_dim,
         test_name,
         logger,
+        cache_dir,
     ):
         old_trick = os.environ.get("TRICK_CI_ENV", None)
         old_cache = os.environ.get("CACHE_DIR", None)
         try:
             os.environ["TRICK_CI_ENV"] = "1"
-            os.environ["CACHE_DIR"] = f"/tmp/aitemplate/{test_name}"
+            os.environ["CACHE_DIR"] = f"{cache_dir}/{test_name}"
             return self._test(
                 first_dim=first_dim,
                 logger=logger,
@@ -106,19 +112,23 @@ class Conv3DProfilerCacheTestCase(unittest.TestCase):
         test_name = "conv3d_profiler_cache"
         logger = "aitemplate.compiler.transform.profile"
 
-        run1_logs = self._run_test(
-            first_dim=first_dim,
-            test_name=test_name,
-            logger=logger,
-        )
-        self.assertIn("generated 1 profilers", run1_logs)
+        _LOGGER.info(f"running {test_name=}")
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            run1_logs = self._run_test(
+                first_dim=first_dim,
+                test_name=test_name,
+                logger=logger,
+                cache_dir=tmp_dirname,
+            )
+            self.assertIn("generated 1 profilers", run1_logs)
 
-        run2_logs = self._run_test(
-            first_dim=first_dim,
-            test_name=test_name,
-            logger=logger,
-        )
-        self.assertIn("generated 0 profilers", run2_logs)
+            run2_logs = self._run_test(
+                first_dim=first_dim,
+                test_name=test_name,
+                logger=logger,
+                cache_dir=tmp_dirname,
+            )
+            self.assertIn("generated 0 profilers", run2_logs)
 
     def test_conv3d_profiler_cache_versioning(self):
         first_dim = IntImm(4)
@@ -127,74 +137,136 @@ class Conv3DProfilerCacheTestCase(unittest.TestCase):
         cache_version_property = "conv3d_cache_version"
         target_name = detect_target().name()
 
-        with patch.object(
-            target=ProfileCacheDB,
-            attribute=cache_version_property,
-            new=1,  # version
-        ):
-            run1_before_version_change_logs = self._run_test(
-                first_dim=first_dim,
-                test_name=test_name,
-                logger=logger,
-            )
-            self.assertIn(
-                f"table_name='{target_name}_conv3d_1' does not exist in the db",
-                run1_before_version_change_logs,
-            )
+        _LOGGER.info(f"running {test_name=}")
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            _LOGGER.info(f"{tmp_dirname=}")
+            with patch.object(
+                target=ProfileCacheDB,
+                attribute=cache_version_property,
+                new=1,  # version
+            ):
+                run1_before_version_change_logs = self._run_test(
+                    first_dim=first_dim,
+                    test_name=test_name,
+                    logger=logger,
+                    cache_dir=tmp_dirname,
+                )
+                self.assertIn(
+                    f"table_name='{target_name}_conv3d_1' does not exist in the db",
+                    run1_before_version_change_logs,
+                )
 
-            run2_before_version_change_logs = self._run_test(
-                first_dim=first_dim,
-                test_name=test_name,
-                logger=logger,
-            )
-            self.assertIn(
-                f"table_name='{target_name}_conv3d_1' exists in the db",
-                run2_before_version_change_logs,
-            )
+                run2_before_version_change_logs = self._run_test(
+                    first_dim=first_dim,
+                    test_name=test_name,
+                    logger=logger,
+                    cache_dir=tmp_dirname,
+                )
+                self.assertIn(
+                    f"table_name='{target_name}_conv3d_1' exists in the db",
+                    run2_before_version_change_logs,
+                )
 
-        with patch.object(
-            target=ProfileCacheDB,
-            attribute=cache_version_property,
-            new=2,  # version
-        ):
-            run1_after_version_change_logs = self._run_test(
-                first_dim=first_dim,
-                test_name=test_name,
-                logger=logger,
-            )
-            self.assertIn(
-                f"table_name='{target_name}_conv3d_2' does not exist in the db",
-                run1_after_version_change_logs,
-            )
+            with patch.object(
+                target=ProfileCacheDB,
+                attribute=cache_version_property,
+                new=2,  # version
+            ):
+                run1_after_version_change_logs = self._run_test(
+                    first_dim=first_dim,
+                    test_name=test_name,
+                    logger=logger,
+                    cache_dir=tmp_dirname,
+                )
+                self.assertIn(
+                    f"table_name='{target_name}_conv3d_2' does not exist in the db",
+                    run1_after_version_change_logs,
+                )
 
-            run2_after_version_change_logs = self._run_test(
-                first_dim=first_dim,
-                test_name=test_name,
-                logger=logger,
-            )
-            self.assertIn(
-                f"table_name='{target_name}_conv3d_2' exists in the db",
-                run2_after_version_change_logs,
-            )
+                run2_after_version_change_logs = self._run_test(
+                    first_dim=first_dim,
+                    test_name=test_name,
+                    logger=logger,
+                    cache_dir=tmp_dirname,
+                )
+                self.assertIn(
+                    f"table_name='{target_name}_conv3d_2' exists in the db",
+                    run2_after_version_change_logs,
+                )
+
+    def test_conv3d_profiler_force_cache(self):
+        first_dim = IntImm(4)
+        test_name = "conv3d_profiler_force_cache"
+        cache_version_property = "conv3d_cache_version"
+
+        old_force_cache = os.environ.get("AIT_FORCE_PROFILER_CACHE", None)
+        logger = "aitemplate.backend.profiler_cache"
+        _LOGGER.info(f"running {test_name=}")
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            _LOGGER.info(f"{tmp_dirname=}")
+            with patch.object(
+                target=ProfileCacheDB,
+                attribute=cache_version_property,
+                new=1,  # version
+            ):
+                _LOGGER.info("force cache with no cache 1")
+                os.environ["AIT_FORCE_PROFILER_CACHE"] = "1"
+                with self.assertRaisesRegex(
+                    RuntimeError, "force_cache is enabled but we could not find"
+                ):
+                    self._run_test(
+                        first_dim=first_dim,
+                        test_name=test_name,
+                        logger=logger,
+                        cache_dir=tmp_dirname,
+                    )
+
+                del os.environ["AIT_FORCE_PROFILER_CACHE"]
+                _LOGGER.info("make cache 1")
+                self._run_test(
+                    first_dim=first_dim,
+                    test_name=test_name,
+                    logger=logger,
+                    cache_dir=tmp_dirname,
+                )
+
+                os.environ["AIT_FORCE_PROFILER_CACHE"] = "1"
+                _LOGGER.info("force cache with no cache 1")
+                self._run_test(
+                    first_dim=first_dim,
+                    test_name=test_name,
+                    logger=logger,
+                    cache_dir=tmp_dirname,
+                )
+
+        if old_force_cache is not None:
+            os.environ["AIT_FORCE_PROFILER_CACHE"] = old_force_cache
+        else:
+            del os.environ["AIT_FORCE_PROFILER_CACHE"]
 
     def test_conv3d_profiler_cache_dynamic(self):
         first_dim = IntVar([2, 8])
         test_name = "conv3d_profiler_cache_dynamic"
         logger = "aitemplate.compiler.transform.profile"
 
-        run1_logs = self._run_test(
-            first_dim=first_dim,
-            test_name=test_name,
-            logger=logger,
-        )
-        self.assertIn("generated 1 profilers", run1_logs)
+        _LOGGER.info(f"running {test_name=}")
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            _LOGGER.info(f"{tmp_dirname=}")
+            run1_logs = self._run_test(
+                first_dim=first_dim,
+                test_name=test_name,
+                logger=logger,
+                cache_dir=tmp_dirname,
+            )
+            self.assertIn("generated 1 profilers", run1_logs)
 
-        run2_logs = self._run_test(
-            first_dim=first_dim,
-            test_name=test_name,
-            logger=logger,
-        )
-        self.assertIn("generated 1 profilers", run2_logs)
+            run2_logs = self._run_test(
+                first_dim=first_dim,
+                test_name=test_name,
+                logger=logger,
+                cache_dir=tmp_dirname,
+            )
+            self.assertIn("generated 1 profilers", run2_logs)
 
 
 if __name__ == "__main__":

--- a/tests/unittest/ops/test_gemm_profiler_cache.py
+++ b/tests/unittest/ops/test_gemm_profiler_cache.py
@@ -12,7 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import logging
 import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -21,6 +23,9 @@ from aitemplate.backend.profiler_cache import ProfileCacheDB
 from aitemplate.compiler import compile_model, ops
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class GemmProfilerCacheTestCase(unittest.TestCase):
@@ -69,12 +74,13 @@ class GemmProfilerCacheTestCase(unittest.TestCase):
         first_dim,
         test_name,
         logger,
+        cache_dir,
     ):
         old_trick = os.environ.get("TRICK_CI_ENV", None)
         old_cache = os.environ.get("CACHE_DIR", None)
         try:
             os.environ["TRICK_CI_ENV"] = "1"
-            os.environ["CACHE_DIR"] = f"/tmp/aitemplate/{test_name}"
+            os.environ["CACHE_DIR"] = f"{cache_dir}/{test_name}"
             return self._test(
                 first_dim=first_dim,
                 logger=logger,
@@ -95,19 +101,24 @@ class GemmProfilerCacheTestCase(unittest.TestCase):
         test_name = "gemm_rcr_profiler_cache"
         logger = "aitemplate.compiler.transform.profile"
 
-        run1_logs = self._run_test(
-            first_dim=first_dim,
-            test_name=test_name,
-            logger=logger,
-        )
-        self.assertIn("generated 1 profilers", run1_logs)
+        _LOGGER.info(f"running {test_name=}")
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            _LOGGER.info(f"{tmp_dirname=}")
+            run1_logs = self._run_test(
+                first_dim=first_dim,
+                test_name=test_name,
+                logger=logger,
+                cache_dir=tmp_dirname,
+            )
+            self.assertIn("generated 1 profilers", run1_logs)
 
-        run2_logs = self._run_test(
-            first_dim=first_dim,
-            test_name=test_name,
-            logger=logger,
-        )
-        self.assertIn("generated 0 profilers", run2_logs)
+            run2_logs = self._run_test(
+                first_dim=first_dim,
+                test_name=test_name,
+                logger=logger,
+                cache_dir=tmp_dirname,
+            )
+            self.assertIn("generated 0 profilers", run2_logs)
 
     def test_gemm_profiler_cache_versioning(self):
         first_dim = IntImm(4)
@@ -116,52 +127,113 @@ class GemmProfilerCacheTestCase(unittest.TestCase):
         cache_version_property = "gemm_cache_version"
         target_name = detect_target().name()
 
-        with patch.object(
-            target=ProfileCacheDB,
-            attribute=cache_version_property,
-            new=1,  # version
-        ):
-            run1_before_version_change_logs = self._run_test(
-                first_dim=first_dim,
-                test_name=test_name,
-                logger=logger,
-            )
-            self.assertIn(
-                f"table_name='{target_name}_gemm_1' does not exist in the db",
-                run1_before_version_change_logs,
-            )
+        _LOGGER.info(f"running {test_name=}")
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            _LOGGER.info(f"{tmp_dirname=}")
+            with patch.object(
+                target=ProfileCacheDB,
+                attribute=cache_version_property,
+                new=1,  # version
+            ):
+                run1_before_version_change_logs = self._run_test(
+                    first_dim=first_dim,
+                    test_name=test_name,
+                    logger=logger,
+                    cache_dir=tmp_dirname,
+                )
+                self.assertIn(
+                    f"table_name='{target_name}_gemm_1' does not exist in the db",
+                    run1_before_version_change_logs,
+                )
 
-            run2_before_version_change_logs = self._run_test(
-                first_dim=first_dim,
-                test_name=test_name,
-                logger=logger,
-            )
-            self.assertIn(
-                f"table_name='{target_name}_gemm_1' exists in the db",
-                run2_before_version_change_logs,
-            )
+                run2_before_version_change_logs = self._run_test(
+                    first_dim=first_dim,
+                    test_name=test_name,
+                    logger=logger,
+                    cache_dir=tmp_dirname,
+                )
+                self.assertIn(
+                    f"table_name='{target_name}_gemm_1' exists in the db",
+                    run2_before_version_change_logs,
+                )
 
-        with patch.object(
-            target=ProfileCacheDB,
-            attribute=cache_version_property,
-            new=2,  # version
-        ):
-            run1_after_version_change_logs = self._run_test(
-                first_dim=first_dim,
-                test_name=test_name,
-                logger=logger,
-            )
-            self.assertIn(
-                f"table_name='{target_name}_gemm_2' does not exist in the db",
-                run1_after_version_change_logs,
-            )
+            with patch.object(
+                target=ProfileCacheDB,
+                attribute=cache_version_property,
+                new=2,  # version
+            ):
+                run1_after_version_change_logs = self._run_test(
+                    first_dim=first_dim,
+                    test_name=test_name,
+                    logger=logger,
+                    cache_dir=tmp_dirname,
+                )
+                self.assertIn(
+                    f"table_name='{target_name}_gemm_2' does not exist in the db",
+                    run1_after_version_change_logs,
+                )
 
-            run2_after_version_change_logs = self._run_test(
-                first_dim=first_dim,
-                test_name=test_name,
-                logger=logger,
-            )
-            self.assertIn(
-                f"table_name='{target_name}_gemm_2' exists in the db",
-                run2_after_version_change_logs,
-            )
+                run2_after_version_change_logs = self._run_test(
+                    first_dim=first_dim,
+                    test_name=test_name,
+                    logger=logger,
+                    cache_dir=tmp_dirname,
+                )
+                self.assertIn(
+                    f"table_name='{target_name}_gemm_2' exists in the db",
+                    run2_after_version_change_logs,
+                )
+
+    def test_gemm_profiler_force_cache(self):
+        first_dim = IntImm(4)
+        test_name = "gemm_rcr_profiler_force_cache"
+        cache_version_property = "gemm_cache_version"
+
+        old_force_cache = os.environ.get("AIT_FORCE_PROFILER_CACHE", None)
+        logger = "aitemplate.backend.profiler_cache"
+        _LOGGER.info(f"running {test_name=}")
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            _LOGGER.info(f"{tmp_dirname=}")
+            with patch.object(
+                target=ProfileCacheDB,
+                attribute=cache_version_property,
+                new=1,  # version
+            ):
+                _LOGGER.info("force cache with no cache 1")
+                os.environ["AIT_FORCE_PROFILER_CACHE"] = "1"
+                with self.assertRaisesRegex(
+                    RuntimeError, "force_cache is enabled but we could not find"
+                ):
+                    self._run_test(
+                        first_dim=first_dim,
+                        test_name=test_name,
+                        logger=logger,
+                        cache_dir=tmp_dirname,
+                    )
+
+                del os.environ["AIT_FORCE_PROFILER_CACHE"]
+                _LOGGER.info("make cache 1")
+                self._run_test(
+                    first_dim=first_dim,
+                    test_name=test_name,
+                    logger=logger,
+                    cache_dir=tmp_dirname,
+                )
+
+                os.environ["AIT_FORCE_PROFILER_CACHE"] = "1"
+                _LOGGER.info("force cache with no cache 1")
+                self._run_test(
+                    first_dim=first_dim,
+                    test_name=test_name,
+                    logger=logger,
+                    cache_dir=tmp_dirname,
+                )
+
+        if old_force_cache is not None:
+            os.environ["AIT_FORCE_PROFILER_CACHE"] = old_force_cache
+        else:
+            del os.environ["AIT_FORCE_PROFILER_CACHE"]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
When we update our cache versions or make some changes, we may generate
a different cache key for a problem size from the previous version.
Such cache misses can result in re-compiling profilers and re-performing
profiling.

We introduce a new environment variable AIT_FORCE_PROFILER_CACHE, which
may be used to ensure such cache missed to not be overlooked.

Differential Revision: D43242228

