### PR TITLE
Add RTX 40 to detect_target

### DIFF
--- a/python/aitemplate/testing/detect_target.py
+++ b/python/aitemplate/testing/detect_target.py
@@ -41,7 +41,7 @@ def _detect_cuda():
         stdout = stdout.decode("utf-8")
         if "H100" in stdout:
             return "90"
-        if any(a in stdout for a in ["A100", "A10G", "RTX 30", "A30"]):
+        if any(a in stdout for a in ["A100", "A10G", "RTX 30", "A30", "RTX 40"]):
             return "80"
         if "V100" in stdout:
             return "70"


### PR DESCRIPTION
RTX 40 series has Compute Capability 8.9 - map it to 80 since cutlass [generator.py](https://github.com/AITemplate/cutlass/blob/master/tools/library/scripts/generator.py) has GenerateSM functions for arch 50, 60, 61, 70, 75, 80, 90.

Alternatively, we can use `nvidia-smi` or `pycuda` to get GPU Compute Capability and convert it to supported SM number - https://github.com/facebookincubator/AITemplate/pull/330