### PR TITLE
Time each make command

### DIFF
--- a/python/aitemplate/backend/builder.py
+++ b/python/aitemplate/backend/builder.py
@@ -53,6 +53,10 @@ def _augment_for_trace(cmd):
     ).format(cmd)
 
 
+def _time_cmd(cmd):
+    return f"exec time -f 'exit_status=%x elapsed_sec=%e argv=\"%C\"' {cmd}"
+
+
 def _log_error_context(
     stderr,
     build_dir,
@@ -328,6 +332,7 @@ class Builder(object):
             else:
                 cmd = cc_cmd.format(target=target, src=src)
 
+            cmd = _time_cmd(cmd)
             _LOGGER.debug(f"The cmd for building {target} is : {cmd}")
             self._runner.push(idx, cmd, target)
         self._runner.join()
@@ -356,6 +361,7 @@ class Builder(object):
             + compile_options
             + " -o {target} {objs}".format(target=target, objs=" ".join(objs))
         )
+        cmd = _time_cmd(cmd)
         _LOGGER.debug(f"The cmd for building {target} is {cmd}")
         self._runner.push(0, cmd, target)
         self._runner.join()
@@ -435,8 +441,12 @@ clean_constants:
             cfile_cmd = _augment_for_trace(cfile_cmd)
             bfile_cmd = _augment_for_trace(bfile_cmd)
             build_so_cmd = _augment_for_trace(build_so_cmd)
+        else:
+            cfile_cmd = _time_cmd(cfile_cmd)
+            bfile_cmd = _time_cmd(bfile_cmd)
+            build_so_cmd = _time_cmd(build_so_cmd)
 
-        build_exe_cmd = "$(CC) $(CFLAGS) -o $@ $(obj_files)"
+        build_exe_cmd = _time_cmd("$(CC) $(CFLAGS) -o $@ $(obj_files)")
         targets = f"{dll_name}"
 
         build_standalone_rules = ""
@@ -734,6 +744,8 @@ clean:
             )
             if self._do_trace:
                 cmd_line = _augment_for_trace(cmd_line)
+            else:
+                cmd_line = _time_cmd(cmd_line)
 
             command = f"{dep_line}\n\t{cmd_line}\n"
             commands.append(command)

--- a/tests/unittest/ops/test_groupnorm.py
+++ b/tests/unittest/ops/test_groupnorm.py
@@ -120,14 +120,12 @@ class GroupnormTestCase(unittest.TestCase):
 
     def test_groupnorm_float16(self):
         self._test_groupnorm()
-        self._test_groupnorm(x_shape=[3, 3, 1, 4], num_groups=2, eps=1e-5)
         self._test_groupnorm(x_shape=[7, 13, 9, 12], num_groups=4, eps=1e-5)
         self._test_groupnorm(x_shape=[1, 16, 16, 8192], num_groups=32, eps=1e-3)
         self._test_groupnorm(x_shape=[3, 64, 64, 128], num_groups=16, eps=1e-5)
         self._test_groupnorm(x_shape=[3, 33, 64, 120], num_groups=10, eps=1e-5)
         self._test_groupnorm(x_shape=[8, 34, 10, 72], num_groups=6, eps=1e-5)
         self._test_groupnorm(x_shape=[1, 8, 1, 64], num_groups=32, eps=1e-5)
-        self._test_groupnorm(x_shape=[1, 8, 1, 4], num_groups=2, eps=1e-5)
         self._test_groupnorm(x_shape=[1, 8, 1, 4], num_groups=2, eps=1e-5, copy_op=True)
 
     def test_groupnorm_swish(self):
@@ -136,33 +134,39 @@ class GroupnormTestCase(unittest.TestCase):
             x_shape=[3, 3, 1, 4], num_groups=2, eps=1e-5, use_swish=True
         )
         self._test_groupnorm(
-            x_shape=[7, 13, 9, 12], num_groups=4, eps=1e-5, use_swish=True
+            x_shape=[7, 13, 9, 12], num_groups=4, eps=1e-5, use_swish=True, copy_op=True
+        )
+        self._test_groupnorm(
+            x_shape=[2, 8, 8, 1280], num_groups=32, eps=1e-5, use_swish=True
+        )
+        self._test_groupnorm(
+            x_shape=[2, 32, 32, 320], num_groups=32, eps=1e-5, use_swish=True
+        )
+        self._test_groupnorm(
+            x_shape=[1, 512, 512, 256], num_groups=32, eps=1e-5, use_swish=True
         )
 
-        shapes = [
-            (2, 16, 16, 1280),
-            (2, 16, 16, 1920),
-            (2, 16, 16, 2560),
-            (2, 16, 16, 640),
-            (2, 32, 32, 1280),
-            (2, 32, 32, 1920),
-            (2, 32, 32, 320),
-            (2, 32, 32, 640),
-            (2, 32, 32, 960),
-            (2, 64, 64, 320),
-            (2, 8, 8, 1280),
-            (2, 8, 8, 2560),
-            (2, 64, 64, 640),
-            (2, 64, 64, 960),
-            (1, 256, 256, 128),
-            (1, 512, 512, 256),
-        ]
-
-        for shape in shapes:
-            self._test_groupnorm(x_shape=shape, num_groups=32, eps=1e-5, use_swish=True)
-            self._test_groupnorm(
-                x_shape=shape, num_groups=32, eps=1e-5, use_swish=True, copy_op=True
-            )
+        # For benchmark only.
+        # shapes = [
+        #     (2, 16, 16, 1280),
+        #     (2, 16, 16, 1920),
+        #     (2, 16, 16, 2560),
+        #     (2, 16, 16, 640),
+        #     (2, 32, 32, 1280),
+        #     (2, 32, 32, 1920),
+        #     (2, 32, 32, 320),
+        #     (2, 32, 32, 640),
+        #     (2, 32, 32, 960),
+        #     (2, 64, 64, 320),
+        #     (2, 8, 8, 1280),
+        #     (2, 8, 8, 2560),
+        #     (2, 64, 64, 640),
+        #     (2, 64, 64, 960),
+        #     (1, 256, 256, 128),
+        #     (1, 512, 512, 256),
+        # ]
+        # for shape in shapes:
+        #     self._test_groupnorm(x_shape=shape, num_groups=32, eps=1e-5, use_swish=True)
 
     @unittest.skipIf(detect_target().name() == "rocm", "fp32 not supported in ROCm")
     def test_groupnorm_float32(self):


### PR DESCRIPTION
Summary:
ATT, get detailed timing info for each nvcc / ld commandline.

Tested a simple case test_gemm_rcr_bias_add_float.
Most time is spent on compiling the profiler: 1m24s.
For .so compilation: 54.37s is spent on obj compilation. 0.18s is spent on linking. obj compilation is done by multiple threads in parallel so the actual compilation time is only 13s.

We could reduce profiler building time by separating compilation and linking stage, and parallelizing profiling compilation in multiple threads.

Differential Revision: D43451031

