### PR TITLE
make ProfilerMemoryPool work with low-memory cases

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/common_dual_gemm.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/common_dual_gemm.py
@@ -71,13 +71,15 @@ TENSOR_DECL_TEMPLATE = jinja2.Template(
 
   // The value 1 is used to force ptr_max_sz to be non-zero
   int64_t ptr_max_sz = std::max<int64_t>({1, a_ptr_sz, b0_ptr_sz, c_ptr_sz});
-  // TODO: special pool size for A100 L2 cache 40M
-  // need to tune it for other devices
-  int64_t mem_pool_sz = std::max(2,  std::min(64, int((1 << 25) / ptr_max_sz)));
+  size_t one_copy_sz = a_ptr_sz + b0_ptr_sz + c_ptr_sz;
+{% if has_bias %}
+  one_copy_sz += b1_ptr_sz;
+{%endif%}
+  int64_t mem_pool_sz = memory_pool->ComputeMemPoolSize(one_copy_sz, ptr_max_sz);
 
   memory_pool->AllocateTensor(a_ptr_sz, mem_pool_sz);  // a_ptr: index 0
   memory_pool->AllocateTensor(b0_ptr_sz, mem_pool_sz);  // b_ptr: index 1
-  memory_pool->AllocateTensor(c_ptr_sz, mem_pool_sz);  // c_ptr: index 2
+  memory_pool->AllocateTensor(c_ptr_sz, mem_pool_sz, /*is_output*/true);  // c_ptr: index 2
 
 {% if has_bias %}
   memory_pool->AllocateTensor(b1_ptr_sz, mem_pool_sz);  // b_ptr: index 3

--- a/python/aitemplate/backend/cuda/gemm_universal/bmm_common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/bmm_common.py
@@ -135,13 +135,18 @@ TENSOR_DECL_TEMPLATE = jinja2.Template(
 
   // The value 1 is used to force ptr_max_sz to be non-zero
   int64_t ptr_max_sz = std::max<int64_t>({1, a_ptr_sz, b_ptr_sz, c_ptr_sz});
-  // TODO: special pool size for A100 L2 cache 40M
-  // need to tune it for other devices
-  int64_t mem_pool_sz = std::max(2,  std::min(64, int((1 << 25) / ptr_max_sz)));
+  size_t one_copy_sz = a_ptr_sz + b_ptr_sz + c_ptr_sz;
+{% if has_bias %}
+  one_copy_sz += c_dim2;
+{%endif%}
+{% if has_d %}
+  one_copy_sz += c_ptr_sz;
+{%endif%}
+  int64_t mem_pool_sz = memory_pool->ComputeMemPoolSize(one_copy_sz, ptr_max_sz);
 
   memory_pool->AllocateTensor(a_ptr_sz, mem_pool_sz);  // a_ptr: index 0
   memory_pool->AllocateTensor(b_ptr_sz, mem_pool_sz);  // b_ptr: index 1
-  memory_pool->AllocateTensor(c_ptr_sz, mem_pool_sz);  // c_ptr: index 2
+  memory_pool->AllocateTensor(c_ptr_sz, mem_pool_sz, /*is_output*/true);  // c_ptr: index 2
 {% if has_bias %}
   memory_pool->AllocateTensor(c_dim2, mem_pool_sz);  // bias_ptr: index 3
 {% endif %}


### PR DESCRIPTION
Summary:
Previously, the minimal number of copies in a ProfilerMemoryPool
instance is 2. It does not work for edge cases where we are
under GPU memory pressure. For example, for some models with large
weights being loaded into the GPU global memory, there may be
a very small amount of memory left for the profiler memory pool.
For example, the free memory could only hold for a single copy
or even less.

This PR mitigate the issue by allocating a single shared blob
that is large enough to hold the largest input of the op
being profiled.

Differential Revision: D43490681

