### PR TITLE
Match AITModule on ait inputs and fx inputs

### DIFF
--- a/fx2ait/fx2ait/ait_module.py
+++ b/fx2ait/fx2ait/ait_module.py
@@ -21,12 +21,24 @@ class AITModule(torch.nn.Module):
     def __init__(
         self,
         engine=None,
+        interp_result=None,
     ):
         super(AITModule, self).__init__()
         self.engine = engine
+        self.interp_result = interp_result
 
     def forward(self, *inputs):
-        outputs = self.engine.forward(inputs)
+        python_inputs = []
+        if self.interp_result:
+            inputs = list(inputs)
+            for name, inp in zip(self.interp_result.fx_input_names, inputs):
+                if name in self.interp_result.input_names:
+                    python_inputs.append(inp)
+            assert len(python_inputs) == len(self.interp_result.input_names)
+        else:
+            python_inputs = inputs
+
+        outputs = self.engine.forward(python_inputs)
         if len(outputs) == 1:
             return outputs[0]
         return tuple(outputs)
@@ -44,12 +56,12 @@ class AITModule(torch.nn.Module):
         self.engine.profile(inputs, filename, num_iters)
 
     @staticmethod
-    def create_ait_module_wrapper(engine, trace_ait_module, *inputs):
+    def create_ait_module_wrapper(engine, interp_result, trace_ait_module, *inputs):
         """
         Some use cases need to torch.jit.script a model with AITModules in
         it, but TorchScript does not support variadic inputs. We can get
         around this by scripting the AITModule with some sample inputs.
         This is turned in by passing allow_scripting=True.
         """
-        mod = AITModule(engine)
+        mod = AITModule(engine, interp_result)
         return torch.jit.trace(mod, inputs) if trace_ait_module else mod

--- a/fx2ait/fx2ait/ait_splitter.py
+++ b/fx2ait/fx2ait/ait_splitter.py
@@ -153,7 +153,8 @@ class AITSplitter(splitter_base._SplitterBase):
                 torch.float16,
                 torch.float,
                 1,  # num_runtimes
-            )
+            ),
+            interpreter_result,
         )
 
     # TODO add _find_culprit once minimizer completed

--- a/fx2ait/fx2ait/lower/lower.py
+++ b/fx2ait/fx2ait/lower/lower.py
@@ -131,6 +131,7 @@ def default_lower_pass(
                 _precision_to_torch_type(lower_settings.output_precision),
                 1,  # num_runtimes
             ),
+            interp_res,
             lower_settings.trace_ait_module,
             *input,
         )

--- a/fx2ait/fx2ait/tools/ait_minimizer.py
+++ b/fx2ait/fx2ait/tools/ait_minimizer.py
@@ -43,6 +43,7 @@ def lower_mod_default(
             torch.float16,
             1,  # num_runtimes
         ),
+        interpreter_result,
     )
     return res_mod
 

--- a/fx2ait/fx2ait/tools/common_aten2ait.py
+++ b/fx2ait/fx2ait/tools/common_aten2ait.py
@@ -150,7 +150,8 @@ class DispatchTestCase(TestCase):
                 torch.float16,
                 torch.float,
                 1,  #  num_runtimes
-            )
+            ),
+            interp_result,
         )
 
         # Inference run and results comparison
@@ -242,7 +243,8 @@ class DispatchTestCase(TestCase):
                 torch.float16,
                 torch.float,
                 1,  #  num_runtimes
-            )
+            ),
+            interp_result,
         )
 
         for inputs in inputs_list:
@@ -360,7 +362,8 @@ class DispatchTestCase(TestCase):
                     torch.float16,
                     torch.float,
                     1,  #  num_runtimes
-                )
+                ),
+                interp_result,
             )
             # Benchmark Pytorch Eager
             # warmup

--- a/fx2ait/fx2ait/tools/common_fx2ait.py
+++ b/fx2ait/fx2ait/tools/common_fx2ait.py
@@ -131,7 +131,8 @@ class AITTestCase(TestCase):
                         torch.float16,
                         torch.float,
                         1,  #  num_runtimes
-                    )
+                    ),
+                    interp_result,
                 )
             else:
                 ait_mod = AITModule(
@@ -142,7 +143,8 @@ class AITTestCase(TestCase):
                         torch.float16,
                         torch.float,
                         1,  #  num_runtimes
-                    )
+                    ),
+                    interp_result,
                 )
 
             ref_outputs = mod(*original_inputs)
@@ -233,7 +235,8 @@ class AITTestCase(TestCase):
                         torch.float16,
                         torch.float,
                         1,  #  num_runtimes
-                    )
+                    ),
+                    interp_result,
                 )
             else:
                 ait_mod = AITModule(
@@ -244,7 +247,8 @@ class AITTestCase(TestCase):
                         torch.float16,
                         torch.float,
                         1,  #  num_runtimes
-                    )
+                    ),
+                    interp_result,
                 )
 
             ref_outputs = mod(*original_inputs)
@@ -358,7 +362,8 @@ def benchmark_function(
                 torch.float16,
                 torch.float,
                 1,  #  num_runtimes
-            )
+            ),
+            interp_result,
         )
         # Benchmark Pytorch Eager
         # warmup


### PR DESCRIPTION
Summary:
Currently AITModule doesn't
check if python's input and AIT input matches, but directly give AIT the corresponding input.

This could cause us some trouble when AIT optimize the graph and eliminate some inputs.
e.g. https://www.internalfb.com/phabricator/paste/view/P619446970?lines=37
Here,  add_14 can be deduced at a very early stage and therefore the source of add_14: cat_37 actually isn't used in AIT graph anywhere!
Therefore, we would got complaint: User passed 6 inputs, but the model expects 5. This is actually because cat_37 is not longer needed in AIT's graph!

This diff put checker in AITinterpreter to insure eeach AIT input can find corresponding python's input.
It also change AITModule by checking both list of python/fx input and ait input, and find corresponding fx input for ait input.

Differential Revision: D43256832

