### PR TITLE
fix backend type for softmax

### DIFF
--- a/python/aitemplate/backend/cuda/softmax/softmax.cuh
+++ b/python/aitemplate/backend/cuda/softmax/softmax.cuh
@@ -120,24 +120,6 @@ __inline__ __device__ T blockReduceMax(T* val) {
   return (T)0.0f;
 }
 
-namespace detail {
-template <typename T>
-struct numeric_limits_helper {
-  __device__ __host__ static constexpr T lowest() {
-    return platform::numeric_limits<T>::lowest();
-  }
-};
-
-// Cutlass doesn't have `lowest` in their specialization for float,
-// so we define our own helper struct here.
-template <>
-struct numeric_limits_helper<float> {
-  __device__ __host__ static constexpr float lowest() {
-    return std::numeric_limits<float>::lowest();
-  }
-};
-} // namespace detail
-
 // input size: [M, K]
 // Currently the softmax kernel only supports 2D input with dim=1.
 // For input with more dimensions, reshape first.
@@ -185,7 +167,7 @@ __global__ void softmax_small_k(Arguments<T> args, size_t M) {
 
     CUTLASS_PRAGMA_UNROLL
     for (size_t i = 0; i < m; i++) {
-      T max = detail::numeric_limits_helper<T>::lowest();
+      T max = std::numeric_limits<T>::lowest();
       // find max
       CUTLASS_PRAGMA_UNROLL
       for (size_t j = 0; j < K; j++) {
@@ -232,7 +214,7 @@ __global__ void softmax_small_k(Arguments<T> args, size_t M) {
         input_tile[j] = input[i * K + j];
       }
 
-      T max = detail::numeric_limits_helper<T>::lowest();
+      T max = std::numeric_limits<T>::lowest();
       // find max
       CUTLASS_PRAGMA_UNROLL
       for (size_t j = 0; j < K; j++) {

--- a/python/aitemplate/backend/cuda/softmax/softmax.py
+++ b/python/aitemplate/backend/cuda/softmax/softmax.py
@@ -299,7 +299,7 @@ def softmax_gen_function(func_attrs: Dict[str, Any]) -> str:
     k = shapes[dim].value()
 
     backend_spec = CUDASpec()
-    elem_input_type = backend_spec.dtype_to_lib_type(
+    elem_input_type = backend_spec.dtype_to_backend_type(
         func_attrs["inputs"][0]._attrs["dtype"]
     )
     return FUNC_TEMPLATE.render(


### PR DESCRIPTION
Summary: use native type instead of cutlass

Differential Revision: D43294434

