### PR TITLE
Implement expand op

### DIFF
--- a/python/aitemplate/backend/backend_spec.py
+++ b/python/aitemplate/backend/backend_spec.py
@@ -57,6 +57,7 @@ class GPUBackendSpec(BackendSpec):
             "float32": "float",
             "float": "float",
             "int64": "int64_t",
+            "int32": "int32_t",
         }
     )
 

--- a/python/aitemplate/backend/cuda/tensor/expand.py
+++ b/python/aitemplate/backend/cuda/tensor/expand.py
@@ -13,19 +13,410 @@
 #  limitations under the License.
 #
 
-from ... import registry
+
+from typing import Any, Dict
+
+import jinja2
+from aitemplate.backend import registry
+
+from aitemplate.backend.backend_spec import CUDASpec
+from aitemplate.backend.cuda.tensor import expand_static_shape  # noqa: F401
+
+
+def _to_cuda_dtype(dtype):
+    dtype = CUDASpec().dtype_to_backend_dtype.get(dtype, None)
+    return dtype
 
 
 @registry.reg("cuda.expand.func_decl")
 def gen_function_decl(func_attrs):
-    raise NotImplementedError("Expand copying kernel is not implemented.")
+    if func_attrs["optimize_fixed_dims"] and func_attrs["non_head_dims_are_fixed"]:
+        func = registry.get("cuda.expand.static.func_decl")
+        return func(func_attrs)
+    x = func_attrs["inputs"][0]
+    func_name = func_attrs["name"]
+    index_type = _to_cuda_dtype(func_attrs.get("index_type", "int64"))
+    dt = x.dtype()
+    dtype = _to_cuda_dtype(dt)
+    assert (
+        dtype is not None
+    ), f"CUDA implementation does not support dtype {x.dtype()} (yet)"
+    return FUNC_DECL_TEMPLATE.render(
+        func_name=func_name,  # name of the function
+        dtype=dtype,  # data type of the input and output tensor elements ( valid CUDA C type like float ))
+        index_type=index_type,
+    )
+
+
+FUNC_DECL_TEMPLATE = jinja2.Template(
+    """
+void {{func_name}}(
+  const void* src,
+  const {{index_type}}* input_dims,
+  const {{index_type}} input_rank,
+  void* dst,
+  {{index_type}}* output_dims, // written to ( runtime shape inference )
+  const {{index_type}} output_rank,
+  const {{index_type}}* output_dim_types,
+  cudaStream_t stream);
+"""
+)
+
+SRC_TEMPLATE = jinja2.Template(
+    """
+#include <limits>
+#include <stdexcept>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include "logging.h"
+
+using bfloat16 = __nv_bfloat16;
+
+{% if index_type=="int64_t" %}
+#define DIM_TYPE_ADD 0l
+#define DIM_TYPE_EXPAND 1l
+#define DIM_TYPE_KEEP 2l
+
+#define MAX_THREADS_PER_BLOCK 1024l
+#define MAX_BLOCKS 65535l
+#define MAX_X_BLOCKS 2147483647l
+{% else %}
+#define DIM_TYPE_ADD 0
+#define DIM_TYPE_EXPAND 1
+#define DIM_TYPE_KEEP 2
+
+#define MAX_THREADS_PER_BLOCK 1024
+#define MAX_BLOCKS 65535
+#define MAX_X_BLOCKS 2147483647
+{% endif %}
+
+// integer ceil division
+#define INT_CEIL_DIV(a,b) (((a) + (b) - 1) / (b))
+
+/**
+ * Sequential write expand kernel for single block case.
+ *
+ * This kernel is optimized for small inputs, where we can load
+ * the entire  input into shared memory more or less at once
+ */
+__global__ void {{func_name}}_sequential_write_single_block_kernel(
+  // Implementation for small inputs where the entire src can be read into shared memory,
+  // and we have just one thread block
+  const {{dtype}}* src,
+  const {{index_type}} src_numel,
+  {{dtype}}* dst,
+  const {{index_type}} dst_numel
+  {% for i in range(output_rank) %}
+        ,const {{index_type}} output_strides_{{i}}
+        ,const {{index_type}} read_strides_{{i}}
+  {% endfor %}
+  ) {
+    // determine our range of elements to read
+    const {{index_type}} write_idx = threadIdx.x;
+    extern __shared__ {{dtype}} src_shared[]; // dynamic shared memory
+    if (write_idx<src_numel) {
+        src_shared[write_idx] = src[write_idx];
+    }
+    __syncthreads();
+    {{index_type}} read_idx = 0;
+    {{index_type}} remaining_idx = write_idx; // Used to calculate remainder
+    {% for i in range(output_rank) %}
+        read_idx += (remaining_idx / output_strides_{{i}}) * read_strides_{{i}};
+        remaining_idx %= output_strides_{{i}};
+    {% endfor %}
+    if (write_idx<dst_numel) {
+        dst[write_idx] = src_shared[read_idx];
+    }
+}
+
+/**
+ * Sequential write expand kernel with batched read/writes on trailing
+ * dimensions.
+ *
+ * This kernel is optimized for the case that trailing dimensions
+ * are kept between input and output, in which case we can do block-wise
+ * reads and writes.
+ */
+__global__ void {{func_name}}_sequential_write_batch_kernel(
+
+  const {{dtype}}* src,
+  {{dtype}}* dst,
+  const {{index_type}} dst_numel,
+  const {{index_type}} batch_size
+  {% for i in range(output_rank) %}
+        ,const {{index_type}} output_strides_{{i}}
+        ,const {{index_type}} read_strides_{{i}}
+  {% endfor %}
+  ) {
+    // determine our range of elements to read
+    const {{index_type}} write_idx = (blockDim.x * blockIdx.x + blockDim.y * blockIdx.y + blockDim.z * blockIdx.z + threadIdx.x) * batch_size;
+    {{index_type}} read_idx = 0;
+    {{index_type}} i = write_idx; // Used to calculate remainder
+    {% for i in range(output_rank) %}
+        read_idx += (i / output_strides_{{i}}) * read_strides_{{i}};
+        i %= output_strides_{{i}};
+    {% endfor %}
+    if (write_idx+batch_size-1<dst_numel) {
+        dst[write_idx] = src[read_idx];
+        for (i = 1; i < batch_size; i++) {
+            dst[write_idx+i] = src[read_idx+i];
+        }
+    }
+}
+
+/**
+ * Sequential write expand kernel.
+ * This kernel deals with the general case. It relies heavily on L2 cache
+ * for scattered read optimization and does sequential writes.
+ * This was benchmarked against an alternative implementation that tried
+ * to minimize overall memory accesses, doing sequential reads and scattered
+ * writes. But this implementation is faster.
+ */
+__global__ void {{func_name}}_sequential_write_kernel(
+
+  const {{dtype}}* src, // source tensor
+  {{dtype}}* dst, // destination tensor
+  const {{index_type}} dst_numel // number of elements in dst
+  {% for i in range(output_rank) %}
+        ,const {{index_type}} output_strides_{{i}} // Stride for writing dimension {{i}} to dst
+        ,const {{index_type}} read_strides_{{i}} // Stride for reading dimension {{i}} from src
+  {% endfor %}
+  ) {
+    // determine our range of elements to read
+    const {{index_type}} write_idx = blockDim.x * blockIdx.x + blockDim.y * blockIdx.y + blockDim.z * blockIdx.z + threadIdx.x;
+    {{index_type}} read_idx = 0;
+    {{index_type}} remaining_idx = write_idx; // Used to calculate remainder
+    {% for i in range(output_rank) %}
+        read_idx += (remaining_idx / output_strides_{{i}}) * read_strides_{{i}};
+        remaining_idx %= output_strides_{{i}};
+    {% endfor %}
+    if (write_idx<dst_numel) {
+        dst[write_idx] = src[read_idx];
+    }
+}
+
+/**
+ * Expand Operator entry point with support for dynamic shapes
+ */
+void {{func_name}} (
+  const void* src, // input tensor
+  const {{index_type}}* input_dims, // input dimensions ( passed by value )
+  const {{index_type}} input_rank,
+  void* dst, // output tensor
+  {{index_type}}* output_dims, // output dimensions ( passed by value )
+  const {{index_type}} output_rank,
+  const {{index_type}}* output_dim_types, // Output dim types ( length=output_rank ). 2 = keep dimension, 1 = expand dimension, 0 = add dimension
+  cudaStream_t stream)
+{
+  // Calculate number of input elements
+  {{index_type}} input_numel = 1;
+  {{index_type}} i;
+  for (i = 0; i < input_rank; ++i) {
+    input_numel *= input_dims[i];
+  }
+  {{index_type}} input_dim_pos = 0;
+
+  // Calculate number of output dimensions
+  {{index_type}} output_numel = 1;
+  for (i = 0; i < output_rank; ++i) {
+    output_numel *= output_dims[i];
+  }
+
+  // Determine stride for each input dimension
+  {{index_type}} input_strides[input_rank];
+  input_strides[input_rank-1] = 1;
+  for (i=input_rank-2;i>=0;--i) {
+    input_strides[i] = input_strides[i+1]*input_dims[i+1];
+  }
+  // Determine stride for each output dimension
+  {{index_type}} output_strides[output_rank];
+  output_strides[output_rank-1] = 1;
+  for (i=output_rank-2;i>=0;--i) {
+    output_strides[i] = output_strides[i+1]*(output_dims[i+1]);
+  }
+
+  // Determine read strides for each output dimension
+  // (0 for expand or add dims, otherwise the stride of
+  // of the corresponding input dim)
+  {{index_type}} read_strides[output_rank];
+
+  input_dim_pos = 0;
+  for (i = 0; i < output_rank; ++i) {
+    {{index_type}} dim_type =  output_dim_types[i];
+    if (dim_type == DIM_TYPE_KEEP ) { // keep
+      read_strides[i] = input_strides[input_dim_pos++];
+    } else {
+      read_strides[i] = 0;
+      if (dim_type==DIM_TYPE_EXPAND) {
+        input_dim_pos++;
+      }
+    }
+  }
+  assert(input_dim_pos==input_rank);
+
+  // Calculating tail dimension in order to determine whether we can do sequential batching
+  {{index_type}} tail_dim = 1;
+  for (i = output_rank-1; i >= 0; --i) {
+      if (output_dim_types[i]!=DIM_TYPE_KEEP) {
+         break;
+      }
+      tail_dim *= output_dims[i];
+  }
+
+  {{index_type}} batch_size = 1; // sequential batch len
+
+  if (output_numel>MAX_THREADS_PER_BLOCK) {
+    // If the input/output is so small that we can read it all into shared mem,
+    // sequential batching makes no sense
+    batch_size = 7; // Determined experimentally via benchmark.
+                    // Should be reevaluated after algorithmic changes.
+    for (;batch_size>1;--batch_size) {
+      if ((tail_dim % batch_size)==0) {
+          break;
+      }
+    }
+  }
+  assert ((output_numel % batch_size)==0);
+
+  // determine CUDA kernel grid layout
+  {{index_type}} output_batches = output_numel / batch_size;
+
+  {{index_type}} block_size = INT_CEIL_DIV(output_batches, MAX_THREADS_PER_BLOCK);
+  {{index_type}} thread_size_x = min(MAX_THREADS_PER_BLOCK, output_batches);
+
+  {{index_type}} block_size_x = block_size;
+  {{index_type}} block_size_y = 1;
+  {{index_type}} block_size_z = 1;
+
+  // for very large dimensions, we need to split into x,y,z grid blocks
+  if (block_size_x>MAX_X_BLOCKS) {
+      block_size_y = INT_CEIL_DIV(block_size_x, MAX_X_BLOCKS);
+      block_size_x = MAX_X_BLOCKS;
+      if (block_size_y > MAX_BLOCKS) {
+        block_size_z = INT_CEIL_DIV(block_size_y, MAX_BLOCKS);
+        block_size_y = MAX_BLOCKS;
+      }
+  }
+  dim3 dimGrid(block_size_x, block_size_y, block_size_z);
+  dim3 dimBlock(thread_size_x, 1, 1);
+  // Select the right kernel to call and call it
+  if (batch_size==1) {
+    if (block_size_x>1) {
+      {{func_name}}_sequential_write_kernel<<<dimGrid,dimBlock,0,stream>>>(
+          static_cast<const {{dtype}}*>(src),
+          static_cast<{{dtype}}*>(dst),
+          output_numel
+          {% for i in range(output_rank) %}
+            ,output_strides[{{i}}]
+            ,read_strides[{{i}}]
+          {% endfor %}
+      );
+    } else {
+      {{func_name}}_sequential_write_single_block_kernel<<<dimGrid,dimBlock,sizeof({{dtype}})*input_numel,stream>>>(
+          static_cast<const {{dtype}}*>(src),
+          input_numel,
+          static_cast<{{dtype}}*>(dst),
+          output_numel
+          {% for i in range(output_rank) %}
+            ,output_strides[{{i}}]
+            ,read_strides[{{i}}]
+          {% endfor %}
+      );
+    }
+  } else {  // batch_size>1, asserting (thread_size_x % batch_size)==0
+      {{func_name}}_sequential_write_batch_kernel<<<dimGrid,dimBlock,0,stream>>>(
+          static_cast<const {{dtype}}*>(src),
+          static_cast<{{dtype}}*>(dst),
+          output_numel,
+          batch_size
+          {% for i in range(output_rank) %}
+            ,output_strides[{{i}}]
+            ,read_strides[{{i}}]
+          {% endfor %}
+      );
+  }
+}
+"""
+)
+
+
+def create_template_args(func_attrs: Dict[str, Any], indent="  "):
+    x = func_attrs["inputs"][0]
+    y = func_attrs["outputs"][0]
+    dst = y._attrs["name"]
+    src = x._attrs["name"]
+    func_name = func_attrs["name"]
+    dtype = _to_cuda_dtype(x.dtype())
+    assert (
+        dtype is not None
+    ), f"CUDA implementation does not support dtype {x.dtype()} (yet)"
+
+    xshape = x._attrs["shape"]
+    yshape = y._attrs["shape"]
+    index_type = _to_cuda_dtype(func_attrs.get("index_type", "int64"))
+    assert index_type is not None
+
+    input_dims = ",".join(
+        [f"static_cast<{index_type}>(" + dim._attrs["name"] + ")" for dim in xshape]
+    )
+    output_dims = ",".join(
+        [f"static_cast<{index_type}>(" + dim._attrs["name"] + ")" for dim in yshape]
+    )
+    input_rank = len(xshape)
+    output_rank = len(yshape)
+    dim_types = ",".join([str(int(dt)) for dt in func_attrs["dim_types"]])
+    return {
+        "func_name": func_name,  # name of the function
+        "dst": dst,  # name of the output tensor (of type dtype*)
+        "src": src,  # name of the input tensor (of type dtype*)
+        "input_dims": input_dims,  # list of input dimensions (as string of comma-separated variable names )
+        "output_dims": output_dims,  # output dimensions (as string of comma-separated variable names)
+        "input_rank": input_rank,  # number of input dimensions
+        "output_rank": output_rank,  # number of output dimensions
+        "dim_types": dim_types,  # list of output dimension types: 2 = keep, 1 = expand, 0 = add
+        "dtype": dtype,  # data type of the input and output tensor elements ( valid CUDA C type like float ))
+        "indent": indent,  # indentation for the function call template,
+        "index_type": index_type,
+    }
 
 
 @registry.reg("cuda.expand.gen_function")
 def gen_function(func_attrs):
-    raise NotImplementedError("Expand copying kernel is not implemented.")
+    if not (
+        func_attrs["optimize_fixed_dims"] and func_attrs["non_head_dims_are_fixed"]
+    ):
+        return SRC_TEMPLATE.render(create_template_args(func_attrs, "    "))
+    else:
+        func = registry.get("cuda.expand.static.gen_function")
+        return func(func_attrs)
 
 
 @registry.reg("cuda.expand.func_call")
-def gen_function_call(func_attrs, indent="  "):
-    raise NotImplementedError("Expand copying kernel is not implemented.")
+def gen_function_call(func_attrs: Dict[str, Any], indent="  ") -> str:
+    if not (
+        func_attrs["optimize_fixed_dims"] and func_attrs["non_head_dims_are_fixed"]
+    ):
+        return FUNC_CALL_TEMPLATE.render(create_template_args(func_attrs, indent))
+    else:
+        func = registry.get("cuda.expand.static.func_call")
+        return func(func_attrs, indent)
+
+
+FUNC_CALL_TEMPLATE = jinja2.Template(
+    """
+    {
+    {{indent}}const {{index_type}} input_dims[] = { {{input_dims}} };
+    {{indent}}{{index_type}} output_dims[] = { {{output_dims}} };
+    {{indent}}const {{index_type}} output_dim_types[] = { {{dim_types}} };
+    {{indent}}{{func_name}}(
+    {{indent}}    {{src}},
+    {{indent}}    input_dims,
+    {{indent}}    {{input_rank}},
+    {{indent}}    {{dst}},
+    {{indent}}    output_dims,
+    {{indent}}    {{output_rank}},
+    {{indent}}    output_dim_types,
+    {{indent}}    stream);
+    }
+    """
+)

--- a/python/aitemplate/backend/cuda/tensor/expand_static_shape.py
+++ b/python/aitemplate/backend/cuda/tensor/expand_static_shape.py
@@ -1,0 +1,394 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import math
+import os
+from itertools import accumulate
+from operator import mul
+from typing import Any, Dict, List
+
+import jinja2
+
+from aitemplate.backend import registry
+
+from aitemplate.backend.backend_spec import CUDASpec
+from aitemplate.backend.target import Target
+from aitemplate.compiler.ops.tensor.expand import ExpandDimensionType
+
+"""
+Specialized and optimized CUDA kernel declarations for the `expand` operator
+dealing with the most common case that the input and target shapes are known at compile time,
+with the possible exception of leading dimensions.
+
+"""
+
+
+@registry.reg("cuda.expand.static.func_decl")
+def gen_function_decl(func_attrs):
+    return FUNC_DECL_TEMPLATE.render(create_template_args(func_attrs))
+
+
+FUNC_DECL_TEMPLATE = jinja2.Template(
+    """
+void {{func_name}} (
+  const {{dtype}}* const src, // input tensor
+  {{dtype}}* const dst, // output tensor
+  const {{index_type}} head_size, // how many times to repeat the first part of the tensor.
+  cudaStream_t stream);
+"""
+)
+
+SRC_TEMPLATE = jinja2.Template(
+    """
+#include <limits>
+#include <stdexcept>
+#include <cuda_pipeline.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include "logging.h"
+
+
+using bfloat16 = __nv_bfloat16;
+
+#define DIM_TYPE_ADD 0
+#define DIM_TYPE_EXPAND 1
+#define DIM_TYPE_KEEP 2
+
+#define MAX_THREADS_PER_BLOCK 1024l
+// integer ceil division
+#define INT_CEIL_DIV(a,b) (((a) + (b) - 1) / (b))
+
+{{custom_libs}}
+
+/**
+ * Get read base offset (e.g. excluding tail offset) in the middle part, given a write offset
+ * into the middle part
+ */
+__forceinline__ __device__ {{index_type}} {{func_name}}_get_read_offset(const {{index_type}} write_offset) {
+    {{index_type}} read_idx = 0;
+    {{index_type}} remaining_write_idx = write_offset; // assert < {{mid_size*tail_size}} ( i.e. < mid_size*tail_size)
+    {% for i in range(head_dim_count, head_dim_count+mid_dim_count-1) %}
+        {% if read_strides[i]!=0 %}
+    read_idx += (remaining_write_idx / {{output_strides[i]}}l) * {{read_strides[i]}}l;
+        {% endif %}
+        remaining_write_idx %= {{output_strides[i]}}l;
+    {% endfor %}
+    {% for i in range(head_dim_count+mid_dim_count-1, head_dim_count+mid_dim_count) %}
+        {% if read_strides[i]!=0 %}
+    read_idx += (remaining_write_idx / {{output_strides[i]}}l) * {{read_strides[i]}}l;
+        {% endif %}
+    {% endfor %}
+    return read_idx;
+}
+
+/**
+ *  Copies tail elements from a contiguous source memory region into a contiguous target memory region
+ *  Using a grid-stride loop and the vectorized dtype
+ *
+ * see https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/
+ */
+__forceinline__ __device__ void {{func_name}}_tail_copy(
+        const {{dtype}} * const src, // base src tensor memory pointer
+        const {{index_type}} read_offset, // base offset into src, via {{dtype}}-typed indexing
+        {{dtype}} * const dst,  // base destination tensor memory pointer
+        const {{index_type}} write_offset, // Base offset into dst via {{dtype}}-typed indexing
+        const {{index_type}} block_thread_index,
+        const {{index_type}} block_thread_count,
+        const {{index_type}} copy_numel
+    ) {
+    for ({{index_type}} i=block_thread_index;i<copy_numel;i+=block_thread_count) {
+        dst[write_offset+i] = src[read_offset+i];
+    }
+}
+
+
+/**
+ * Implement the "middle" part of the kernel, where we have to deal with non-contiguous reads/writes.
+ *
+ * Also utilizes grid-stride loop for efficiency and flexibility
+ * see  * see https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-stride-loops/
+ */
+__global__ void {{func_name}}_mid_kernel(
+
+  const {{dtype}}* const src, // source tensor
+  {{dtype}}* const dst // destination tensor
+  ) {
+    // determine our range of elements to read
+    const {{index_type}} write_offset = (blockDim.x * blockIdx.x + threadIdx.x) * {{tail_size}}l;
+    const {{index_type}} read_offset = {{func_name}}_get_read_offset(write_offset);
+    const {{index_type}} grid_size_x = gridDim.x*blockDim.x;
+    const {{index_type}} grid_size_y = gridDim.y*blockDim.y;
+    const {{index_type}} thread_idx_y = blockDim.y * blockIdx.y + threadIdx.y;
+    for ({{index_type}} i=write_offset;i<{{mid_size*tail_size}}l;i+=grid_size_x) {
+        {{func_name}}_tail_copy(src, read_offset, dst, write_offset, thread_idx_y, grid_size_y, {{tail_size}}l);
+    }
+
+}
+
+
+__global__ void {{func_name}}_mid_kernel2(
+
+  const {{dtype}}* const src, // source tensor
+  {{dtype}}* const dst // destination tensor
+  ) {
+    // determine our range of elements to read
+    const {{index_type}} write_offset = (blockDim.y * blockIdx.y + threadIdx.y) * {{tail_size}}l;
+    const {{index_type}} read_offset = {{func_name}}_get_read_offset(write_offset);
+    const {{index_type}} grid_size_x = gridDim.x*blockDim.x;
+    const {{index_type}} grid_size_y = gridDim.y*blockDim.y;
+    const {{index_type}} step_size_y = grid_size_y * {{tail_size}}l;
+    const {{index_type}} thread_idx_x = blockDim.x * blockIdx.x + threadIdx.x;
+    for ({{index_type}} i=write_offset;i<{{mid_size*tail_size}}l;i+=step_size_y) {
+        {{func_name}}_tail_copy(src, read_offset, dst, write_offset, thread_idx_x, grid_size_x, {{tail_size}}l);
+    }
+
+}
+
+/**
+ * Expand Operator entry point, optimized for static shapes. Only the head dimension may be dynamic.
+ */
+void {{func_name}} (
+  const {{dtype}}* const src, // input tensor
+  {{dtype}}* const dst, // output tensor
+  const {{index_type}} head_size, // how many times to repeat the first part of the tensor.
+  cudaStream_t stream)
+{
+  {% if mid_dim_count>0 %}
+  // we have middle dimensions which involve non-contiguous reads
+  // so we need to invoke the middle kernel
+  dim3 dimGrid({{mid_grid_blocks_x}}, {{mid_grid_blocks_y}});
+  dim3 dimBlock({{mid_grid_threads_x}}, {{mid_grid_threads_y}});
+  {{func_name}}_mid_kernel2<<<dimGrid,dimBlock,0,stream>>>(src, dst);
+  if (head_size>1l) {
+     // now repeat copy what we already built once, multiple times into the rest of the output tensor
+     cuda_repeat_head(dst, {{mid_size*tail_size}}l*sizeof({{dtype}}),head_size-1, stream);
+  }
+  {% else %}
+    // we have no middle dimensions, so all we need to do is repeatedly copy the source multiple times
+    // repeat the entire thing a dynamic number of times ( e.g. head_size times )
+    cuda_repeat_src(src, dst, {{mid_size*tail_size}}l*sizeof({{dtype}}), head_size, stream);
+  {% endif %}
+}
+"""
+)
+
+_dtype_sizes = {
+    "half": 2,
+    "bfloat16": 2,
+    "float32": 4,
+    "int64_t": 8,
+    "int32_t": 4,
+    "float": 4,
+}
+
+_size_dtypes = {
+    2: "half",
+    4: "float",
+    8: "int64_t",
+    16: "int4",
+}
+
+
+def _ceil(num):
+    return int(math.ceil(num))
+
+
+def create_template_args(func_attrs: Dict[str, Any], indent="  "):
+    x = func_attrs["inputs"][0]
+    y = func_attrs["outputs"][0]
+    dst = y._attrs["name"]
+    src = x._attrs["name"]
+    func_name = func_attrs["name"]
+    custom_libs = Target.current().get_custom_libs(
+        os.path.dirname(__file__), "repeat.cuh"
+    )
+    dtype = CUDASpec().dtype_to_backend_dtype[x.dtype()]
+    assert (
+        dtype is not None
+    ), f"CUDA implementation does not support dtype {x.dtype()} (yet)"
+    dtype2 = _size_dtypes.get(_dtype_sizes[dtype] * 2, None)
+    dtype4 = _size_dtypes.get(_dtype_sizes[dtype] * 4, None)
+    xshape = x._attrs["shape"]
+    yshape = y._attrs["shape"]
+    dim_types: List[ExpandDimensionType] = func_attrs["dim_types"]
+    index_type = "int64_t"
+    assert all(
+        dim.lower_bound() == dim.upper_bound() for dim in xshape
+    ), "All input shapes need to be fixed"
+    assert all(
+        dim.lower_bound() == dim.upper_bound() for dim in yshape
+    ), "All output shapes need to be fixed"
+
+    # Calculate number of times we can repeatedly copy the entire result, based on how many add, expand and singleton dimensions
+    # we have at the start
+    head_size_lower = 1  # Number of times we can batch-repeat the entire result in an efficient batch-copying manner
+    head_size_upper = 1
+    head_dim_count = 0  # Number of head dimensions
+
+    for dim_type, dim in zip(func_attrs["dim_types"], yshape):
+        if dim_type == ExpandDimensionType.KEEP_DIM and dim.lower_bound() != 1:
+            break
+        head_size_lower *= dim.lower_bound()
+        head_size_upper *= dim.upper_bound()
+        head_dim_count += 1
+
+    # Create a symbolic term for calculating head size ( e.g. repeat count )
+    if head_size_lower == head_size_upper:
+        head_size_symbolic = f"{head_size_upper}l"
+    else:
+        head_size_symbolic = "*".join(
+            [
+                f"static_cast<{index_type}>(" + dim._attrs["name"] + ")"
+                for dim in yshape[:head_dim_count]
+            ]
+        )
+
+    # Calculate number of tail elements, e.g. number of elements we can batch-copy in the inner loop
+    # via effective sequential reads & writes
+    tail_dim_count = 0  # number of tail dimensions
+    tail_size = 1  # Number of the elements in all these  tail dimensions
+    for dim_type, dim in reversed(
+        list(zip(dim_types[head_dim_count:], yshape[head_dim_count:]))
+    ):
+        if dim_type != ExpandDimensionType.KEEP_DIM and dim.lower_bound() != 1:
+            break
+        tail_dim_count += 1
+        tail_size *= dim.lower_bound()
+
+    input_strides = list(
+        reversed(
+            list(accumulate([1] + [d.lower_bound() for d in reversed(xshape)], mul))
+        )
+    )
+    output_strides = list(
+        reversed(
+            list(
+                accumulate(
+                    [1] + [d.lower_bound() for d in reversed(yshape[head_dim_count:])],
+                    mul,
+                )
+            )
+        )
+    )
+
+    output_numel = output_strides[
+        0
+    ]  # this does not include the number of elements obtained from head repetitions
+    # since we have excluded head dimensions above
+    input_numel = input_strides[0]
+
+    mid_size = output_numel // tail_size
+    mid_dim_count = len(yshape) - tail_dim_count - head_dim_count
+
+    mid_expansion_rate = mid_size * tail_size // input_numel
+
+    # remove the first dimension, which is the total number of elements
+    # and prepend the head_dims with stride 0
+    output_strides = [0] * head_dim_count + output_strides[1:]
+    input_strides = input_strides[1:]
+
+    input_stride_pos = 0
+    read_strides = [0] * len(yshape)
+    for i in range(len(yshape)):
+        if dim_types[i] == ExpandDimensionType.ADD_DIM:
+            continue
+        if dim_types[i] == ExpandDimensionType.KEEP_DIM:
+            read_strides[i] = input_strides[input_stride_pos]
+        # For keep dim, read stride remains at zero
+        input_stride_pos += 1
+
+    assert input_stride_pos == len(
+        xshape
+    ), "Incorrect number of keep and expand dims. Something went wrong."
+    output_rank = len(yshape)
+    dim_types = ",".join([str(int(dt)) for dt in func_attrs["dim_types"]])
+
+    # If tail size is aligned to 2 or 4 elements, we can vectorize reads/writes
+    # Note: Further vectorization not easily possible, given that it could happen that
+    # the read offset and the write offset can get different alignments within the expand op
+    #
+    if (tail_size % 4 == 0) and (dtype4 is not None):
+        dtype = dtype4
+        tail_size = tail_size // 4
+        output_strides = [s // 4 for s in output_strides]
+        read_strides = [s // 4 for s in read_strides]
+    elif tail_size % 2 == 0:
+        dtype = dtype2
+        tail_size = tail_size // 2
+        output_strides = [s // 2 for s in output_strides]
+        read_strides = [s // 2 for s in read_strides]
+
+    mid_grid_blocks_x = 1
+    mid_grid_threads_x = min(tail_size, 32)
+    mid_max_y_threads = 1024 // mid_grid_threads_x  # guaranteed to be >= 1
+    mid_grid_threads_y = min(
+        mid_max_y_threads, mid_size
+    )  # so that  mid_grid_threads_x*max_x_threads <= 1024
+    mid_grid_blocks_y = _ceil(mid_size / mid_grid_threads_y)
+
+    if dtype == "bfloat16":
+        # bfloat16 is not available in model-generated.h as a type,
+        # so we can either just declare the input to be void*
+        # or  just use the fact that we don't care about how to interpret the value
+        # and just treat it like every other 16 bit type.
+        dtype = "half"
+
+    return {
+        "func_name": func_name,  # name of the function
+        "dst": dst,  # name of the output tensor (of type dtype*)
+        "src": src,  # name of the input tensor (of type dtype*)
+        "output_strides": output_strides,  # list of output stride values
+        "read_strides": read_strides,  # list of read stride values
+        "tail_dim_count": tail_dim_count,  # number of tail dimensions
+        "tail_size": tail_size,  # number of elements in all these tail dimensions
+        "head_dim_count": head_dim_count,  # number of head dimensions
+        "head_size": head_size_symbolic,  # number of elements in all these head dimensions
+        "mid_dim_count": mid_dim_count,
+        "mid_size": mid_size,
+        "mid_expansion_rate": mid_expansion_rate,  # How many times do we read the input for the middle
+        "output_rank": output_rank,  # number of output dimensions
+        "dim_types": dim_types,  # list of output dimension types: 2 = keep, 1 = expand, 0 = add
+        "dtype": dtype,  # data type of the input and output tensor elements ( valid CUDA C type like float )
+        "indent": indent,  # indentation for the function call template,
+        "index_type": index_type,
+        "mid_grid_blocks_y": mid_grid_blocks_y,
+        "mid_grid_blocks_x": mid_grid_blocks_x,
+        "mid_grid_threads_y": mid_grid_threads_y,
+        "mid_grid_threads_x": mid_grid_threads_x,
+        "custom_libs": custom_libs,
+    }
+
+
+@registry.reg("cuda.expand.static.gen_function")
+def gen_function(func_attrs):
+    return SRC_TEMPLATE.render(create_template_args(func_attrs, "    "))
+
+
+@registry.reg("cuda.expand.static.func_call")
+def gen_function_call(func_attrs: Dict[str, Any], indent="  ") -> str:
+    return FUNC_CALL_TEMPLATE.render(create_template_args(func_attrs, indent))
+
+
+FUNC_CALL_TEMPLATE = jinja2.Template(
+    """
+    {
+    {{indent}}{{func_name}}(
+    {{indent}}    static_cast<{{dtype}}*>({{src}}),
+    {{indent}}    static_cast<{{dtype}}*>({{dst}}),
+    {{indent}}    {{head_size}},
+    {{indent}}    stream);
+    }
+    """
+)

--- a/python/aitemplate/backend/cuda/tensor/repeat.cuh
+++ b/python/aitemplate/backend/cuda/tensor/repeat.cuh
@@ -1,0 +1,161 @@
+/*
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+Functions for repeating parts of a CUDA source tensor onto itself
+or into a target tensor.
+
+Used by expand_static_shape.py ( expand operator )
+
+*/
+
+#define INT_CEIL_DIV(a, b) (((a) + (b)-1) / (b))
+#define SHM_MAX 1024 * 44
+
+__global__ void repeat_head_kernel(
+    const int64_t* const src,
+    int64_t* data,
+    size_t head_mem_num_elements,
+    size_t num_repeat_copies) {
+  extern __shared__ int64_t shared[];
+  const size_t stride_y = blockDim.y * gridDim.y;
+  const size_t stride_x = blockDim.x * gridDim.x;
+
+  // outer grid-stride loop
+  for (size_t ri = blockDim.x * blockIdx.x + threadIdx.x;
+       ri < head_mem_num_elements;
+       ri += stride_x) {
+    // read only with one thread per y dim
+    if (threadIdx.y == 0) {
+      // in y direction: thread 0 reads, all threads write
+      // repeatedly direct async copy from global to shared memory, see
+      // https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/#optimizing-cuda-applications
+      // and
+      // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#memcpy-async-primitiv
+      __pipeline_memcpy_async(&shared[threadIdx.x], &src[ri], sizeof(int64_t));
+      __pipeline_commit();
+      __pipeline_wait_prior(0);
+    }
+    __syncthreads(); // wait for shared memory to be populated
+    // inner grid-stride loop, write with all threads out of shared memory
+    size_t wi = threadIdx.y + blockDim.y * blockIdx.y;
+    for (; wi < num_repeat_copies; wi += stride_y) {
+      data[ri + head_mem_num_elements * wi] = shared[threadIdx.x];
+    }
+  }
+}
+
+__host__ cudaError_t cuda_repeat_head_vectorized(
+    const int64_t* const src,
+    int64_t* data,
+    size_t head_mem_num_elements,
+    size_t num_repeat_copies,
+    cudaStream_t stream) {
+  size_t threads_x = 32;
+  size_t threads_y = 1024 / threads_x;
+  size_t blocks_x = INT_CEIL_DIV(head_mem_num_elements, threads_x);
+  size_t blocks_y = INT_CEIL_DIV(num_repeat_copies, threads_y);
+  size_t serialization_level =
+      INT_CEIL_DIV(threads_x * sizeof(int64_t) * blocks_x * blocks_y, SHM_MAX);
+  // reduce number of blocks if necessary, so we do not exceed available shared
+  // memory
+  blocks_y = INT_CEIL_DIV(
+      blocks_y, serialization_level); // reduce thread count in y dimension
+                                      // first, e.g. sequentialized writes
+  serialization_level =
+      INT_CEIL_DIV(threads_x * sizeof(int64_t) * blocks_x * blocks_y, SHM_MAX);
+  // reduce number of blocks in x direction if this is not sufficient yet
+  blocks_x = INT_CEIL_DIV(blocks_x, serialization_level);
+  dim3 dimGrid(blocks_x, blocks_y);
+  dim3 dimBlock(threads_x, threads_y);
+  repeat_head_kernel<<<
+      dimGrid,
+      dimBlock,
+      threads_x * sizeof(int64_t),
+      stream>>>(src, data, head_mem_num_elements, num_repeat_copies);
+  return cudaPeekAtLastError();
+}
+
+__host__ cudaError_t cuda_repeat_head(
+    void* data,
+    const size_t head_mem_bytes,
+    size_t num_repeat_copies,
+    cudaStream_t stream) {
+  cudaError_t res = cudaSuccess;
+  if (num_repeat_copies == 0)
+    return res;
+  if ((head_mem_bytes % 8) == 0) {
+    // no need to double memory any further if it is 64-bit aligned
+    res = cuda_repeat_head_vectorized(
+        static_cast<const int64_t* const>(data),
+        static_cast<int64_t*>(data) + (head_mem_bytes / 8),
+        head_mem_bytes / 8,
+        num_repeat_copies,
+        stream);
+    if (res != cudaSuccess) {
+      return res;
+    }
+  } else {
+    res = cudaMemcpyAsync(
+        static_cast<void*>(static_cast<uint8_t*>(data) + head_mem_bytes),
+        data,
+        head_mem_bytes,
+        cudaMemcpyDeviceToDevice,
+        stream);
+    if (res != cudaSuccess) {
+      return res;
+    }
+    if (num_repeat_copies >= 2) {
+      // recurse
+      // we have already repeated 1 time, therefore the (num_repeat_copies-1)
+      res = cuda_repeat_head(
+          data, head_mem_bytes * 2, (num_repeat_copies - 1) / 2, stream);
+      if (res != cudaSuccess) {
+        return res;
+      }
+      // deal with possible remainder
+      if (((num_repeat_copies - 1) % 2) == 1) {
+        res = cudaMemcpyAsync(
+            static_cast<void*>(
+                static_cast<uint8_t*>(data) +
+                num_repeat_copies * head_mem_bytes),
+            data,
+            head_mem_bytes,
+            cudaMemcpyDeviceToDevice,
+            stream);
+      }
+    }
+  }
+  return res;
+}
+
+__host__ cudaError_t cuda_repeat_src(
+    const void* const src,
+    void* data,
+    const size_t head_mem_bytes,
+    size_t num_repeat_copies,
+    cudaStream_t stream) {
+  cudaError_t res = cudaSuccess;
+  if (num_repeat_copies == 0) {
+    return res;
+  }
+
+  res = cudaMemcpyAsync(
+      data, src, head_mem_bytes, cudaMemcpyDeviceToDevice, stream);
+  if ((res != cudaSuccess) || (num_repeat_copies == 1)) {
+    return res;
+  }
+  return cuda_repeat_head(data, head_mem_bytes, num_repeat_copies - 1, stream);
+}

--- a/python/aitemplate/compiler/ops/tensor/expand.py
+++ b/python/aitemplate/compiler/ops/tensor/expand.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+from enum import IntEnum
 from typing import List, Union
 
 from aitemplate.backend import registry
@@ -35,6 +36,12 @@ def _dim_has_value(dim: IntVar, value: int) -> bool:
     return isinstance(dim, IntImm) and dim.value() == value
 
 
+class ExpandDimensionType(IntEnum):
+    ADD_DIM = 0
+    EXPAND_DIM = 1
+    KEEP_DIM = 2
+
+
 class expand(Operator):
     """
     Expands a tensor's singleton dimensions.
@@ -44,12 +51,17 @@ class expand(Operator):
     The output shape may be dynamic.
 
     The other dimensions in the input must match the input shape exactly,
-    or be set to -1.
+    or be set to -1, in which case the output shape is unchanged for that dimension.
+
+    Tensor can be also expanded to a larger number of dimensions, and the new ones will
+    be appended at the front. For the new dimensions, the size cannot be set to -1.
 
     Args:
         input (Tensor) : the source tensor
-        dim (List[Union[IntImm, IntVar, int]]) : the target dim
-
+        shape (List[Union[IntImm, IntVar, int]]) : target shape ( dimensions with size -1 will be kept, excess dimensions are added at the front )
+        index_type (str): Native type used for indices, may be "int64" (default) or "int32".
+                          Pick "int32" only if the total number of elements is lower than 2^31
+        optimize_fixed_dims (bool) : if True, and if the conditions are given, allow to apply optimizatins assuming mostly fixed shapes.
     Returns:
         Tensor : the destination tensor
 
@@ -75,55 +87,92 @@ class expand(Operator):
     def _should_reuse_input_dim(dim_tensor: IntVar, dim_arg: IntVar) -> bool:
         return _dim_has_value(dim_arg, -1) or dim_tensor == dim_arg
 
-    def _infer_shape(self, tensor: Tensor, shape: List[IntVar]) -> List[IntVar]:
+    def _infer_shape(self, tensor: Tensor, target_shape: List[IntVar]) -> List[IntVar]:
         output_shape = []
         input_shape = tensor._attrs["shape"]
+        assert len(input_shape) > 0, "Input tensor must have a shape of length > 0"
+        for i, dim in enumerate(input_shape):
+            if dim.lower_bound() <= 0:
+                raise ValueError(
+                    f"Dimension {i} of expand input tensor shape has range [{dim.lower_bound()}:{dim.upper_bound()}], which includes zero or negative values."
+                )
+        for i, dim in enumerate(target_shape):
+            if dim.lower_bound() <= 0 and dim.lower_bound() != -1:
+                raise ValueError(
+                    f"Dimension {i} of expand target shape has range [{dim.lower_bound()}:{dim.upper_bound()}], which includes zero or negative values."
+                )
 
-        if len(shape) != len(input_shape):
+        if len(target_shape) < len(input_shape):
             raise ValueError(
-                f"Input shape ndim ({len(shape)}) must match tensor's ndim ({len(input_shape)})"
+                f"Target shape length ({len(target_shape)}) must be greater or equal to input tensor's shape length ({len(input_shape)})"
             )
-
-        for i, dim_tensor in enumerate(input_shape):
-            dim_arg = shape[i]
+        add_ndims = len(target_shape) - len(input_shape)
+        for i, dim_to_add in enumerate(target_shape[:add_ndims]):
+            if dim_to_add.lower_bound() <= 0:
+                raise ValueError(
+                    f"Output shape dimension {i} to be added has value range [{dim_to_add.lower_bound()}:{dim_to_add.upper_bound()}], but violates constraint that it must be greater or equal to 1."
+                )
+            output_shape.append(dim_to_add)
+        self._attrs["dim_types"] = [
+            ExpandDimensionType.ADD_DIM
+        ] * add_ndims  # 0 meaning, dimension is added
+        for i, dim_input in enumerate(input_shape):
+            dim_target = target_shape[i + add_ndims]
 
             # Convert IntVars with the same upper and lower bounds to IntImm's.
             # This lets us tell that expanding IntImm(1) into IntVar([1, 1]) is
             # actually a no-op.
-            dim_tensor = _normalize_dim(dim_tensor)
-            dim_arg = _normalize_dim(dim_arg)
+            dim_input = _normalize_dim(dim_input)
+            dim_target = _normalize_dim(dim_target)
 
-            if self._should_reuse_input_dim(dim_tensor, dim_arg):
+            if self._should_reuse_input_dim(dim_input, dim_target):
                 output_shape.append(
-                    gen_int_var(
-                        dim_tensor._attrs["values"], name=dim_tensor._attrs["name"]
-                    )
-                )
-            elif _dim_has_value(dim_tensor, 1):
-                if self._attrs["expand_dim"] is not None:
-                    raise NotImplementedError(
-                        f"Expand only supports expanding one dim. Tried to expand dim {i}, but already expanded dim {self._attrs['expand_dim']}."
-                    )
-                self._attrs["expand_dim"] = i
-                output_shape.append(
-                    gen_int_var(dim_arg._attrs["values"], name=dim_arg._attrs["name"])
-                )
+                    dim_input
+                )  # no deepcopy, dim symbol should be identical
+                self._attrs["dim_types"].append(
+                    ExpandDimensionType.KEEP_DIM
+                )  # 2 meaning, dimension is kept as is
+            elif _dim_has_value(dim_input, 1):
+                output_shape.append(dim_target)
+                self._attrs["dim_types"].append(
+                    ExpandDimensionType.EXPAND_DIM
+                )  # 1 meaning, dimension is expanded
             else:
                 raise ValueError(
-                    f"Tried to expand non-singleton dimension {i}. Input tensor dim: {dim_tensor}, target shape dim: {dim_arg}"
+                    f"Tried to expand non-singleton dimension {i}. Input tensor dim: {dim_input}, target shape dim: {dim_target}"
                 )
-
+        head_dim_count = 0
+        head_size = 1
+        for dim_type, dim in zip(self._attrs["dim_types"], output_shape):
+            if dim_type == ExpandDimensionType.KEEP_DIM and dim.lower_bound() != 1:
+                break
+            head_size *= dim.lower_bound()
+            head_dim_count += 1
+        self._attrs["head_dim_count"] = head_dim_count
+        self._attrs["head_size"] = head_size
+        self._attrs["non_head_dims_are_fixed"] = all(
+            dim.lower_bound() == dim.upper_bound() for dim in output_shape[add_ndims:]
+        )
         return output_shape
 
     def __call__(
-        self, tensor: Tensor, shape: List[Union[int, IntVar, IntVarTensor]]
+        self,
+        tensor: Tensor,
+        shape: List[Union[int, IntVar, IntVarTensor]],
+        index_type="int64",
+        optimize_fixed_dims=True,
     ) -> Tensor:
         self._attrs["inputs"] = [tensor]
+        self._attrs["index_type"] = index_type
+        self._attrs["optimize_fixed_dims"] = optimize_fixed_dims
         for dim in shape:
             if isinstance(dim, IntVarTensor):
                 self._attrs["inputs"].append(dim)
         shape = convert_shape_to_IntVar(shape)
+        if index_type not in ["int64", "int32"]:
+            raise ValueError("index_type for expand op has to be int64_t or int32_t")
         self._set_depth()
+
         output_shape = self._infer_shape(tensor, shape)
         output = Tensor(output_shape, src_ops={self}, dtype=tensor._attrs["dtype"])
         self._attrs["outputs"] = [output]

--- a/python/aitemplate/compiler/transform/remove_no_ops.py
+++ b/python/aitemplate/compiler/transform/remove_no_ops.py
@@ -31,14 +31,13 @@ call the passes in this file more than once.
 """
 from typing import List
 
-from aitemplate.compiler.base import IntVar, Operator
+from aitemplate.compiler.base import IntVar, Operator, Tensor
+from aitemplate.compiler.ops.tensor.expand import ExpandDimensionType
 
 from aitemplate.compiler.transform import transform_utils
 
 from aitemplate.utils import graph_utils
 from aitemplate.utils.shape_utils import is_singleton_dimension
-
-from ..base import Tensor
 
 
 def _remove_no_op_expands(sorted_graph: List[Tensor]) -> List[Tensor]:
@@ -56,9 +55,6 @@ def _remove_no_op_expands(sorted_graph: List[Tensor]) -> List[Tensor]:
         if op._attrs["op"] != "expand":
             continue
 
-        if op._attrs["expand_dim"] is not None:
-            continue
-
         outputs = op._attrs["outputs"]
         assert len(outputs) == 1, "expand must only have 1 output"
         expand_output = outputs[0]
@@ -69,6 +65,14 @@ def _remove_no_op_expands(sorted_graph: List[Tensor]) -> List[Tensor]:
         inputs = op._attrs["inputs"]
         assert len(inputs) >= 1, "expand must have at least 1 input"
         expand_input = inputs[0]
+
+        assert len(op._attrs["dim_types"]) == len(
+            expand_output._attrs["shape"]
+        ), "expand must have dim_type for every output dimension"
+
+        # If we just keep every dimension as-is, it is a no-op
+        if any(dt != ExpandDimensionType.KEEP_DIM for dt in op._attrs["dim_types"]):
+            continue
 
         # This expand is a no-op, so we know that these shapes should
         # be the same. However, the shape inference system may not be aware

--- a/tests/unittest/compiler/test_fuse_expand.py
+++ b/tests/unittest/compiler/test_fuse_expand.py
@@ -55,7 +55,6 @@ class TestFuseExpand(unittest.TestCase):
 
                 z_ait = torch.empty_like(z_pt)
                 mod.run_with_tensors({"x": x_pt, "y": y_pt}, {"z": z_ait})
-
                 self.assertTrue(torch.equal(z_ait, z_pt))
 
 

--- a/tests/unittest/ops/test_expand.py
+++ b/tests/unittest/ops/test_expand.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import math
+import sys
 import unittest
 
 import torch
@@ -21,6 +23,7 @@ from aitemplate.compiler.base import IntVar, Tensor
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor, graph_has_op
+from parameterized import param, parameterized
 
 
 @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
@@ -161,6 +164,252 @@ class ExpandTestCase(unittest.TestCase):
         self._test_no_op_expands_removed_size_op(
             test_name="no_op_expands_removed_size_op_fp32",
             dtype="float32",
+        )
+
+    @parameterized.expand(
+        [
+            param("fp32_small_noadd_1", "float32", [10, 1, 5], [-1, 10, 5]),
+            param("fp32_small_noadd_2", "float32", [10, 1, 8], [-1, 10, 8]),
+            param("fp32_small_noadd_3", "float32", [10, 1, 2], [-1, 10, 2]),
+            param("fp32_small_noadd_4", "float32", [10, 1, 5], [10, 10, 5]),
+            param("fp32_small_1", "float32", [10, 1, 5], [3, 10, 10, 5]),
+            param("fp32_small_2", "float32", [3, 1, 5], [3, 3, 3, -1]),
+            param("fp32_small_3", "float32", [2, 1, 4, 1, 6], [-1, 10, 4, 5, 6]),
+            param("fp32_small_var_1", "float32", [10, 1, 5], [3, 10, 10, 5], False),
+            param("fp32_small_var_2", "float32", [1, 1, 5], [3, 3, 10, -1], False),
+            param(
+                "fp32_small_var_3", "float32", [2, 1, 4, 1, 6], [-1, 10, 4, 5, 6], False
+            ),
+            param("float16_small_1", "float16", [2, 3, 1, 5], [2, -1, 3, 10, 5]),
+            param("float16_small_2", "float16", [1, 2, 10], [10, 2, 10]),
+            param("bfloat16_small_1", "bfloat16", [2, 3, 1, 5], [2, -1, 3, 10, 5]),
+            param("int64_small_1", "int64", [2, 3, 1, 5], [2, -1, 3, 10, 5]),
+            param(
+                "fp32_large_1",
+                "float32",
+                [100, 1, 9, 3],
+                [2, 20, -1, 100, 9, -1],
+                "int32",
+            ),
+            param(
+                "fp32_large_2",
+                "float32",
+                [101, 1, 91, 3],
+                [-1, 100, 91, -1],
+                "int64",
+            ),
+            param(
+                "fp32_large_3",
+                "float32",
+                [100, 1, 9, 3],
+                [2, 20, -1, 100, 9, -1],
+                "int64",
+            ),
+            # Largest tests commented out, as these lead to GPU OOM failures on Github CircleCI Hardware
+            # param(
+            #    "fp32_large_4",
+            #    "float32",
+            #    [100, 1, 91, 3],
+            #    [2, 20, -1, 100, 91, -1],
+            #    "int64",
+            # ),
+            # param(
+            #     "fp32_large_5",
+            #     "float32",
+            #     [101, 1, 91, 7],
+            #     [3, 21, -1, 103, 91, -1],
+            #     "int64",
+            # ),
+            # param(
+            #     "fp32_large_repeat",
+            #     "float32",
+            #     [101, 1, 91, 8],
+            #     [1000, -1, -1, -1, -1],
+            #     "int64",
+            # ),
+            # param(
+            #     "fp32_large_var_2",
+            #     "float32",
+            #     [100, 1, 9, 3],
+            #     [2, 20, -1, 100, 9, -1],
+            #     False,
+            #     "int64",
+            # ),
+            # param(
+            #     "benchmark_1",
+            #     "float32",
+            #     [100, 1, 9, 4],
+            #     [20, 20, 100, 100, 9, -1],
+            #     True,
+            #     "int64",
+            # ),
+            # param(
+            #     "benchmark_2",
+            #     "int64",
+            #     [100, 1, 9, 4],
+            #     [20, 20, 100, 100, 9, -1],
+            #     True,
+            #     "int64",
+            # ),
+            # param(
+            #     "benchmark_3",
+            #     "float16",
+            #     [100, 1, 9, 4],
+            #     [20, 20, 100, 100, 9, -1],
+            #     True,
+            #     "int64",
+            # ),
+            # param(
+            #     "benchmark_var_1",
+            #     "float32",
+            #     [100, 1, 9, 4],
+            #     [20, 20, 100, 100, 9, -1],
+            #     False,
+            #     "int64",
+            # ),
+            # param(
+            #     "benchmark_var_2",
+            #     "int64",
+            #     [100, 1, 9, 4],
+            #     [20, 20, 100, 100, 9, -1],
+            #     False,
+            #     "int64",
+            # ),
+            # param(
+            #     "benchmark_var_3",
+            #     "float16",
+            #     [100, 1, 9, 4],
+            #     [20, 20, 100, 100, 9, -1],
+            #     False,
+            #     "int64",
+            # ),
+            param("fp32_m_1", "float32", [5, 1, 3, 2], [2, 2, -1, 5, 3, -1]),
+            param("fp32_m_2", "float32", [5, 1, 3, 5], [2, 2, -1, 5, 3, -1]),
+            param("edge_case_shapes_1", "float32", [1, 1, 1, 1], [1, 1, -1, 1, -1, 1]),
+            param("edge_case_shapes_2", "float32", [1], [-1]),
+            param("edge_case_shapes_3", "float32", [3], [-1]),
+            param("edge_case_shapes_4", "float32", [1], [1]),
+            param(
+                "edge_case_shapes_var_1",
+                "float32",
+                [1, 1, 1, 1],
+                [1, 1, -1, 1, -1, 1],
+                False,
+            ),
+            param("edge_case_shapes_var_2", "float32", [1], [-1], False),
+            param("edge_case_shapes_var_3", "float32", [3], [-1], False),
+            param("edge_case_shapes_var_4", "float32", [1], [1], False),
+        ]
+    )
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_expand_op(
+        self,
+        name,
+        dtype,
+        src_shape,
+        expand_shape,
+        optimize_fixed_dims=True,
+        index_type="int64",
+    ):
+        x = Tensor(
+            src_shape,
+            name="X",
+            is_input=True,
+            dtype=dtype,
+        )
+        y = ops.expand()(
+            x,
+            expand_shape,
+            optimize_fixed_dims=optimize_fixed_dims,
+            index_type=index_type,
+        )
+        y._attrs["is_output"] = True
+        y._attrs["name"] = "Y"
+        if dtype != "int64":
+            x_pt = get_random_torch_tensor(src_shape, dtype=dtype)
+        else:
+            x_pt = torch.arange(
+                1, math.prod(src_shape) + 1, 1, dtype=torch.int64, device="cuda"
+            ).view(src_shape)
+        y_pt = x_pt.expand(expand_shape)
+        y_ait = torch.zeros_like(y_pt)
+        stream = torch.cuda.default_stream()
+        start_event_pt = torch.cuda.Event(enable_timing=True)
+        end_event_pt = torch.cuda.Event(enable_timing=True)
+        num_iters = 20
+        with compile_model(
+            y, detect_target(), "./tmp", "test_expand_codegen_" + name
+        ) as module:
+            module.run_with_tensors({"X": x_pt}, {"Y": y_ait})
+            self.assertTrue(graph_has_op(module.debug_sorted_graph, "expand"))
+            time_mean_ms, time_std_ms, result_tensors = module.benchmark_with_tensors(
+                {"X": x_pt}, {"Y": y_ait}, count=num_iters
+            )
+        print(
+            f"Write GB/sec:{1000*y_pt.numel()*y_pt.element_size()/time_mean_ms/(1024*1024*1024)}"
+        )
+        self.assertTrue(torch.equal(y_ait, y_pt))
+        # measure time against torch.contiguous()
+        cache_trasher = torch.zeros(1000, 1000, 42, device="cuda", requires_grad=False)
+        sum_elapsed_pt = 0.0
+        for _ in range(num_iters):
+            # trash the L2 cache, just like the benchmark code of AIT does
+            cache_trasher.normal_()
+            start_event_pt = torch.cuda.Event(enable_timing=True)
+            end_event_pt = torch.cuda.Event(enable_timing=True)
+            torch.cuda.synchronize()
+            start_event_pt.record(stream=stream)
+            _ = y_pt.contiguous()
+            end_event_pt.record(stream=stream)
+            torch.cuda.synchronize()
+            sum_elapsed_pt += start_event_pt.elapsed_time(end_event_pt)
+
+        pt_time = sum_elapsed_pt / num_iters
+        ait_throughput_write = (
+            1000
+            * y_pt.numel()
+            * y_pt.element_size()
+            / time_mean_ms
+            / (1024 * 1024 * 1024)
+        )
+        ait_throughput_read_once = (
+            1000
+            * x_pt.numel()
+            * x_pt.element_size()
+            / time_mean_ms
+            / (1024 * 1024 * 1024)
+        )
+        ait_throughput_total_lower_bound = (
+            ait_throughput_write + ait_throughput_read_once
+        )  # Assuming we just read the input once
+        ait_throughput_total_upper_bound = (
+            ait_throughput_write * 2
+        )  # Assuming every byte written has been read as well
+
+        pt_throughput_write = (
+            1000 * y_pt.numel() * y_pt.element_size() / pt_time / (1024 * 1024 * 1024)
+        )
+        pt_throughput_read = (  # Assuming we just read the input once
+            1000 * x_pt.numel() * x_pt.element_size() / pt_time / (1024 * 1024 * 1024)
+        )
+
+        pt_throughput_total_lower_bound = (
+            pt_throughput_write + pt_throughput_read
+        )  # Assuming we just read the input once
+        pt_throughput_total_upper_bound = (
+            pt_throughput_write * 2
+        )  # Assuming every byte written has been read as well
+
+        # ait_speedup_percent = round(100.0 * pt_time / time_mean_ms - 100.0)
+        ait_speedup_factor = f"{pt_time/time_mean_ms:.2f}"
+        ait_expand_variant = "general"
+        if optimize_fixed_dims:
+            ait_expand_variant = "optimized"
+        print(
+            f"""Benchmark Summary (test_expand_op:{name}) - {src_shape} => {expand_shape}: dtype={dtype}, variant={ait_expand_variant}. AIT speedup={ait_speedup_factor}x. Throughputs in GB/sec.: Write: pt={pt_throughput_write:.1f}, ait={ait_throughput_write:.1f}, Total (lower): pt={pt_throughput_total_lower_bound:.1f}, ait={ait_throughput_total_lower_bound:.1f} Total (upper): pt={pt_throughput_total_upper_bound:.1f}, ait=={ait_throughput_total_upper_bound:.1f} ]
+Benchmark note: Total throughput (lower) assumes the input is read once, Total throughput (upper) assumes every byte written has been read as well. The truth is inbetween due to caching of repeated reads.""",
+            file=sys.stdout,
+            flush=True,
         )
 
 


### PR DESCRIPTION
Summary:
### Implement expand operator CUDA backend

Adding CUDA backend implementation for expand: https://fburl.com/code/nb2mcsmg.

The operator semantic should be the same as the pytorch version https://fburl.com/fljywh6p.

#### Implementation

The previous expand operator was a no-op version, which only worked under very limited conditions, namely when it expanded just a single, already existing direction, and could be merged into a following elementwise op that supports tensor broadcasting.

This new version actually expands the tensor, supporting multiple expansion dimensions, dynamic shapes and adding dimensions, just like the pytorch version.

The pytorch version is in principle more effective, nevertheless, because in pytorch it just needs to create a new view on a source tensor with different read strides. As AIT has no general notion of strides for tensor dimensions, this is not a real option at the moment, unless we add that support to tensors and operators on them.

#### Further possible optimizations (not part of this PR )

 * When adding leading dimensions, this can be decomposed into writing an upper part of the tensor ( requiring strided reads or writes ) and then repeatedly copying that tensor ( which can be accomplished using effective sequential reads and writes and can utilize shared memory )
 * Further operator fusions should be possible

Differential Revision: D43419041

