### PR TITLE
Reduce unittest runtime.

### DIFF
--- a/tests/unittest/ops/test_groupnorm.py
+++ b/tests/unittest/ops/test_groupnorm.py
@@ -120,14 +120,12 @@ class GroupnormTestCase(unittest.TestCase):
 
     def test_groupnorm_float16(self):
         self._test_groupnorm()
-        self._test_groupnorm(x_shape=[3, 3, 1, 4], num_groups=2, eps=1e-5)
         self._test_groupnorm(x_shape=[7, 13, 9, 12], num_groups=4, eps=1e-5)
         self._test_groupnorm(x_shape=[1, 16, 16, 8192], num_groups=32, eps=1e-3)
         self._test_groupnorm(x_shape=[3, 64, 64, 128], num_groups=16, eps=1e-5)
         self._test_groupnorm(x_shape=[3, 33, 64, 120], num_groups=10, eps=1e-5)
         self._test_groupnorm(x_shape=[8, 34, 10, 72], num_groups=6, eps=1e-5)
         self._test_groupnorm(x_shape=[1, 8, 1, 64], num_groups=32, eps=1e-5)
-        self._test_groupnorm(x_shape=[1, 8, 1, 4], num_groups=2, eps=1e-5)
         self._test_groupnorm(x_shape=[1, 8, 1, 4], num_groups=2, eps=1e-5, copy_op=True)
 
     def test_groupnorm_swish(self):
@@ -136,33 +134,39 @@ class GroupnormTestCase(unittest.TestCase):
             x_shape=[3, 3, 1, 4], num_groups=2, eps=1e-5, use_swish=True
         )
         self._test_groupnorm(
-            x_shape=[7, 13, 9, 12], num_groups=4, eps=1e-5, use_swish=True
+            x_shape=[7, 13, 9, 12], num_groups=4, eps=1e-5, use_swish=True, copy_op=True
+        )
+        self._test_groupnorm(
+            x_shape=[2, 8, 8, 1280], num_groups=32, eps=1e-5, use_swish=True
+        )
+        self._test_groupnorm(
+            x_shape=[2, 32, 32, 320], num_groups=32, eps=1e-5, use_swish=True
+        )
+        self._test_groupnorm(
+            x_shape=[1, 512, 512, 256], num_groups=32, eps=1e-5, use_swish=True
         )
 
-        shapes = [
-            (2, 16, 16, 1280),
-            (2, 16, 16, 1920),
-            (2, 16, 16, 2560),
-            (2, 16, 16, 640),
-            (2, 32, 32, 1280),
-            (2, 32, 32, 1920),
-            (2, 32, 32, 320),
-            (2, 32, 32, 640),
-            (2, 32, 32, 960),
-            (2, 64, 64, 320),
-            (2, 8, 8, 1280),
-            (2, 8, 8, 2560),
-            (2, 64, 64, 640),
-            (2, 64, 64, 960),
-            (1, 256, 256, 128),
-            (1, 512, 512, 256),
-        ]
-
-        for shape in shapes:
-            self._test_groupnorm(x_shape=shape, num_groups=32, eps=1e-5, use_swish=True)
-            self._test_groupnorm(
-                x_shape=shape, num_groups=32, eps=1e-5, use_swish=True, copy_op=True
-            )
+        # For benchmark only.
+        # shapes = [
+        #     (2, 16, 16, 1280),
+        #     (2, 16, 16, 1920),
+        #     (2, 16, 16, 2560),
+        #     (2, 16, 16, 640),
+        #     (2, 32, 32, 1280),
+        #     (2, 32, 32, 1920),
+        #     (2, 32, 32, 320),
+        #     (2, 32, 32, 640),
+        #     (2, 32, 32, 960),
+        #     (2, 64, 64, 320),
+        #     (2, 8, 8, 1280),
+        #     (2, 8, 8, 2560),
+        #     (2, 64, 64, 640),
+        #     (2, 64, 64, 960),
+        #     (1, 256, 256, 128),
+        #     (1, 512, 512, 256),
+        # ]
+        # for shape in shapes:
+        #     self._test_groupnorm(x_shape=shape, num_groups=32, eps=1e-5, use_swish=True)
 
     @unittest.skipIf(detect_target().name() == "rocm", "fp32 not supported in ROCm")
     def test_groupnorm_float32(self):


### PR DESCRIPTION
Summary: ATT, remove unnecessary unittests to reduce test runtime.

Reviewed By: chenyang78

Differential Revision: D43450380

