### PR TITLE
Do not allow users to modify constants set by AIT internal.

### DIFF
--- a/python/aitemplate/backend/codegen.py
+++ b/python/aitemplate/backend/codegen.py
@@ -436,6 +436,9 @@ class ModelContainerGenerator:
         self.num_constants += 1
 
     def _codegen_bound_constant(self, tensor: Tensor) -> None:
+        if tensor._attrs.get("is_internal_constant", False):
+            return
+
         name = tensor._attrs["name"]
         self.set_up_constant_names.append(
             set_value(

--- a/python/aitemplate/backend/main_templates.py
+++ b/python/aitemplate/backend/main_templates.py
@@ -170,10 +170,13 @@ constexpr std::array<ConstantInfo, {{ num_constants }}> owned_constants = {
 ModelContainerBase::ModelContainerBase(
     size_t num_inputs,
     size_t num_outputs,
+    size_t num_bound_constants,
     size_t num_unbound_constants,
     size_t params_size,
     AITemplateAllocator& allocator)
     : constants_(RAII_DeviceMalloc(params_size, allocator)),
+      bound_constant_size_(num_bound_constants),
+      bound_constant_dtypes_(num_bound_constants),
       num_params_(num_inputs + num_outputs + num_unbound_constants),
       param_names_(num_params_),
       param_dtypes_(num_params_),
@@ -183,6 +186,8 @@ ModelContainerBase::ModelContainerBase(
 {{ set_up_constant_names }}
 {{ set_up_param_names }}
 {{ set_up_param_dtypes }}
+{{ set_up_bound_constant_dtypes }}
+{{ set_up_bound_constant_size }}
 {{ set_up_output_shapes }}
   for (size_t i = 0; i < num_params_; ++i) {
     max_param_numel_[i] = std::accumulate(
@@ -209,7 +214,7 @@ ModelContainerBase::ModelContainerBase(
 
 ModelContainer* CreateModelContainer(size_t num_runtimes, AITemplateAllocator& allocator) {
   // num_runtimes, blob_size, workspace_size, num_inputs, num_outputs, num_unbound_constants, param_size, allocator
-  return new ModelContainer(num_runtimes, {{num_inputs}}, {{num_outputs}}, {{num_unbound_constants}}, {{param_size}}, allocator);
+  return new ModelContainer(num_runtimes, {{num_inputs}}, {{num_outputs}}, {{num_bound_constants}}, {{num_unbound_constants}}, {{param_size}}, allocator);
 }
 } // namespace ait
 """

--- a/python/aitemplate/compiler/base.py
+++ b/python/aitemplate/compiler/base.py
@@ -351,6 +351,7 @@ class Tensor(Node):
         is_output: bool = False,
         value: Any = None,
         is_view_of: Any = None,
+        is_internal_constant: bool = False,
         check_nan_and_inf: bool = False,
         check_outputs: bool = False,
     ) -> None:
@@ -381,6 +382,8 @@ class Tensor(Node):
             empty list, this Tensor is used to represent a number.
         is_view_of : Any, optional
             Whether this Tensor is a view of another Tensor.
+        is_internal_constant: bool, optional
+            Whether this constant tensor could be modified.
         check_nan_and_inf : bool, optional
             Whether or not to check this tensor is nan or inf during runtime.
         check_outputs : bool, optional
@@ -399,6 +402,7 @@ class Tensor(Node):
         self._attrs["is_output"] = is_output
         self._attrs["is_input"] = is_input
         self._attrs["is_param"] = False
+        self._attrs["is_internal_constant"] = is_internal_constant
 
         # True if this is an internal tensor that aliases an output through
         # a view. Set up in mark_param_tensor
@@ -575,6 +579,7 @@ def _create_host_zero_tensor(
     dst_ops: Set[Node] = None,
     dtype: str = "float16",
     is_output: bool = False,
+    is_internal_constant: bool = True,
 ):
     """
     Create a zero tensor stored on the host machine.
@@ -584,6 +589,7 @@ def _create_host_zero_tensor(
         b"\x00" * get_aligned_size(shape, dtype, alignment=1), dtype=dtype
     )
     tensor = Tensor(shape, name, dst_ops=dst_ops, dtype=dtype, is_output=is_output)
+    tensor._attrs["is_internal_constant"] = is_internal_constant
     tensor._bind_data(zeros)
     return tensor
 

--- a/python/aitemplate/compiler/model.py
+++ b/python/aitemplate/compiler/model.py
@@ -941,20 +941,32 @@ class Model(object):
             self.handle, ctypes.c_void_p(stream_ptr), ctypes.c_bool(sync)
         )
 
-    def _get_constant_names_impl(self, constant_folding_only: bool) -> List[str]:
+    def _get_constant_names_impl(
+        self, unbound_constants_only: bool, constant_folding_only: bool
+    ) -> List[str]:
         num_constants = ctypes.c_size_t()
         constant_folding_inputs_only = ctypes.c_bool(constant_folding_only)
+        unbound_constants_only_ = ctypes.c_bool(unbound_constants_only)
         self.DLL.AITemplateModelContainerGetNumConstants(
-            self.handle, constant_folding_inputs_only, ctypes.byref(num_constants)
+            self.handle,
+            unbound_constants_only_,
+            constant_folding_inputs_only,
+            ctypes.byref(num_constants),
         )
         names = (ctypes.c_char_p * num_constants.value)()
         self.DLL.AITemplateModelContainerGetConstantNames(
-            self.handle, constant_folding_inputs_only, names
+            self.handle, unbound_constants_only_, constant_folding_inputs_only, names
         )
         return [name.decode("utf-8") for name in names]
 
-    def get_constant_names(self) -> List[str]:
-        return self._get_constant_names_impl(False)
+    def get_constant_names(
+        self, unbound_constants_only: bool = True, constant_folding_only: bool = False
+    ) -> List[str]:
+        return self._get_constant_names_impl(
+            unbound_constants_only, constant_folding_only
+        )
 
-    def get_constant_folding_input_names(self) -> List[str]:
-        return self._get_constant_names_impl(True)
+    def get_constant_folding_input_names(
+        self, unbound_constants_only: bool = True
+    ) -> List[str]:
+        return self._get_constant_names_impl(unbound_constants_only, True)

--- a/python/aitemplate/compiler/transform/constant_folding.py
+++ b/python/aitemplate/compiler/transform/constant_folding.py
@@ -71,6 +71,7 @@ def _non_output_from_tensor(tensor: Tensor) -> Tensor:
         dst_ops=tensor._attrs["dst_ops"].copy(),
         dtype=tensor._attrs["dtype"],
         is_view_of=tensor._attrs["is_view_of"],
+        is_internal_constant=tensor._attrs["is_internal_constant"],
     )
     new_tensor._attrs["is_param"] = tensor._attrs["is_param"]
     new_tensor._attrs["data"] = tensor._attrs["data"]

--- a/static/csrc/model_interface.cpp
+++ b/static/csrc/model_interface.cpp
@@ -125,6 +125,7 @@ AIT_EXPORT AITemplateError AITemplateModelContainerSetManyConstants(
 
 AITemplateError AITemplateModelContainerGetNumConstants(
     AITemplateModelHandle handle,
+    bool unbound_constants_only,
     bool constant_folding_inputs_only,
     size_t* num_constants_out) {
   RETURN_ERROR_IF_NULL(handle)
@@ -132,15 +133,17 @@ AITemplateError AITemplateModelContainerGetNumConstants(
   auto* m = reinterpret_cast<ait::ModelContainer*>(handle);
   CONVERT_EXCEPTION_TO_ERROR_CODE({
     if (constant_folding_inputs_only) {
-      *num_constants_out = m->GetNumConstantFoldingInputs();
+      *num_constants_out =
+          m->GetNumConstantFoldingInputs(unbound_constants_only);
     } else {
-      *num_constants_out = m->GetNumConstants();
+      *num_constants_out = m->GetNumConstants(unbound_constants_only);
     }
   })
 }
 
 AITemplateError AITemplateModelContainerGetConstantNames(
     AITemplateModelHandle handle,
+    bool unbound_constants_only,
     bool constant_folding_inputs_only,
     const char** constant_names_out) {
   RETURN_ERROR_IF_NULL(handle)
@@ -149,7 +152,9 @@ AITemplateError AITemplateModelContainerGetConstantNames(
   auto* m = reinterpret_cast<ait::ModelContainer*>(handle);
   CONVERT_EXCEPTION_TO_ERROR_CODE({
     m->WriteAllConstantNamesTo(
-        constant_names_out, constant_folding_inputs_only);
+        constant_names_out,
+        unbound_constants_only,
+        constant_folding_inputs_only);
   })
 }
 

--- a/static/include/model_interface.h
+++ b/static/include/model_interface.h
@@ -157,11 +157,13 @@ AIT_EXPORT AITemplateError AITemplateModelContainerSetManyConstants(
 
 AIT_EXPORT AITemplateError AITemplateModelContainerGetNumConstants(
     AITemplateModelHandle handle,
+    bool unbound_constants_only,
     bool constant_folding_inputs_only,
     size_t* num_constants_out);
 
 AIT_EXPORT AITemplateError AITemplateModelContainerGetConstantNames(
     AITemplateModelHandle handle,
+    bool unbound_constants_only,
     bool constant_folding_inputs_only,
     const char** constant_names_out);
 

--- a/tests/unittest/backend/test_model_api.py
+++ b/tests/unittest/backend/test_model_api.py
@@ -44,6 +44,7 @@ from aitemplate.compiler.model import (
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
+from aitemplate.testing.test_utils import get_random_torch_tensor
 
 
 class ModelAPITestCase(unittest.TestCase):
@@ -1438,44 +1439,60 @@ class ModelAPITestCase(unittest.TestCase):
         target = detect_target()
 
         input_0 = Tensor(shape=[1, 2], dtype="float16", name="input_0", is_input=True)
+        constant_0 = Tensor(shape=[1, 2], dtype="float16", name="constant_0")
         constant_1 = Tensor(shape=[1, 2], dtype="float16", name="constant_1")
         constant_2 = Tensor(shape=[1, 2], dtype="float16", name="constant_2")
-        x = ops.elementwise(FuncEnum.MUL)(input_0, constant_1)
-        output = ops.elementwise(FuncEnum.MUL)(x, constant_2)
-        output._attrs["name"] = "output"
-        output._attrs["is_output"] = True
+        constant_3 = Tensor(shape=[1, 2], dtype="float16", name="constant_3")
+        constant_4 = Tensor(shape=[1, 2], dtype="float16", name="constant_4")
+        constants = {}
 
-        module = compile_model(output, target, "./tmp", "test_get_constant_names")
-        names = module.get_constant_names()
-        self.assertEqual(len(names), 2)
-        self.assertIn("constant_1", names)
-        self.assertIn("constant_2", names)
+        # constant 0 and constant 1 are not folded.
+        # constant 0 is unbounded, constant 1 is bounded.
+        x = ops.elementwise(FuncEnum.MUL)(input_0, constant_0)
+        x1 = ops.concatenate()([x, x, constant_1])
+        constants["constant_1"] = get_random_torch_tensor((1, 2), "float16")
 
-    def test_get_constant_folding_input_names(self):
-        target = detect_target()
+        # constants 2 and 3 and 4 are folded.
+        # constants 2 and 4 are unbounded, constants 3 is bounded.
+        y = ops.concatenate()([constant_2, constant_3, constant_4])
+        constants["constant_3"] = get_random_torch_tensor((1, 2), "float16")
 
-        input_0 = Tensor(shape=[1, 2], dtype="float16", name="input_0", is_input=True)
-        constant_1 = Tensor(shape=[1, 2], dtype="float16", name="constant_1")
-        constant_2 = Tensor(shape=[1, 2], dtype="float16", name="constant_2")
-        constant_2 = Tensor(shape=[1, 2], dtype="float16", name="constant_3")
-        # constant 1 is not folded.
-        x = ops.elementwise(FuncEnum.MUL)(input_0, constant_1)
-        # constants 2 and 3 are
-        y = ops.elementwise(FuncEnum.MUL)(constant_2, constant_2)
-
-        output = ops.elementwise(FuncEnum.MUL)(x, y)
+        output = ops.elementwise(FuncEnum.MUL)(x1, y)
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
         module = compile_model(
-            output, target, "./tmp", "test_get_constant_folding_input_names"
+            output, target, "./tmp", "test_get_constant_names", constants=constants
         )
-        names = module.get_constant_folding_input_names()
-        self.assertEqual(names, [])
-        # TODO: uncomment when the new constant folding pass is enabled.
-        # self.assertEqual(len(names), 2)
-        # self.assertIn("constant_2", names)
-        # self.assertIn("constant_3", names)
+
+        names_0 = module.get_constant_names(
+            unbound_constants_only=True, constant_folding_only=False
+        )
+        self.assertEqual(set(names_0), {"constant_0", "constant_2", "constant_4"})
+
+        names_1 = module.get_constant_names(
+            unbound_constants_only=False, constant_folding_only=False
+        )
+        self.assertEqual(
+            set(names_1),
+            {"constant_0", "constant_1", "constant_2", "constant_3", "constant_4"},
+        )
+
+        names_2 = module.get_constant_names(
+            unbound_constants_only=True, constant_folding_only=True
+        )
+        self.assertEqual(set(names_2), {"constant_2", "constant_4"})
+
+        names_3 = module.get_constant_names(
+            unbound_constants_only=False, constant_folding_only=True
+        )
+        self.assertEqual(set(names_3), {"constant_2", "constant_3", "constant_4"})
+
+        names_4 = module.get_constant_folding_input_names(unbound_constants_only=True)
+        self.assertEqual(set(names_4), {"constant_2", "constant_4"})
+
+        names_5 = module.get_constant_folding_input_names(unbound_constants_only=False)
+        self.assertEqual(set(names_5), {"constant_2", "constant_3", "constant_4"})
 
     def test_set_many_constants(self):
         target = detect_target()


### PR DESCRIPTION
Summary: We add a modifiable_constant in Tensor to make sure users don't accidentally modify constants that are generated by AIT internally.

Differential Revision: D43232224

