### PR TITLE
Add jagged Tensor foundations

### DIFF
--- a/python/aitemplate/backend/cuda/view_ops/__init__.py
+++ b/python/aitemplate/backend/cuda/view_ops/__init__.py
@@ -15,6 +15,9 @@
 """
 CUDA view_ops module init
 """
-from . import view_ops
+from . import make_jagged, view_ops
 
-__all__ = ["view_ops"]
+__all__ = [
+    "view_ops",
+    "make_jagged",
+]

--- a/python/aitemplate/backend/cuda/view_ops/make_jagged.py
+++ b/python/aitemplate/backend/cuda/view_ops/make_jagged.py
@@ -1,0 +1,260 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Codegen functions for the make_jagged op.
+
+The main responsibilities of the make_jagged backend are:
+
+  1. Associate the offsets structure members (lengths and data)
+  with the corresponding rank-1 offsets Tensors' first dimension
+  and data pointer, respectively.
+
+  2. Check the validity of the offset content (non-strict
+  monotonicity, first and last values in each array). Offset
+  contents are on the device, hence are checked by a simple
+  CUDA kernel doing an assertion for each constraint. Some
+  of the constraints can be checked on the device, in which
+  case an std::runtime_error is thrown on violation.
+"""
+import jinja2
+
+from ....backend import registry
+
+
+SRC_TEMPLATE = jinja2.Template(
+    """
+#include <assert.h>
+#include <stdexcept>
+
+#include "jagged.h"
+
+
+namespace {
+
+struct OffsetBounds {
+  {{offsets_type}} min_values[{{num_offsets}}]{0};
+  {{offsets_type}} max_values[{{num_offsets}}]{0};
+  {{offsets_type}} last_values[{{num_offsets}}]{0};
+};
+
+__global__ void check_offsets(
+  {{offsets_struct_type}} offsets,
+  OffsetBounds bounds
+) {
+  int64_t length = offsets.lengths[blockIdx.x];
+  const {{offsets_type}}* data = offsets.data[blockIdx.x];
+
+  if (threadIdx.x >= length - 1) {
+    // out of bounds of the offset array
+    return;
+  }
+
+  {{offsets_type}} group_size = data[threadIdx.x + 1] - data[threadIdx.x];
+  if (group_size < bounds.min_values[blockIdx.x] || group_size > bounds.max_values[blockIdx.x]) {
+    printf(
+      "\\n[func name: {{func_name}}, blockIdx.x: %d, threadIdx.x: %d]: "
+      "Error: the offset difference %d is out of bounds of the jagged dimension %d (min: %d, max: %d).",
+      (int32_t)blockIdx.x,
+      (int32_t)threadIdx.x,
+      (int32_t)group_size,
+      (int32_t)blockIdx.x,
+      (int32_t)bounds.min_values[blockIdx.x],
+      (int32_t)bounds.max_values[blockIdx.x]
+    );
+    __trap();
+  }
+
+  if (threadIdx.x == 0) {
+    {{offsets_type}} first_offset = data[0];
+    if (first_offset != 0)
+    {
+      printf(
+        "\\n[func name: {{func_name}}, blockIdx.x: %d, threadIdx.x: %d]: "
+        "Error: the first offset of the jagged dimension %d is non-zero: %d.",
+        (int32_t)blockIdx.x,
+        (int32_t)threadIdx.x,
+        (int32_t)blockIdx.x,
+        (int32_t)first_offset
+      );
+      __trap();
+    }
+  }
+
+  if (threadIdx.x == length - 2) {
+    {{offsets_type}} last_offset = data[length - 1];
+    if (last_offset != bounds.last_values[blockIdx.x])
+    {
+      printf(
+        "\\n[func name: {{func_name}}, blockIdx.x: %d, threadIdx.x: %d]: "
+        "Error: the last offset of the jagged dimension %d is incorrect: %d (must be %d).",
+        (int32_t)blockIdx.x,
+        (int32_t)threadIdx.x,
+        (int32_t)blockIdx.x,
+        (int32_t)last_offset,
+        (int32_t)bounds.last_values[blockIdx.x]
+      );
+      __trap();
+    }
+  }
+}
+
+} // namespace
+
+
+void {{func_name}}(
+{% for idx in range(num_offsets) %}
+  int64_t offsets_length_{{idx}},
+  const void* offsets_data_{{idx}},
+{% endfor %}
+  {{offsets_struct_type}}& offsets,
+  int64_t* batch_dim,
+  int64_t total_length
+) {
+{% for idx in range(num_offsets) %}
+    offsets.lengths[{{idx}}] = offsets_length_{{idx}};
+    offsets.data[{{idx}}] = reinterpret_cast<const {{offsets_type}}*>(offsets_data_{{idx}});
+{% endfor %}
+
+{% if set_batch_dim %}
+    // batch_dim must be set by this code
+    *batch_dim = offsets.lengths[0] - 1;
+{% else %}
+    // batch_dim must have been set before this code
+    if (*batch_dim != offsets.lengths[0] - 1) {
+      throw std::runtime_error("batch_dim != len(offsets[0]) - 1");
+    }
+{% endif %}
+
+    int64_t max_offset_length = 0;
+    for (int i = 0; i < {{num_offsets}}; ++i) {
+        if (offsets.lengths[i] <= 1) {
+            throw std::runtime_error("offset array's length must be at least 2");
+        }
+        if (offsets.lengths[i] > max_offset_length) {
+            max_offset_length = offsets.lengths[i];
+        }
+    }
+
+    OffsetBounds bounds;
+{% for idx in range(num_offsets) %}
+    bounds.min_values[{{idx}}] = {{jagged_dim_min_values[idx]}};
+    bounds.max_values[{{idx}}] = {{jagged_dim_max_values[idx]}};
+    bounds.last_values[{{idx}}] = {{ "offsets.lengths[" + ((idx + 1) | string) + "] - 1" if idx < num_offsets - 1 else "total_length" }};
+{% endfor %}
+
+    check_offsets<<<{{num_offsets}}, max_offset_length - 1, 0, 0>>>(offsets, bounds);
+}
+""",
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+FUNC_DECL_TEMPLATE = jinja2.Template(
+    """
+void {{func_name}}(
+{% for idx in range(num_offsets) %}
+  int64_t,
+  const void*,
+{% endfor %}
+  {{offsets_struct_type}}&,
+  int64_t*,
+  int64_t
+);
+""",
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+FUNC_CALL_TEMPLATE = jinja2.Template(
+    """
+{{indent}}{{func_name}}(
+{% for idx in range(num_offsets) %}
+{{indent}}  {{offsets_first_dim_names[idx]}},
+{{indent}}  {{offsets_data_names[idx]}},
+{% endfor %}
+{{indent}}  {{offsets_var_name}},
+{{indent}}  &{{batch_dim_name}},
+{{indent}}  {{source_first_dim_name}}
+{{indent}});
+""",
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+
+@registry.reg("cuda.make_jagged.gen_function")
+def make_jagged_gen_function(func_attrs):
+    func_name = func_attrs["name"]
+    offsets_list = func_attrs["inputs"][1:]
+
+    output = func_attrs["outputs"][0]
+    jagged_int_var = output._attrs["shape"][0]
+    set_batch_dim = jagged_int_var.batch_dim()._attrs.get("isolated", False)
+    offsets_struct_type = jagged_int_var.offsets_struct_type()
+    jagged_dim_min_values = [dim.min_value() for dim in jagged_int_var.jagged_dims()]
+    jagged_dim_max_values = [dim.max_value() for dim in jagged_int_var.jagged_dims()]
+
+    return SRC_TEMPLATE.render(
+        func_name=func_name,
+        num_offsets=len(offsets_list),
+        set_batch_dim=set_batch_dim,
+        offsets_struct_type=offsets_struct_type,
+        jagged_dim_min_values=jagged_dim_min_values,
+        jagged_dim_max_values=jagged_dim_max_values,
+        offsets_type=jagged_int_var.offsets_type(),
+    )
+
+
+@registry.reg("cuda.make_jagged.func_decl")
+def make_jagged_gen_function_decl(func_attrs):
+    func_name = func_attrs["name"]
+    offsets_list = func_attrs["inputs"][1:]
+
+    output = func_attrs["outputs"][0]
+    jagged_int_var = output._attrs["shape"][0]
+    offsets_struct_type = jagged_int_var.offsets_struct_type()
+
+    return FUNC_DECL_TEMPLATE.render(
+        func_name=func_name,
+        num_offsets=len(offsets_list),
+        offsets_struct_type=offsets_struct_type,
+    )
+
+
+@registry.reg("cuda.make_jagged.func_call")
+def make_jagged_gen_function_call(func_attrs, indent="  "):
+    func_name = func_attrs["name"]
+    source = func_attrs["inputs"][0]
+    offsets_list = func_attrs["inputs"][1:]
+    output = func_attrs["outputs"][0]
+    jagged_int_var = output._attrs["shape"][0]
+
+    offsets_first_dim_names = [
+        offsets._attrs["shape"][0]._attrs["name"] for offsets in offsets_list
+    ]
+    offsets_data_names = [offsets._attrs["name"] for offsets in offsets_list]
+    batch_dim_name = jagged_int_var.batch_dim()._attrs["name"]
+    source_first_dim_name = source._attrs["shape"][0]._attrs["name"]
+
+    return FUNC_CALL_TEMPLATE.render(
+        indent="      ",
+        func_name=func_name,
+        num_offsets=len(offsets_list),
+        offsets_var_name=jagged_int_var.offsets_var_name(),
+        offsets_first_dim_names=offsets_first_dim_names,
+        offsets_data_names=offsets_data_names,
+        batch_dim_name=batch_dim_name,
+        source_first_dim_name=source_first_dim_name,
+    )

--- a/python/aitemplate/backend/main_templates.py
+++ b/python/aitemplate/backend/main_templates.py
@@ -29,6 +29,7 @@ MODEL_TEMPLATE = jinja2.Template(
 #include "raii_wrapper.h"
 #include "model.h"
 #include "macros.h"
+#include "jagged.h"
 #include <algorithm>
 #include <deque>
 #include <fstream>
@@ -179,6 +180,7 @@ class {{model_name}} : public ModelBase<{{model_name}}> {
   private:
 {{ tensor_decl }}
 {{ dim_decl }}
+{{ jagged_decl }}
 {{ function_state }}
 };
 } // namespace ait

--- a/python/aitemplate/compiler/base.py
+++ b/python/aitemplate/compiler/base.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import reduce
 from pprint import pformat
-from typing import Any, Dict, List, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 import numpy as np
 
@@ -204,6 +204,228 @@ class IntImm(IntVar):
 
     def pseudo_code(self, with_shape=False) -> str:
         return str(self.value())
+
+
+class JaggedDim(Node):
+    """
+    A class representing a single jagged dimension encoded within a JaggedIntVar.
+    Each instance contains the min and max value for the variable-length jagged
+    dimension. It is also associated with the rank-1 offsets Tensor representing
+    the layout of the jagged dimension within the JaggedIntVar. The offsets are
+    associated with the JaggedDim instances after creation, while creating
+    a jagged tensor with the make_jagged op.
+
+    See the docstring of the JaggedIntVar class for details.
+    """
+
+    def __init__(
+        self,
+        min_value: int,
+        max_value: int,
+    ):
+        """Initializes a JaggedDim.
+
+        Parameters
+        ----------
+        min_value : int
+            Minimum possible value of the jagged dimension.
+        max_value : int
+            Maximum possible value of the jagged dimension.
+        """
+        if min_value < 0:
+            raise ValueError(f"{min_value=}, but must be non-negative.")
+        if min_value > max_value:
+            raise ValueError(f"{min_value=} can't be larger than {max_value=}.")
+
+        super().__init__()
+
+        self._attrs["values"] = [min_value, max_value]
+        self._attrs["offsets"] = None
+
+    def __eq__(self, another: JaggedDim) -> bool:
+        return (
+            isinstance(another, JaggedDim)
+            and self.min_value() == another.min_value()
+            and self.max_value() == another.max_value()
+            and self.offsets() == another.offsets()
+        )
+
+    def __str__(self) -> str:
+        attrs = dict(self._attrs)
+        if self._attrs["offsets"] is not None:
+            attrs["offsets"] = {"name": self._attrs["offsets"]._attrs["name"]}
+        return str(attrs)
+
+    def min_value(self) -> int:
+        """The minimum possible value of the JaggedDim."""
+        return self._attrs["values"][0]
+
+    def max_value(self) -> int:
+        """The maximum possible value of the JaggedDim."""
+        return self._attrs["values"][1]
+
+    def offsets(self) -> Optional[Tensor]:
+        """The rank-1 offsets Tensor associated with the JaggedDim"""
+        return self._attrs["offsets"]
+
+    def pseudo_code(self, with_shape=False) -> str:
+        return f"JaggedDim({str(self._attrs['values'])})"
+
+
+class JaggedIntVar(IntVar):
+    """
+    JaggedIntVar is a specific case of IntVar that encodes one or more jagged
+    dimensions within itself. JaggedIntVar is used as the first dimension in
+    jagged Tensors' shape (this is, basically, what makes a Tensor jagged).
+    E.g., a JaggedIntVar with a single JaggedDim represents a single dynamic
+    dimension encoding a batch of variable sequence length. For the batch
+    size of B, in some sources this is indicated as sum_B(N_B): the sum of
+    individual sequence lengths: N_1, N_2, ..., N_B of B sequences. This sum
+    is represented as a single dynamic dimension: total_length, with B being
+    defined by the batch_dim.
+
+    Because JaggedIntVar is an IntVar, it can be treated so by the AIT ops
+    that are unaware of the jagged Tensor semantics. But the ops that are
+    aware can interpet the JaggedIntVar as the first dimension of the jagged
+    Tensor by specifically processing the underlying batch_dim and jagged_dims.
+
+    If there is more than one JaggedDim in a JaggedIntVar, those jagged dimensions
+    are nested within the single dynamic dimension. E.g., if there are two JaggedDims,
+    the JaggedIntVar represents a batch of B (batch_dim) variable-length sequences,
+    each in turn consisting of variable-length sequences. In principle, the nesting
+    can be arbitrarily deep, but in practice it's usually just a single JaggedDim.
+
+    JaggedIntVar should not be created directly. Please use the make_jagged op
+    for creating a jagged Tensor from a normal Tensor, the offsets, and the
+    metadata (like batch_dim and jagged_dims). The make_jagged op creates the
+    corresponding JaggedIntVar under the hood.
+    """
+
+    def __init__(
+        self,
+        total_length: IntVar,
+        batch_dim: IntVar,
+        jagged_dims: List[JaggedDim],
+    ):
+        """Initializes a JaggedIntVar.
+
+        Parameters
+        ----------
+        total_length : IntVar
+            The existing IntVar defining the total length sum_B(N_B) of the
+            JaggedIntVar. The "name" and "values" attributes of the JaggedIntVar
+            are the same as those of the total_length. This allows transparent
+            treatment of the jagged Tensor as dense by non-jagged-aware ops.
+            Must be a dynamic dim (IntVar, not IntImm).
+        batch_dim : IntVar
+            The batch dimension B in the sum_B(N_B) representation of the
+            JaggedIntVar. Specifies the number of (outermost) variable-length
+            sequences encoded within the JaggedIntVar. Must be a dynamic dim
+            (IntVar, not IntImm).
+        jagged_dims : List[JaggedDim]
+            One or more jagged dimension encoded in the JaggedIntVar. Each
+            JaggedDim specifies the bounds of one level of nested jaggedness
+            of the JaggedIntVar. See the class docstring for details.
+            The list must contain at least one JaggedDim. All JaggedDims
+            in the list must have their offsets already set to the
+            corresponding rank-1 Tensors.
+        """
+        if total_length is None or type(total_length) != IntVar:
+            raise TypeError(
+                "total_length must be dynamic (IntVar), "
+                f"but given {type(total_length).__name__}."
+            )
+        if batch_dim is None or type(batch_dim) != IntVar:
+            raise TypeError(
+                "batch_dim must be dynamic (IntVar), "
+                f"but given {type(batch_dim).__name__}."
+            )
+        if not jagged_dims or not all(
+            isinstance(dim, JaggedDim) for dim in jagged_dims
+        ):
+            raise TypeError(
+                "jagged_dims must be a non-empty list of JaggedDims, "
+                f"but given {jagged_dims}."
+            )
+        offsets_types = set()
+        for i, dim in enumerate(jagged_dims):
+            if dim.offsets() is None:
+                raise ValueError(
+                    f"JaggedDim {i} in the jagged_dims list has no associated offsets. "
+                    "This probably means that the JaggedIntVar is instantiated directly. "
+                    "Instead, jagged Tensor must be created by calling the make_jagged op."
+                )
+            else:
+                offsets_type = dim.offsets()._attrs["dtype"]
+                if offsets_type not in ["int32", "int64"]:
+                    raise TypeError(
+                        "The offsets Tensors can be either int32 or int64, "
+                        f"but given the Tensor of type {offsets_type}."
+                    )
+                offsets_types.add(offsets_type)
+        if len(offsets_types) > 1:
+            raise TypeError(
+                "All offsets Tensors must be of the same type,"
+                f" but given the Tensors of different types: {offsets_types}."
+            )
+
+        super().__init__(
+            values=total_length._attrs["values"],
+            name=total_length._attrs["name"],
+        )
+
+        self._attrs["batch_dim"] = batch_dim
+        self._attrs["jagged_dims"] = jagged_dims
+        self._attrs["offsets_type"] = f"{offsets_types.pop()}_t"
+        self._total_length = total_length
+
+    def __eq__(self, another: JaggedIntVar) -> bool:
+        return (
+            isinstance(another, JaggedIntVar)
+            and self.total_length() == another.total_length()
+            and self.batch_dim() == another.batch_dim()
+            and self.jagged_dims() == another.jagged_dims()
+        )
+
+    def total_length(self) -> IntVar:
+        """The total_length dimension the JaggedIntVar is based on."""
+        return self._total_length
+
+    def batch_dim(self) -> IntVar:
+        """The batch_dim of the JaggedIntVar."""
+        return self._attrs["batch_dim"]
+
+    def jagged_dims(self) -> List[JaggedDim]:
+        """The jagged_dims of the JaggedIntVar."""
+        return self._attrs["jagged_dims"]
+
+    def offsets_type(self) -> str:
+        """The type of the offsets of the JaggedIntVar's jagged_dims."""
+        return self._attrs["offsets_type"]
+
+    def offsets_var_name(self) -> str:
+        """The name of the offsets struct variable in runtime."""
+        name = self._attrs["name"]
+        if name is None:
+            raise RuntimeError("The JaggedIntVar is not named yet")
+        return f"{name}_jagged_offsets"
+
+    def offsets_struct_type(self) -> str:
+        """The type of the offsets struct variable used in runtime."""
+        num_jagged_dims = len(self.jagged_dims())
+        return f"ait::JaggedOffsets<{self.offsets_type()}, {num_jagged_dims}>"
+
+    def get_max_dense_shape(self) -> List[IntVar]:
+        """
+        Returns a list of IntVars representing the maximum dense shape
+        (rectangular volume) that the JaggedIntVar can correspond to.
+        The result has the batch_dim as the first item and the IntImm
+        with the max_value of each JaggedDim that follows.
+        """
+        result = [self.batch_dim()]
+        for dim in self.jagged_dims():
+            result.append(IntImm(dim.max_value()))
+        return result
 
 
 def get_aligned_size(shape: List[IntVar], dtype: str, alignment: int = 64) -> int:
@@ -495,6 +717,12 @@ class Tensor(Node):
     def is_a_const_num(self) -> bool:
         """Returns whether this Tensor represents a constant number."""
         return len(self._attrs["shape"]) == 0 and self._attrs["value"] is not None
+
+    def is_jagged(self) -> bool:
+        """Whether the Tensor is jagged (the first dim is JaggedIntVar)."""
+        return len(self._attrs["shape"]) > 0 and isinstance(
+            self._attrs["shape"][0], JaggedIntVar
+        )
 
     def size_bytes(self, alignment: int = 1) -> int:
         """Returns acutal size (in bytes) of this Tensor."""

--- a/static/include/jagged.h
+++ b/static/include/jagged.h
@@ -1,0 +1,36 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+#pragma once
+
+namespace ait {
+
+// This structure is used to pack the offset metadata related to a
+// jagged Tensor's first dimension: JaggedIntVar. The offsets are not
+// available in compile time, as they are coming in a rank-1 Tensor.
+// In runtime, the members of the structure are set by the make_jagged
+// op's back-end, from the corresponding rank-1 offset Tensors' length
+// and data. The OFFSET_TYPE can be either int32 or int64. The number
+// of offset arrays is known in compile time, hence specified as the
+// NUM_OFFSET_ARRAYS template argument here.
+template <typename OFFSET_TYPE, int32_t NUM_OFFSET_ARRAYS>
+struct JaggedOffsets {
+  // the lengths the individual offset arrays
+  int64_t lengths[NUM_OFFSET_ARRAYS]{0};
+  // the data in each of the offset arrays
+  // (i.e., the offsets of the JaggedIntVar)
+  const OFFSET_TYPE* data[NUM_OFFSET_ARRAYS]{nullptr};
+};
+
+} // namespace ait

--- a/tests/unittest/ops/test_make_jagged.py
+++ b/tests/unittest/ops/test_make_jagged.py
@@ -1,0 +1,115 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import unittest
+
+import torch
+
+from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler.base import JaggedDim, JaggedIntVar
+from aitemplate.frontend import IntImm, IntVar, Tensor
+from aitemplate.testing import detect_target
+from aitemplate.testing.test_utils import (
+    get_random_torch_tensor,
+    get_torch_empty_tensor,
+)
+
+
+class MakeJaggedTestCase(unittest.TestCase):
+    def test_make_jagged(
+        self,
+    ):
+        offsets1 = Tensor(
+            shape=[
+                IntVar(values=[1, 16]),
+            ],
+            name="off1",
+            dtype="int32",
+            is_input=True,
+        )
+        offsets2 = Tensor(
+            shape=[
+                IntVar(values=[1, 16]),
+            ],
+            name="off2",
+            dtype="int32",
+            is_input=True,
+        )
+
+        X = Tensor(
+            shape=[
+                IntVar(values=[1, 1024]),
+                IntImm(value=128),
+            ],
+            name="X",
+            dtype="float16",
+            is_input=True,
+        )
+        W = Tensor(
+            shape=[
+                IntImm(value=128),
+                IntImm(value=64),
+            ],
+            name="W",
+            dtype="float16",
+            is_input=True,
+        )
+
+        batch_dim = IntVar(values=[1, 128])
+        jd0 = JaggedDim(min_value=0, max_value=10)
+        jd1 = JaggedDim(min_value=0, max_value=15)
+        Y = ops.make_jagged(
+            batch_dim=batch_dim,
+            jagged_dims=[jd0, jd1],
+        )(X, [offsets1, offsets2])
+        Z = ops.gemm_rrr()(Y, W)
+
+        assert Y.is_jagged()
+        assert Z.is_jagged()
+
+        Y_dim_0 = Y._attrs["shape"][0]
+        assert isinstance(Y_dim_0, JaggedIntVar)
+        assert Y_dim_0.jagged_dims() == [jd0, jd1]
+        assert jd0.offsets() == offsets1
+        assert jd1.offsets() == offsets2
+
+        Z_dim_0 = Z._attrs["shape"][0]
+        assert Z_dim_0 == Y_dim_0
+
+        Y._attrs["name"] = "Y"
+        Y._attrs["is_output"] = True
+        Z._attrs["name"] = "Z"
+        Z._attrs["is_output"] = True
+
+        model = compile_model([Y, Z], detect_target(), "./tmp", "test_make_jagged")
+
+        offsets1_pt = torch.tensor([0, 1, 3, 5], dtype=torch.int32).cuda()
+        offsets2_pt = torch.tensor([0, 2, 4, 4, 9, 10], dtype=torch.int32).cuda()
+        x_pt = get_random_torch_tensor([10, 128], "float16")
+        w_pt = get_random_torch_tensor([128, 64], "float16")
+        z_pt = torch.matmul(x_pt, w_pt)
+
+        y = get_torch_empty_tensor([10, 128], "float16")
+        z = get_torch_empty_tensor([10, 64], "float16")
+
+        inputs = {"X": x_pt, "off1": offsets1_pt, "off2": offsets2_pt, "W": w_pt}
+        model.run_with_tensors(inputs, [y, z])
+
+        torch.testing.assert_close(y, x_pt)
+        torch.testing.assert_close(z, z_pt)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    unittest.main()


### PR DESCRIPTION
Summary:
This diff introduces jagged Tensor foundations in AIT: to allow creating and interpreting jagged Tensors in the front-end / IR, as well as processing the jagged Tensor metadata in a unified way in the back-end / runtime. In the following diffs, new jagged-aware ops or jagged-aware extensions of some existing ops will follow.

## What Is Jagged Tensor?

Jagged Tensor is a compact representation of (potentially nested) variable-length data. Conventionally, variable-length sequences are padded to represent them in a form of a normal rectangular Tensor, but this comes at memory and performance costs. Jagged Tensor's compact representation, together with its interpretation, provide a more efficient approach.

In this diff, we adopt fbgemm jagged Tensor semantics. More specifically (from the document linked above):

fbgemm introduces a number of specific jagged ops that take dense Tensor inputs and return dense Tensor outputs. But the jagged ops treat some of those dense Tensors as (potentially) nested jagged Tensors along the first dynamic dimension. Some examples of fbgemm jagged ops:

- [jagged_dense_dense_elementwise_add_jagged_output](https://pytorch.org/FBGEMM/python-api/jagged_tensor_ops.html#torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output)
- [jagged_dense_elementwise_mul](https://pytorch.org/FBGEMM/python-api/jagged_tensor_ops.html#torch.ops.fbgemm.jagged_dense_elementwise_mul)
- [batched_dense_vec_jagged_2d_mul](https://pytorch.org/FBGEMM/python-api/jagged_tensor_ops.html#torch.ops.fbgemm.batched_dense_vec_jagged_2d_mul)

Where an fbgemm jagged op expects a jagged Tensor as input, it normally takes two arguments:

1. A rank-2 dense tensor `x_values` with the shape `[sum_B(N_B), D]`, where `sum_B(N_B)` is a dynamic dimension and `D` is a fixed dimension (e.g., embedding dimension).
2. A list of rank-1 dense tensors `x_offsets`.

The first dimension `sum_B(N_B)` in `x_values` is interpreted as a collection of B groups of different lengths `N_1`, `N_2`, …, `N_B`, with all those variable lengths summing to `sum_B(N_B)`. If there is a single jagged dimension in the jagged Tensor, each of those `B` groups contains a variable-sized fraction of the `sum_B(N_B)` `D`-sized vectors in the `x_values`. However, there can be more than one jagged dimension, in which case each of the `B` groups contains variable-sized sub-groups, each of which in turn contains a variable-sized fraction of the `sum_B(N_B)` `D`-sized vectors in `x_values`. Again, the numbers of vectors in each sub-group in each group should sum to `sum_B(N_B)`. Theoretically, the level of nesting of the jagged dimensions can be arbitrary: groups can contain sub-groups, sub-groups can contain sub-sub-groups, etc. until the lowest-level sub-...-sub-groups contain contiguous fractions of the `sum_B(N_B)` `D`-sized vectors in `x_values`. Ultimately, the sizes of all the lowest-level sub-...-sub-groups should sum to `sum_B(N_B)`.

fbgemm encodes the nested group information about the single `sum_B(N_B)` dimension in the second argument: `x_offsets`. It is a list of rank-1 `int32` Tensors (vectors), each representing the offsets at a progressively deeper level of group nesting. Consider an example of an `x_offsets` list with two rank-1 offset Tensors: representing the offsets at the first and second levels of group nesting. `lengths[i]` below shows the size of each group at a given level, whereas `offsets[i]` is cumsum over `lengths[i]`, with a prepended zero. `offsets[i]` is an actual item in the `x_offsets` list representing a jagged Tensor (`lengths[i]` are shown here for clarity).

```
lengths[0]: tensor([ 3,  2,  5, 1])
offsets[0]: tensor([ 0,  3,  5, 10, 11])

lengths[1]: tensor([ 0,  1,  6, 17, 12,  5,  8, 17, 10, 15,  4])
offsets[1]: tensor([ 0,  0,  1,  7, 24, 36, 41, 49, 66, 76, 91, 95])
```

At the first level, there are 4 groups in the jagged Tensor, with the sizes represented by the `lengths[0]`: 3, 2, 5, and 1 sub-groups in each. In total, there are 3+2+5+1=11 sub-groups. The sizes of those 11 sub-groups, in turn, are represented by the `lengths[1]`. Each sub-group contains the specified number of `D`-sized vectors in `x_values`. The shares of each sub-group in `x_values` are contiguous along the first dimension `sum_B(N_B)` of `x_values`, with the sum of the sub-group sizes being equal to `sum_B(N_B)` (in this case: 95). Therefore, the shape of `x_values` corresponding to this particular  `x_offsets` list is `[95, D]`.

## Front-End Implementation Details

In this diff, we extend the fbgemm jagged Tensor semantics by allowing arbitrary number of dimensions following the `sum_B(N_B)` (not just one dimension `D`). Otherwise, the suggested jagged Tensor API follows the above. It also aims at making it more convenient to combine the separate pieces like `x_values` and `x_offsets`, as well as some IR-level metadata, into a single jagged Tensor entity.

The new front-end components are:

- `JaggedDim`: a class for representing a single jagged dimension encoded in the first `sum_B(N_B)` dimension of the jagged Tensor. With min/max value and the associated rank-1 `offsets` Tensor.

- `JaggedIntVar`: a specification of `IntVar` that contains jagged Tensor-related metadata: `batch_dim` (`B`), `jagged_dims` (as many as there are levels of nesting in the jagged Tensor), and `total_length` (the actual dynamic IntVar dim this JaggedIntVar is based on, representing `sum_B(N_B)`). The name and `values` of the `JaggedIntVar` are the same as those of the `total_length`. Basically, a jagged Tensor is a normal Tensor with the first dimension in the shape set to a `JaggedIntVar`. That's why a jagged Tensor can be transparently interpreted as a normal tensor with the shape `[sum_B(N_B), D1, ... Dn]` by non-jagged-aware ops in AIT (e.g., gemm or bmm with the jagged Tensor as the first argument).

- `make_jagged` is a new op that takes the normal "source" Tensor with jagged Tensor's data (`x_values` in fbgemm), the list of rank-1 offset Tensors (`x_offsets` in fbgemm), as well as the metadata (`batch_dim` and `jagged_dims`) and spits out a jagged Tensor as the output. Importantly, the jagged Tensor is a view of the source Tensor, just with the fully specified JaggedIntVar in `_attrs["shape"][0]`. Other than being convenient, one important reason why `make_jagged` should be used instead of "constructing" the jagged Tensor directly is that, if it isn't, the rank-1 offsets Tensors may otherwise remain "hanging in the air" and optimized out by the graph transformation passes.

## Back-End Implementation Details

In the back-end, the offsets of each jagged Tensor are represented by a new structure `ait::JaggedOffsets<N>` templated by the number `N` of jagged dims (or, equivalently, offset tensors) in the jagged Tensor's representation. The structure packs the lengths (on host) and data (on device) of the rank-1 offset Tensors, making it convenient to pass all of those by value to CUDA kernels. In the runtime, the `JaggedOffsets` variable is given a name formed from the name of the `JaggedIntVar`, hence fully predictable by the back-end codegen of the jagged-aware ops.

The back-end codegen of the `make_jagged` ops solves two tasks:

1. Associate the lenghts and data of the rank-1 offset Tensors with the corresponding members of the `JaggedOffsets` structure of the jagged Tensor.

2. Check the validity of the offset contents (there are a few things to check here: monotonicity, end values, matching the total group numbers or the batch_dim with the number of offsets in the next array). With the offset validity determined by `make_jagged`, the subsequent jagged-aware ops (e.g., elementwise) can rely on the established invariant. This should simplify the implementation of those ops.

The docstrings of the individual components provide more details of each.

Differential Revision: D43225824

