### PR TITLE
Hack on bmm dynamic shape

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -926,6 +926,25 @@ def acc_ops_flatten(
     return flatten(start_dim=start_dim, end_dim=end_dim)(input_val)
 
 
+def acc_ops_bmm(name: str, lhs: AITTensor, rhs: AITTensor) -> ConverterOutput:
+    lhs_shape = lhs.shape()
+    rhs_shape = rhs.shape()
+    if (
+        lhs_shape[0] == rhs_shape[0]
+        and lhs_shape[0]._attrs["name"] is None
+        and rhs_shape[0]._attrs["name"] is None
+    ):
+        lhs_shape[0]._attrs["name"] = f"acc_{name}_batch_size"
+        rhs_shape[0]._attrs["name"] = f"acc_{name}_batch_size"
+    elif lhs_shape[0] != rhs_shape[0]:
+        if lhs_shape[0]._attrs["values"] == rhs_shape[0]._attrs["values"]:
+            if lhs_shape[0]._attrs["name"] is None:
+                lhs_shape[0] = rhs_shape[0]
+            else:
+                rhs_shape[0] = lhs_shape[0]
+    return bmm_rrr()(lhs, rhs)
+
+
 @ait_converter(acc_ops.matmul)
 def acc_ops_matmul(
     target: Target,
@@ -952,30 +971,41 @@ def acc_ops_matmul(
     if len(rhs_shape) == 2:
         return gemm_rrr()(lhs, rhs)
     elif len(lhs_shape) <= 3 and len(rhs_shape) <= 3:
-        return bmm_rrr()(lhs, rhs)
+        return acc_ops_bmm(name, lhs, rhs)
     elif len(lhs_shape) == 4 and len(rhs_shape) == 4 and lhs_shape[1] == rhs_shape[1]:
-        assert all(isinstance(i, IntImm) for i in lhs_shape)
-        assert all(isinstance(i, IntImm) for i in rhs_shape)
+        assert all(isinstance(i, IntImm) for i in lhs_shape[1:])
+        assert all(isinstance(i, IntImm) for i in rhs_shape[1:])
         # Current AIT bmm only supports 3-dim. Use reshape to workaround.
-        reshape_op_0 = reshape()
-        batch_size = lhs_shape[0].value()
+        channel = lhs_shape[1].value()
         M = lhs_shape[2].value()
         K = lhs_shape[3].value()
-        channel = lhs_shape[1].value()
-        shape_0 = (batch_size * channel, M, K)
-        reshape_op_1 = reshape()
         N = rhs_shape[3].value()
         if K != rhs_shape[2].value():
             raise ValueError(
                 f"K dim mismatch on matmaul. Expected: [N, K] X [K, M]. Found: : [{M}, {K}] X [{rhs_shape[2].value()}, {N}]"
             )
-
-        shape_1 = (batch_size * channel, K, N)
-        reshape_op_2 = reshape()
-        shape_2 = (batch_size, channel, M, N)
-        return reshape_op_2(
-            bmm_rrr()(reshape_op_0(lhs, shape_0), reshape_op_1(rhs, shape_1)), shape_2
-        )
+        if isinstance(lhs_shape[0], IntImm) and (rhs_shape[0], IntImm):
+            batch_size = lhs_shape[0].value()
+            shape_0 = (batch_size * channel, M, K)
+            shape_1 = (batch_size * channel, K, N)
+            shape_2 = (batch_size, channel, M, N)
+        elif isinstance(lhs_shape[0], IntVar) and isinstance(rhs_shape[0], IntVar):
+            if lhs_shape[0]._attrs["values"] != rhs_shape[0]._attrs["values"]:
+                raise ValueError(
+                    f"Batch size mismatch on matmul. Expected: {lhs_shape[0]} == {rhs_shape[0]}"
+                )
+            lhs_size = size()(lhs)
+            new_size = getitem()(lhs_size, 0) * getitem()(lhs_size, 1)
+            shape_0 = (new_size, M, K)
+            shape_1 = (new_size, K, N)
+            shape_2 = (getitem()(lhs_size, 0), channel, M, N)
+        else:
+            raise NotImplementedError(
+                f"Expected all dimension except for the batch dim to be static. Got {lhs_shape} vs. {rhs_shape}"
+            )
+        reshape_op_0 = reshape()(lhs, shape_0)
+        reshape_op_1 = reshape()(rhs, shape_1)
+        return reshape()(acc_ops_bmm(name, reshape_op_0, reshape_op_1), shape_2)
     else:
         raise NotImplementedError(
             f"This case is unsupported in {name}: {len(lhs_shape)} and {len(rhs_shape)}"

--- a/fx2ait/fx2ait/test/converters/test_ait_matmul.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_matmul.py
@@ -14,6 +14,7 @@
 #
 import torch
 from fx2ait.acc_tracer import acc_ops
+from fx2ait.tensor_spec import TensorSpec
 from fx2ait.tools.common_fx2ait import AITTestCase
 
 from parameterized import parameterized
@@ -90,3 +91,43 @@ class TestMatMulConverter(AITTestCase):
             torch.randn(*rhs_shape).half().cuda(),
         ]
         self.run_test(model, inputs, expected_ops={acc_ops.matmul})
+
+    def test_reshape_bmm(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                x = torch.reshape(x, [-1, 3, 4])
+                y = torch.reshape(y, [-1, 4, 6])
+                return torch.bmm(x, y)
+
+        model = TestModule().cuda()
+        inputs_spec = TensorSpec.create_spec_from_shapes(
+            inputs_min=[[2, 3, 4], [2, 4, 6]],
+            inputs_max=[[20, 3, 4], [20, 4, 6]],
+            dtype_list=[
+                torch.float16,
+                torch.float16,
+            ],
+        )
+        self.run_test_with_dynamic_shape(
+            model, inputs_spec, expected_ops={acc_ops.matmul}
+        )
+
+    def test_reshape_4d_bmm(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                x = torch.reshape(x, [-1, 1, 3, 4])
+                y = torch.reshape(y, [-1, 1, 4, 6])
+                return torch.matmul(x, y)
+
+        model = TestModule().cuda()
+        inputs_spec = TensorSpec.create_spec_from_shapes(
+            inputs_min=[[2, 3, 4], [2, 4, 6]],
+            inputs_max=[[20, 3, 4], [20, 4, 6]],
+            dtype_list=[
+                torch.float16,
+                torch.float16,
+            ],
+        )
+        self.run_test_with_dynamic_shape(
+            model, inputs_spec, expected_ops={acc_ops.matmul}
+        )


### PR DESCRIPTION
Summary:
This is a hack on bmm's batch size; otherwise a lot of production model would be blocked.

AIT has a strict checker on batch size to be equal for bmm: https://fburl.com/code/xagsi9yq
It is fine if the model is written in AIT. However, the fx2ait lowered author would write something like
```
a1 = reshape(a0, [-1, M, K])
b1 = reshape(b0, [-1, K, N])
c0 = matmul(a1, b1)
```
Here first dimensions of both `a1` and `b1` are the same, i.e. batch_size, but AIT doesn't know that!
AIT will treat `a1.shape[0]` and `b1.shape[1]` as different symbols, name them differently, and at bmm, we got trouble.
A concrete example can be found at: https://fburl.com/phabricator/fkrwxz6c
which raises the issue: P618427861

The solution is to trust fx2ait converter. The rationale behind is models given to fx2ait converter has been successfully run by pytorch Eager mode, so users shouldn't be wrong at shape. Therefore, at fx2ait level, we directly unify the shape names.

========================================
side note:
Originally, I added runtime checker at bmm gen_function，but then I found it unnecessary, because if the names are the same, the emit shape name would also be the same, and the runtime checker would therefore, always pass.
e.g. A test P625543843 would generate model-generated.h: https://fburl.com/phabricator/dbx9of86, which simply checks `batch_size!=batch_size`.

But this is fine, because before we reach that line, P625543843 would raise runtime error P625545240, coming from model interface: https://fburl.com/code/rbm6jxwz
Therefore we are good.

========================================

**Notice all of these are just temporary fix and we are waiting on Mu-chu's proper fix on symbolic shape: D42295538

Differential Revision: D43176013

