### PR TITLE
Revert D43109561: Multisect successfully blamed D43109561 for test or build failures

### DIFF
--- a/fx2ait/fx2ait/test/converters/converters_module/test_ait_multihead_attention.py
+++ b/fx2ait/fx2ait/test/converters/converters_module/test_ait_multihead_attention.py
@@ -47,7 +47,7 @@ class TestMultiHeadAttentionConverter(AITTestCase):
                 acc_ops.unsqueeze,
                 acc_ops.getitem,
             },
-            leaf_module=torch.nn.MultiheadAttention,
+            transformer_mode=True,
         )
 
     def test_multihead_attention(self):
@@ -75,5 +75,5 @@ class TestMultiHeadAttentionConverter(AITTestCase):
             model,
             [x],
             expected_ops={torch.nn.MultiheadAttention},
-            leaf_module=torch.nn.MultiheadAttention,
+            transformer_mode=True,
         )

--- a/fx2ait/fx2ait/tools/common_fx2ait.py
+++ b/fx2ait/fx2ait/tools/common_fx2ait.py
@@ -81,21 +81,18 @@ class AITTestCase(TestCase):
         precision: LowerPrecision = LowerPrecision.FP16,
         permute_inputs: Optional[List[int]] = None,
         permute_outputs: Optional[List[int]] = None,
+        transformer_mode: Optional[bool] = False,
         passes: List[Callable] = [],  # noqa: B006
-        leaf_module: Callable = None,  # one leaf module
     ):
         # TODO: add precision to interpreter once AIT supports multiple precision level
         # TODO: @qxy11 remove permute options once AIT supports channels-first format
         mod.eval()
-
-        leaf_module_list = []
-        if leaf_module:
-            leaf_module_list.append(leaf_module)
-
         mod = acc_tracer.trace(
             mod,
             inputs,
-            leaf_module_list=leaf_module_list,
+            leaf_module_list=[
+                torch.nn.MultiheadAttention if transformer_mode else None
+            ],
         )
         for p in passes:
             mod = p(mod, inputs)
@@ -158,9 +155,10 @@ class AITTestCase(TestCase):
             end_event.record()
             torch.cuda.synchronize()
             print("AIT run time(s)=", (start_event.elapsed_time(end_event) * 1.0e-3))
+
             # PyTorch Transformer model would yield 2 output tensors, of which the second one is
             # not useful. AIT model only output 1 output tensor, alter ref_output to match this.
-            if leaf_module == torch.nn.MultiheadAttention:
+            if transformer_mode:
                 ref_outputs = ref_outputs[0]
             if isinstance(outputs, torch.Tensor):
                 ref_outputs = [ref_outputs]


### PR DESCRIPTION
Summary:
This diff is reverting D43109561 (https://github.com/facebookincubator/AITemplate/commit/256d08bb845de90f3c9b2ffeae88cebf1fc56b1b)
D43109561 (https://github.com/facebookincubator/AITemplate/commit/256d08bb845de90f3c9b2ffeae88cebf1fc56b1b): [fx2ait] attention module by frank-wei has been identified to be causing the following test or build failures:

Tests affected:
- [ai_demos/server_model_zoo/models/uncrop:uncrop_push_blocking - testIndividualModel (ai_demos.server_model_zoo.models.uncrop.uncrop_test_model_instantiation.TestModelInstantiation)](https://www.internalfb.com/intern/test/844425009864384/)

Here's the Multisect link:
https://www.internalfb.com/intern/testinfra/multisect/1568617
Here are the tasks that are relevant to this breakage:
T145356499: 1 test started failing for oncall aiacu in the last 2 weeks
We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

Differential Revision: D43204945

