### PR TITLE
Fix mixed-rank read_t in fused elementwise

### DIFF
--- a/python/aitemplate/backend/common/elementwise_common.py
+++ b/python/aitemplate/backend/common/elementwise_common.py
@@ -377,7 +377,7 @@ def _get_types_and_sizes(
                     input_shape, output_shape
                 )
             )
-        num_rightmost_non_broadcast_elements = len(input_shape)
+        num_rightmost_non_broadcast_elements = len(output_shape)
         extended_input_shape = list(input_shape)
         if input_shape == output_shape:
             input_broadcast_sizes.append(None)


### PR DESCRIPTION
Summary:
In the `fused_elementwise` backend (`elementwise_common.py`), `num_rightmost_non_broadcast_elements` in the function `_get_types_and_sizes` is initialized to `len(input_shape)`. If the `extended_input_shape` is longer than the `input_shape`, [these lines](https://github.com/facebookincubator/AITemplate/blob/main/python/aitemplate/backend/common/elementwise_common.py#L388-L390) decrements more than necessary:

```
            for i in reversed(range(len(extended_input_shape))):
                if extended_input_shape[i] != output_shape[i]:
                    num_rightmost_non_broadcast_elements -= i + 1
```

As a consequence, even when the last dim of an elementwise input with a lower rank than the output shape allows vectorization (i.e., using `uint4` as a `read_t`), it doesn't happen and the values are read / written to GMEM in `half`s. As `fused_elementwise` is I/O-bound, this may cause inefficiency.

Initializing `num_rightmost_non_broadcast_elements` to `len(output_shape)` resolves the issue, as in both the following `if` and `else` branches it is processed correctly.

Differential Revision: D43331365

