### PR TITLE
Use pycuda to get GPU compute capability in detect_target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,15 @@ setup_env: &setup_env
       name: Setup environment
       command: |
         for i in {1..3}; do
+          echo 'export PATH=/usr/local/cuda/bin:$PATH' >> $BASH_ENV &&
+          source "$BASH_ENV"
           python3.8 --version &&
           python3.8 -m pip install --upgrade pip &&
           cd /home/circleci/project/python &&
           python3.8 setup.py bdist_wheel &&
           sudo python3.8 -m pip install --no-input dist/*.whl &&
           cd /home/circleci/project &&
+          python3.8 -m pip install pycuda &&
           python3.8 -m pip install pytest &&
           python3.8 -m pip install torch &&
           python3.8 -m pip install numpy &&
@@ -35,7 +38,6 @@ setup_env: &setup_env
           git submodule sync &&
           git submodule update --init &&
           echo 'export PYTHONPATH=$PWD/python:$PYTHONPATH' >> $BASH_ENV &&
-          echo 'export PATH=/usr/local/cuda-11.4/bin:$PATH' >> $BASH_ENV &&
           echo 'export CI_FLAG=CIRCLECI' >> $BASH_ENV &&
           echo 'export CACHE_DIR=$PWD/tests/ci_profile_cache' >> $BASH_ENV &&
           break || sleep 5;

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -40,6 +40,9 @@ RUN bash /Install/install_doc_dep.sh
 # install Pytorch
 RUN pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu113
 
+# install Pycuda
+RUN pip3 install pycuda
+
 # for detection
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 RUN bash /Install/install_detection_deps.sh

--- a/python/aitemplate/testing/detect_target.py
+++ b/python/aitemplate/testing/detect_target.py
@@ -32,22 +32,21 @@ FLAG = ""
 
 def _detect_cuda():
     try:
-        proc = Popen(
-            ["nvidia-smi", "--query-gpu=gpu_name", "--format=csv"],
-            stdout=PIPE,
-            stderr=PIPE,
-        )
-        stdout, stderr = proc.communicate()
-        stdout = stdout.decode("utf-8")
-        if "H100" in stdout:
+        import pycuda.driver as drv
+
+        drv.init()
+        major, minor = drv.Device(0).compute_capability()
+        comp_cap = major * 10 + minor
+        if comp_cap >= 90:
             return "90"
-        if any(a in stdout for a in ["A100", "A10G", "RTX 30", "A30", "RTX 40"]):
+        elif comp_cap >= 80:
             return "80"
-        if "V100" in stdout:
-            return "70"
-        if "T4" in stdout:
+        elif comp_cap >= 75:
             return "75"
-        return None
+        elif comp_cap >= 70:
+            return "70"
+        else:
+            return None
     except Exception:
         return None
 


### PR DESCRIPTION
New version of `nvidia-smi` allows to get GPU Compute Capability. Command example
```
$ nvidia-smi --query-gpu=compute_cap --format=csv,noheader
8.6
8.6
8.6
8.6
```
Hovewer, circleCI pipeline use image: "ubuntu-2004-cuda-11.4:202110-01" - it has driver-470, cuda-11.4 which do not support `--query-gpu=compute_cap`.

Alternative solution is to use `pycuda` python package.
It provides API to get Major and Minor Compute Capability of a particular Device.

Once we get the number we can convert it to SM number supported by cutlass [generator.py](https://github.com/AITemplate/cutlass/blob/master/tools/library/scripts/generator.py#L4824).

Currently it supports SM 50, 60, 61, 70, 75, 80, 90.

Not sure if we want to support SM less than 70. So, we can focus on 70, 75, 80 and 90 only.

