### PR TITLE
Config the mem_align for the Attention kernel

### DIFF
--- a/fx2ait/fx2ait/converters/ait_module_converters.py
+++ b/fx2ait/fx2ait/converters/ait_module_converters.py
@@ -40,11 +40,6 @@ def multi_head_attention_module(
     value = kwargs["value"] if "value" in kwargs else args[2]
     bsz, seq_len_q, dim = query.shape()
     _, seq_len, _ = key.shape()
-    # TODO update check condition once AIT backend ease kAlignment check condition
-    if submod.num_heads % 8 != 0:
-        raise ValueError(
-            f"The number of heads for MHA module is not supported:{submod.num_heads}"
-        )
     attn = nn.CrossAttention(
         dim=submod.embed_dim,
         seq_len=seq_len_q.value(),

--- a/tests/unittest/ops/test_attention.py
+++ b/tests/unittest/ops/test_attention.py
@@ -574,11 +574,32 @@ class attentionTestCase(unittest.TestCase):
                 test_name=f"mem_eff_attention_fp16_{use_perm}_causal",
                 dtype="float16",
             )
+            self._test_mem_eff_attention(
+                batch_size=16,
+                nheads=4,
+                seqlen=8,
+                n=80,
+                use_perm=use_perm,
+                test_name="mem_eff_attention_fp16_nheads_20",
+                dtype="float16",
+            )
             # self._test_mem_eff_attention(batch_size=1, nheads=8, seqlen=8, n=64, use_perm=use_perm, test_name="mem_eff_attention1")
             # self._test_mem_eff_attention(batch_size=16, nheads=8, seqlen=8, n=512, use_perm=use_perm, test_name="mem_eff_attention2")
             # self._test_mem_eff_attention(batch_size=16, nheads=8, seqlen=8, n=1024, use_perm=use_perm, test_name="mem_eff_attention3")
             # self._test_mem_eff_attention(batch_size=16, nheads=8, seqlen=16, n=1024, use_perm=use_perm, test_name="mem_eff_attention4")
             # self._test_mem_eff_attention(batch_size=1, nheads=8, seqlen=16, n=64, use_perm=use_perm, test_name="mem_eff_attention5")
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    @unittest.expectedFailure
+    def test_mem_eff_attention_invalid_head_size_fp16(self):
+        self._test_mem_eff_attention(
+            batch_size=16,
+            nheads=8,
+            seqlen=8,
+            n=80,
+            test_name="mem_eff_attention_fp16_invalid_head_size",
+            dtype="float16",
+        )
 
     @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
     @unittest.skipIf(


### PR DESCRIPTION
Summary:
Let's not force the mem_align to be true for the attention kernel.
Instead, we set it to be true when the head_size meets the alignment
requirement and false otherwise. This change allows us to keep
the mem_align benefit while extending the kernel for more cases,
e.g. we just use the minimal alignment value for "ill-aligned"
head_size.

This change also replaced the simple return with a runtime exception
when the alignment check failed.

The temporary alignment check in fx2ait was removed since we
can ensure the kernel safety now.

Differential Revision: D43415811

