### PR TITLE
Pass fixing and refactoring

### DIFF
--- a/fx2ait/fx2ait/converters/aten2ait_converters.py
+++ b/fx2ait/fx2ait/converters/aten2ait_converters.py
@@ -67,6 +67,7 @@ from fx2ait.passes.lower_basic_pass_aten import (
     aten_compose_bmm_3d,
     aten_compose_chunk,
     aten_compose_getitem_slice,
+    aten_compose_mm_2d,
     aten_operator_getitem,
 )
 from torch.fx.node import Argument, Target
@@ -555,6 +556,7 @@ def aten_ops_max_pool2d(
     return max_pool2d(kernel_size=kernel_size, stride=stride, pad=padding)(input_val)
 
 
+@ait_converter(aten_compose_mm_2d)
 @ait_converter(aten_compose_bmm_3d)
 @ait_converter(aten_compose_bmm_2d)
 @ait_converter(torch.ops.aten.addmm.default)

--- a/fx2ait/fx2ait/passes/lower_basic_pass_aten.py
+++ b/fx2ait/fx2ait/passes/lower_basic_pass_aten.py
@@ -18,7 +18,8 @@ from typing import Any, NamedTuple
 
 import torch
 import torch.fx
-from fx2ait.acc_tracer import acc_ops
+from fx2ait.tools.ait_subgraph_rewriter import replace_pattern
+
 from torch.fx.experimental.const_fold import split_const_subgraphs
 from torch.fx.passes.infra.pass_base import PassResult
 from torch.fx.passes.shape_prop import TensorMetadata
@@ -28,6 +29,34 @@ _LOGGER = logging.getLogger(__name__)
 # Create an alias for module input type to avoid littering pyre-ignore for Any
 # throughout the file.
 Input = Any
+
+from fx2ait.acc_tracer import acc_ops
+from torch.fx import symbolic_trace
+
+
+def replacement_pattern_abstract(replacement):
+    """
+    Replace the pattern graph by a node of call_function of this `replacement`
+    """
+    traced = symbolic_trace(replacement)
+    replacement_placeholders = [
+        node for node in traced.graph.nodes if node.op == "placeholder"
+    ]
+    for n in traced.graph.nodes:
+        if n.op == "output":
+            before_output = n.all_input_nodes[0]
+            with traced.graph.inserting_after(before_output):
+                new_args = tuple(replacement_placeholders)
+                new_node = traced.graph.create_node(
+                    "call_function",
+                    replacement,
+                    args=new_args,
+                    kwargs=None,
+                )
+                before_output.replace_all_uses_with(new_node)
+    traced.graph.eliminate_dead_code()
+    traced.recompile()
+    return traced
 
 
 def run_const_fold(traced_mod: torch.fx.GraphModule) -> torch.fx.GraphModule:
@@ -99,6 +128,7 @@ def nchw2nhwc_pass(
     return PassResult(module, modified)
 
 
+# TODO: delete in future
 def replace_inplace_ops(
     module: torch.fx.GraphModule,
 ) -> torch.fx.GraphModule:
@@ -210,6 +240,49 @@ def replace_transpose_mm_op_with_linear(
                 module.graph.erase_node(v)
     module.graph.eliminate_dead_code()
     module.recompile()
+    return PassResult(module, modified)
+
+
+def replace_batch_norm(module: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    """
+    Current exir.capture enable_aot and it captures bwd needed nodes in output P619801318
+    This pass removes those unused node and replace with classic aten.batch_norm
+    """
+    batch_node_list = []
+    for n in module.graph.nodes:
+        if n.target == torch.ops.aten._native_batch_norm_legit_functional.default:
+            batch_node_list.append(n)
+        if n.target == "output":
+            output_node = n
+
+    if len(batch_node_list) > 0:
+        modified = True
+    else:
+        modified = False
+    for n in batch_node_list:
+        new_op = torch.ops.aten.batch_norm
+        new_args = list(n.args)
+        new_args.append(False)
+        new_args = tuple(new_args)
+        user_list = [x for x in n.users]
+        user_list_copy_node = []
+        user_list_copy_node.append(next(iter(user_list[1].users)))
+        user_list_copy_node.append(next(iter(user_list[2].users)))
+        getitem_node = user_list[0]
+        with module.graph.inserting_after(getitem_node):
+            new_node = module.graph.create_node(
+                "call_function",
+                new_op,
+                args=new_args,
+                kwargs=n.kwargs,
+            )
+            getitem_node.replace_all_uses_with(new_node)
+
+        output_args = output_node.args[0]
+        new_output_args = [x for x in output_args if x not in user_list_copy_node]
+        output_node.args = (new_output_args,)
+        module.graph.eliminate_dead_code()
+        module.recompile()
     return PassResult(module, modified)
 
 
@@ -416,17 +489,35 @@ def compose_getitem_slice(
         if node.op == "call_function" and node.target == torch.ops.aten.slice.Tensor:
             holder = []
             holder.append(node)
-            while (
-                len(node.users.keys()) == 1
-                and next(iter(node.users)).target == torch.ops.aten.slice.Tensor
-                and node.args[1] + 1 == next(iter(node.users)).args[1]
-            ):
-                node = next(iter(node.users))
-                holder.append(node)
+            qualified = True
+            user_change_input = []
+
+            while qualified:
+                next_user = None
+                for user in node.users:
+                    if (
+                        user.target == torch.ops.aten.slice.Tensor
+                        and node.args[1] + 1 == user.args[1]
+                    ):
+                        next_user = user
+                    elif (
+                        user.target == torch.ops.aten.sym_size
+                        and user.args[1] == node.args[1]
+                    ):
+                        user_change_input.append(user)
+                    else:
+                        qualified = False
+                        break
+                if qualified and next_user:
+                    node = next_user
+                    holder.append(node)
+                else:
+                    qualified = False
+
             if len(holder) == 1:
                 return (False,)
             else:
-                return (True, holder)
+                return (True, holder, user_change_input)
         return (False,)
 
     modified = False
@@ -435,6 +526,7 @@ def compose_getitem_slice(
         if res[0]:
             modified = True
             holder = res[1]
+            user_change_input = res[2]
             input_n = holder[0].args[0]
             last_n = holder[-1]
             list_args = []
@@ -446,13 +538,30 @@ def compose_getitem_slice(
                 new_node = module.graph.create_node(
                     "call_function",
                     aten_compose_getitem_slice,
-                    args=new_args,
+                    args=tuple(new_args),
                     kwargs=None,
                 )
             last_n.replace_all_uses_with(new_node)
+            for n in user_change_input:
+                new_args = list(n.args)
+                new_args[0] = new_node
+                n.args = tuple(new_args)
+
     module.graph.eliminate_dead_code()
     module.recompile()
     return PassResult(module, modified)
+
+
+def aten_compose_mm_2d(arg0_1, arg1_1):
+    sym_size = torch.ops.aten.sym_size(arg0_1, 0)
+    sym_size_1 = torch.ops.aten.sym_size(arg0_1, 1)
+    mul = sym_size * sym_size_1
+    sym_size_2 = torch.ops.aten.sym_size(arg0_1, 2)
+    view = torch.ops.aten.view.default(arg0_1, [mul, sym_size_2])
+    mm = torch.ops.aten.mm.default(view, arg1_1)
+    sym_size_3 = torch.ops.aten.sym_size(arg1_1, 1)
+    view_1 = torch.ops.aten.view.default(mm, [sym_size, sym_size_1, sym_size_3])
+    return view_1
 
 
 def aten_compose_bmm_2d(flat_args_1, flat_args_2):
@@ -500,48 +609,49 @@ def compose_bmm(
     combine decomposed bmm (matmul)
     """
     modified = False
-    for n in module.graph.nodes:
-        if n.op == "call_function" and n.target in (torch.ops.aten.bmm.default,):
-            modified = True
-            node = n
-            input_n = node.all_input_nodes[0]
-            other_n = node.all_input_nodes[1]
-            output = next(iter(node.users))
-            input_input_n = input_n.all_input_nodes[0]
-            if (
-                input_input_n.target != torch.ops.aten.expand.default
-                and input_n.target != torch.ops.aten.view.default
-            ):
-                raise RuntimeError(
-                    "Bmm is addressed in fixed pattern. A new pattern is met!"
-                )
-            real_input = input_input_n.all_input_nodes[0]
-            input_other_n = other_n.all_input_nodes[0]
-            if (
-                input_other_n.target != torch.ops.aten.expand.default
-                and other_n.target != torch.ops.aten.view.default
-            ):
-                raise RuntimeError(
-                    "Bmm is addressed in fixed pattern. A new pattern is met!"
-                )
-            real_other = input_other_n.all_input_nodes[0]
-            if len(real_other.meta["val"].size()) == 2:
-                new_func = aten_compose_bmm_2d
-            if len(real_other.meta["val"].size()) == 3:
-                new_func = aten_compose_bmm_3d
+    # pattern replacement for aten_compose_mm_2d
+    _LOGGER.info("compose_bmm: pattern matching for aten_compose_mm_2d...")
+    aten_compose_mm_2d_replacement = replacement_pattern_abstract(aten_compose_mm_2d)
+    res = replace_pattern(module, aten_compose_mm_2d, aten_compose_mm_2d_replacement)
+    if len(res) > 0:
+        modified = True
+    # pattern replacement for aten_compose_bmm_2d
+    _LOGGER.info("compose_bmm: pattern matching for aten_compose_bmm_3d...")
 
-            with module.graph.inserting_after(node):
-                new_args = (real_input, real_other)
-                new_node = module.graph.create_node(
-                    "call_function",
-                    new_func,
-                    args=new_args,
-                    kwargs=None,
-                )
-            output.replace_all_uses_with(new_node)
+    def match_filter_aten_compose_bmm_2d(match, original_graph, pattern_graph):
+        if len(match.placeholder_nodes[1].meta["val"].shape) == 2:
+            return True
+        else:
+            return False
 
-    module.graph.eliminate_dead_code()
-    module.recompile()
+    aten_compose_bmm_2d_replacement = replacement_pattern_abstract(aten_compose_bmm_2d)
+    res = replace_pattern(
+        module,
+        aten_compose_bmm_2d,
+        aten_compose_bmm_2d_replacement,
+        [match_filter_aten_compose_bmm_2d],
+    )
+    if len(res) > 0:
+        modified = True
+    # pattern replacement for aten_compose_bmm_3d
+    _LOGGER.info("compose_bmm: pattern matching for aten_compose_bmm_2d...")
+
+    def match_filter_aten_compose_bmm_3d(match, original_graph, pattern_graph):
+        if len(match.placeholder_nodes[1].meta["val"].shape) == 3:
+            return True
+        else:
+            return False
+
+    aten_compose_bmm_3d_replacement = replacement_pattern_abstract(aten_compose_bmm_3d)
+    res = replace_pattern(
+        module,
+        aten_compose_bmm_3d,
+        aten_compose_bmm_3d_replacement,
+        [match_filter_aten_compose_bmm_3d],
+    )
+    if len(res) > 0:
+        modified = True
+
     return PassResult(module, modified)
 
 
@@ -615,12 +725,12 @@ def compose_chunk(
     return PassResult(module, modified)
 
 
+## TODO: we will remove this pass once dynamo fixed the bug
 def acc_replace_mul_ops(
     module: torch.fx.GraphModule,
 ) -> torch.fx.GraphModule:
     """
     Put constant at the end of multiplicaiton, i.e change 15*x.size(1) to x.size(1)*15.
-    TODO: we will remove this pass once dynamo fixed the bug
     """
     for n in module.graph.nodes:
         if n.op == "call_function" and n.target == acc_ops.mul:

--- a/fx2ait/fx2ait/test/converters_aten/test_ait_chunk_aten.py
+++ b/fx2ait/fx2ait/test/converters_aten/test_ait_chunk_aten.py
@@ -14,6 +14,7 @@
 #
 import torch
 from fx2ait.fx2ait import TensorSpec
+from fx2ait.passes.lower_basic_pass_aten import aten_compose_chunk
 from fx2ait.tools.common_aten2ait import DispatchTestCase
 from parameterized import param, parameterized
 
@@ -40,7 +41,7 @@ class TestChunkConverter(DispatchTestCase):
 
         model = TestModule().cuda().half()
         inputs = [torch.randn(shape).half().cuda()]
-        self.run_test(model, inputs, expected_ops={})
+        self.run_test(model, inputs, expected_ops={aten_compose_chunk})
 
     def test_chunk_dynamic(self):
         class TestModule(torch.nn.Module):
@@ -57,4 +58,6 @@ class TestChunkConverter(DispatchTestCase):
             ],
         )
 
-        self.run_test_with_dynamic_shape(model, inputs_spec, expected_ops={})
+        self.run_test_with_dynamic_shape(
+            model, inputs_spec, expected_ops={aten_compose_chunk}
+        )

--- a/fx2ait/fx2ait/test/converters_aten/test_ait_matmul_aten.py
+++ b/fx2ait/fx2ait/test/converters_aten/test_ait_matmul_aten.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 #
 import torch
+from fx2ait.passes.lower_basic_pass_aten import aten_compose_bmm_3d, aten_compose_mm_2d
 from fx2ait.tensor_spec import TensorSpec
 from fx2ait.tools.common_aten2ait import DispatchTestCase
 
@@ -23,14 +24,21 @@ class TestMatMulConverter(DispatchTestCase):
     @parameterized.expand(
         [
             [[2, 3], [3, 4], torch.ops.aten.mm.default],
-            [[2, 3, 4], [4, 6], torch.ops.aten.mm.default],
-            [[2, 3, 4], [2, 4, 6], torch.ops.aten.bmm.default],
+            # TODO check again in future since there is a diff about not decompose https://fburl.com/nysuuf7q
+            [
+                [2, 3, 4],
+                [4, 6],
+                aten_compose_mm_2d,
+            ],
+            [[2, 3, 4], [2, 4, 6], aten_compose_bmm_3d],
             [[2, 2, 2, 3, 4], [4, 6], torch.ops.aten.mm.default],
         ]
     )
     def test_simple(self, lhs_shape, rhs_shape, op):
         class TestModule(torch.nn.Module):
             def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+                x = x.mul(1)
+                y = y.mul(1)
                 return torch.matmul(x, y)
 
         model = TestModule().cuda()
@@ -56,11 +64,11 @@ class TestMatMulConverter(DispatchTestCase):
         [
             # Only M can be dynamic: https://github.com/fairinternal/AITemplate/blob/main/tests/unittest/ops/test_gemm.py
             [[[2, 3], [3, 3], [6, 6]], torch.ops.aten.mm.default],
-            [[[2, 3], [2, 3], [3, 3], [6, 6]], torch.ops.aten.mm.default],
+            [[[2, 3], [2, 3], [3, 3], [6, 6]], aten_compose_mm_2d],
             [[[1, 3], [2, 3], [6, 8], [3, 3], [6, 6]], torch.ops.aten.mm.default],
             # FIXME: batch_size cannot be dynamic because the permutation of shape change the names: P544607056
             # b, m, k, n
-            [[[2, 2], [6, 8], [3, 3], [6, 6]], torch.ops.aten.bmm.default, True],
+            [[[2, 2], [6, 8], [3, 3], [6, 6]], aten_compose_bmm_3d, True],
         ]
     )
     def test_dynamic(self, shape, op, bmm=False):

--- a/fx2ait/fx2ait/test/converters_aten/test_ait_slice_tensor_aten.py
+++ b/fx2ait/fx2ait/test/converters_aten/test_ait_slice_tensor_aten.py
@@ -47,7 +47,7 @@ class TestSliceTensor(DispatchTestCase):
                 "slice_basic",
                 (slice(None, None, None), slice(0, 3, 1)),
                 {
-                    torch.ops.aten.slice.Tensor,
+                    aten_compose_getitem_slice,
                     torch.ops.aten.add.Tensor,
                 },
                 None,
@@ -76,7 +76,7 @@ class TestSliceTensor(DispatchTestCase):
                     slice(None, None, None),
                 ),
                 {
-                    torch.ops.aten.slice.Tensor,
+                    aten_compose_getitem_slice,
                     torch.ops.aten.add.Tensor,
                 },
                 None,
@@ -88,7 +88,7 @@ class TestSliceTensor(DispatchTestCase):
                     slice(None, 2, 1),
                 ),
                 {
-                    torch.ops.aten.slice.Tensor,
+                    aten_compose_getitem_slice,
                     torch.ops.aten.add.Tensor,
                 },
                 None,
@@ -97,7 +97,7 @@ class TestSliceTensor(DispatchTestCase):
                 "slice_end_none",
                 (slice(None, None, None), slice(1, None, 1)),
                 {
-                    torch.ops.aten.slice.Tensor,
+                    aten_compose_getitem_slice,
                     torch.ops.aten.add.Tensor,
                 },
                 None,
@@ -109,7 +109,7 @@ class TestSliceTensor(DispatchTestCase):
                     slice(0, 3, None),
                 ),
                 {
-                    torch.ops.aten.slice.Tensor,
+                    aten_compose_getitem_slice,
                     torch.ops.aten.add.Tensor,
                 },
                 None,
@@ -127,7 +127,7 @@ class TestSliceTensor(DispatchTestCase):
                 "slice_neg_slice",
                 (slice(None, None, None), slice(-8, -2, 1)),
                 {
-                    torch.ops.aten.slice.Tensor,
+                    aten_compose_getitem_slice,
                     torch.ops.aten.add.Tensor,
                 },
                 None,
@@ -145,7 +145,7 @@ class TestSliceTensor(DispatchTestCase):
                 "slice_multi_dim",
                 (slice(None, None, None), slice(0, 3, 1), slice(1, -1, 1)),
                 {
-                    torch.ops.aten.slice.Tensor,
+                    aten_compose_getitem_slice,
                     torch.ops.aten.add.Tensor,
                 },
                 None,
@@ -172,7 +172,7 @@ class TestSliceTensor(DispatchTestCase):
                 "slice_zero_slice",
                 (slice(None, None, None), slice(None, None, None), slice(0, 0, None)),
                 {
-                    torch.ops.aten.slice.Tensor,
+                    aten_compose_getitem_slice,
                     torch.ops.aten.add.Tensor,
                 },
                 None,

--- a/fx2ait/fx2ait/test/converters_aten/test_ait_unary_ops_aten.py
+++ b/fx2ait/fx2ait/test/converters_aten/test_ait_unary_ops_aten.py
@@ -31,8 +31,8 @@ unary_ops = [
     (torch.sqrt, torch.ops.aten.sqrt.default),
     (
         torch.clone,
-        torch.ops.aten.clone.default,
-    ),  # clone op can not be the output directly
+        torch.ops.aten.mul.Tensor,
+    ),  # clone op can not be the output directly so expected is the op after it(aten.mul)
 ]
 
 

--- a/fx2ait/fx2ait/tools/ait_subgraph_rewriter.py
+++ b/fx2ait/fx2ait/tools/ait_subgraph_rewriter.py
@@ -1,0 +1,481 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import copy
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Set, Union
+
+import torch
+
+from torch.fx._symbolic_trace import symbolic_trace
+from torch.fx.graph import Graph
+from torch.fx.graph_module import GraphModule
+from torch.fx.node import Node
+from torch.fx.passes.utils.matcher_utils import InternalMatch, SubgraphMatcher
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class AITSubgraphMatcher(SubgraphMatcher):
+    def __init__(
+        self,
+        pattern: Graph,
+        match_output: bool = False,
+        match_placeholder: bool = False,
+        remove_overlapping_matches: bool = True,
+    ):
+        super(AITSubgraphMatcher, self).__init__(
+            pattern, match_output, match_placeholder, remove_overlapping_matches
+        )
+
+    def _match_args(self, pn: Any, gn: Any, match: InternalMatch) -> bool:
+        logger.info(f"  matching arguments: {pn} to {gn}")
+        assert not (
+            isinstance(pn, Node) and isinstance(gn, Node)
+        ), "pn and gn cannot both be Node"
+        if isinstance(pn, Node) and not isinstance(gn, Node):
+            if pn.op == "placeholder":
+                # Check if we've already matched these nodes in the current
+                # traversal
+                if pn in match.nodes_map:
+                    return match.nodes_map[pn] == gn
+
+                match.nodes_map[pn] = gn
+                return True
+            elif pn.op == "call_function" and pn.target == torch.ops.aten.sym_size:
+                return True
+            else:
+                return False
+        elif not isinstance(pn, Node) and isinstance(gn, Node):
+            return False
+        else:
+            return type(gn) == type(pn) and gn == pn
+
+    def _match_nodes(self, pn: Node, gn: Node, match: InternalMatch) -> bool:
+        logger.info(f"  matching node: {pn} to {gn}")
+        # breakpoint()
+        assert isinstance(pn, Node) and isinstance(gn, Node), str(
+            f"pn and gn must be Node, pn: {pn}, gn: {gn}"
+        )
+        if (
+            pn.target == torch.ops.aten.sym_size
+            and gn.target == torch.ops.aten.sym_size
+        ):
+            return True
+        # Check if we've already matched these nodes in the current
+        # traversal
+        if pn in match.nodes_map:
+            return match.nodes_map[pn] == gn
+
+        # TODO: use a more efficienty way to check if gn is matched before: two-way dict
+        if gn in match.nodes_map.values():
+            return False
+
+        if not self._nodes_are_equal(pn, gn):
+            return False
+
+        # Optimistically mark `pn` as a match for `gn`, and save a local copy of match
+        saved_match = copy.copy(match)
+        match.nodes_map[pn] = gn
+
+        if pn.op == "placeholder":
+            return True
+
+        # Recursively traverse upwards to check if `pn` is a true
+        # match for `gn`
+        match_found = True
+
+        def flatten_args(args) -> List[Any]:
+            # Recursively flatten args
+            result: List[Any] = []
+            for arg in args:
+                # flatten the list, if only it's a list/tuple of nodes
+                if (
+                    isinstance(arg, (list, tuple))
+                    and len(arg) > 0
+                    and isinstance(arg[0], Node)
+                ):
+                    result.extend(flatten_args(arg))
+                else:
+                    result.append(arg)
+
+            return result
+
+        pn_flatten_args = flatten_args(pn.args)
+        gn_flatten_args = flatten_args(gn.args)
+
+        if pn.kwargs.keys() == gn.kwargs.keys():
+            for key in pn.kwargs.keys():
+                pn_flatten_args.append(pn.kwargs[key])
+                gn_flatten_args.append(gn.kwargs[key])
+        else:
+            match_found = False
+
+        if match_found and len(pn_flatten_args) == len(gn_flatten_args):
+            for pn_, gn_ in zip(pn_flatten_args, gn_flatten_args):
+                if isinstance(gn_, Node) and isinstance(pn_, Node):
+                    matched = self._match_nodes(pn_, gn_, match)
+                else:
+                    matched = self._match_args(pn_, gn_, match)
+                if not matched:
+                    match_found = False
+                    break
+        else:
+            match_found = False
+
+        if not match_found:
+            # revert to saved_match before matching with current node
+            match = copy.copy(saved_match)
+            return False
+
+        return True
+
+
+__all__ = [
+    "Match",
+    "replace_pattern",
+    "ReplacedPatterns",
+]
+
+
+class Match(NamedTuple):
+    # Node from which the match was found
+    anchor: Node
+    # Maps nodes in the pattern subgraph to nodes in the larger graph
+    nodes_map: Dict[Node, Node]
+
+
+@dataclass
+class ReplacedPatterns:
+    # Node from which the match was found
+    anchor: Node
+    # Maps nodes in the pattern subgraph to nodes in the larger graph
+    nodes_map: Dict[Node, Node]
+    # List of nodes that were added into the graph
+    replacements: List[Node]
+
+
+def _replace_submodules(gm: GraphModule, replacement: torch.nn.Module) -> None:
+    gm.delete_all_unused_submodules()
+
+    if isinstance(replacement, GraphModule):
+        replacement.graph.lint()
+
+    def try_get_submodule(
+        mod: torch.nn.Module, target: str
+    ) -> Optional[torch.nn.Module]:
+        try:
+            mod_match = mod.get_submodule(target)
+            return mod_match
+        except AttributeError:
+            return None
+
+    for node in gm.graph.nodes:
+        if node.op == "call_module" or node.op == "get_attr":
+            gm_submod = try_get_submodule(gm, node.target)
+
+            replacement_submod = try_get_submodule(replacement, node.target)
+
+            # CASE 1: This target already exists as a submodule in our
+            # result GraphModule. Whether or not it exists in
+            # `replacement`, the existing submodule takes precedence.
+            if gm_submod is not None:
+                continue
+
+            # CASE 2: The target exists as a submodule in `replacement`
+            # only, so we need to copy it over.
+            elif replacement_submod is not None:
+                new_submod = copy.deepcopy(getattr(replacement, node.target))
+                gm.add_submodule(node.target, new_submod)
+
+            # CASE 3: The target doesn't exist as a submodule in `gm`
+            # or `replacement`
+            else:
+                raise RuntimeError(
+                    'Attempted to create a "',
+                    node.op,
+                    '" node during subgraph rewriting '
+                    f"with target {node.target}, but "
+                    "the referenced submodule does not "
+                    "exist in either the original "
+                    "GraphModule `gm` or the replacement"
+                    " GraphModule `replacement`",
+                )
+
+    gm.graph.lint()
+
+
+def replace_pattern(
+    gm: GraphModule,
+    pattern: Union[Callable, GraphModule],
+    replacement: Union[Callable, GraphModule],
+    match_filters: List[Callable[["InternalMatch", Graph, Graph], bool]] = None,  # type: ignore[name-defined]
+) -> List[Match]:
+    """
+    Matches all possible non-overlapping sets of operators and their
+    data dependencies (``pattern``) in the Graph of a GraphModule
+    (``gm``), then replaces each of these matched subgraphs with another
+    subgraph (``replacement``).
+
+    Args:
+        ``gm``: The GraphModule that wraps the Graph to operate on
+        ``pattern``: The subgraph to match in ``gm`` for replacement
+        ``replacement``: The subgraph to replace ``pattern`` with
+
+    Returns:
+        List[Match]: A list of ``Match`` objects representing the places
+        in the original graph that ``pattern`` was matched to. The list
+        is empty if there are no matches. ``Match`` is defined as:
+
+        .. code-block:: python
+
+            class Match(NamedTuple):
+                # Node from which the match was found
+                anchor: Node
+                # Maps nodes in the pattern subgraph to nodes in the larger graph
+                nodes_map: Dict[Node, Node]
+
+    Examples:
+
+    .. code-block:: python
+
+        import torch
+        from torch.fx import symbolic_trace, subgraph_rewriter
+
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x, w1, w2):
+                m1 = torch.cat([w1, w2]).sum()
+                m2 = torch.cat([w1, w2]).sum()
+                return x + torch.max(m1) + torch.max(m2)
+
+        def pattern(w1, w2):
+            return torch.cat([w1, w2]).sum()
+
+        def replacement(w1, w2):
+            return torch.stack([w1, w2])
+
+        traced_module = symbolic_trace(M())
+
+        subgraph_rewriter.replace_pattern(traced_module, pattern, replacement)
+
+    The above code will first match ``pattern`` in the ``forward``
+    method of ``traced_module``. Pattern-matching is done based on
+    use-def relationships, not node names. For example, if you had
+    ``p = torch.cat([a, b])`` in ``pattern``, you could match
+    ``m = torch.cat([a, b])`` in the original ``forward`` function,
+    despite the variable names being different (``p`` vs ``m``).
+
+    The ``return`` statement in ``pattern`` is matched based on its
+    value only; it may or may not match to the ``return`` statement in
+    the larger graph. In other words, the pattern doesn't have to extend
+    to the end of the larger graph.
+
+    When the pattern is matched, it will be removed from the larger
+    function and replaced by ``replacement``. If there are multiple
+    matches for ``pattern`` in the larger function, each non-overlapping
+    match will be replaced. In the case of a match overlap, the first
+    found match in the set of overlapping matches will be replaced.
+    ("First" here being defined as the first in a topological ordering
+    of the Nodes' use-def relationships. In most cases, the first Node
+    is the parameter that appears directly after ``self``, while the
+    last Node is whatever the function returns.)
+
+    One important thing to note is that the parameters of the
+    ``pattern`` Callable must be used in the Callable itself,
+    and the parameters of the ``replacement`` Callable must match
+    the pattern. The first rule is why, in the above code block, the
+    ``forward`` function has parameters ``x, w1, w2``, but the
+    ``pattern`` function only has parameters ``w1, w2``. ``pattern``
+    doesn't use ``x``, so it shouldn't specify ``x`` as a parameter.
+    As an example of the second rule, consider replacing
+
+    .. code-block:: python
+
+        def pattern(x, y):
+            return torch.neg(x) + torch.relu(y)
+
+    with
+
+    .. code-block:: python
+
+        def replacement(x, y):
+            return torch.relu(x)
+
+    In this case, ``replacement`` needs the same number of parameters
+    as ``pattern`` (both ``x`` and ``y``), even though the parameter
+    ``y`` isn't used in ``replacement``.
+
+    After calling ``subgraph_rewriter.replace_pattern``, the generated
+    Python code looks like this:
+
+    .. code-block:: python
+
+        def forward(self, x, w1, w2):
+            stack_1 = torch.stack([w1, w2])
+            sum_1 = stack_1.sum()
+            stack_2 = torch.stack([w1, w2])
+            sum_2 = stack_2.sum()
+            max_1 = torch.max(sum_1)
+            add_1 = x + max_1
+            max_2 = torch.max(sum_2)
+            add_2 = add_1 + max_2
+            return add_2
+    """
+    match_and_replacements = _replace_pattern(gm, pattern, replacement, match_filters)
+    return [
+        Match(anchor=m.anchor, nodes_map=m.nodes_map) for m in match_and_replacements
+    ]
+
+
+def _replace_pattern(
+    gm: GraphModule,
+    pattern: Union[Callable, GraphModule],
+    replacement: Union[Callable, GraphModule],
+    match_filters: List[Callable[["InternalMatch", Graph, Graph], bool]] = None,  # type: ignore[name-defined]
+) -> List[ReplacedPatterns]:
+
+    if match_filters is None:
+        match_filters = []
+
+    # Get the graphs for `gm`, `pattern`, `replacement`
+    original_graph: Graph = gm.graph
+
+    if isinstance(pattern, GraphModule):
+        pattern_graph = pattern.graph
+    else:
+        pattern_graph = symbolic_trace(pattern).graph
+
+    if isinstance(replacement, GraphModule):
+        replacement_graph = replacement.graph
+    else:
+        replacement_graph = symbolic_trace(replacement).graph
+    matcher = AITSubgraphMatcher(
+        pattern_graph,
+        match_output=False,
+        match_placeholder=False,
+        remove_overlapping_matches=True,
+    )
+
+    _matches: List[InternalMatch] = matcher.match(original_graph)
+    logger.info(f"matches = {_matches}")
+    # Filter out matches that don't match the filter
+    _matches = [
+        m
+        for m in _matches
+        if all(
+            match_filter(m, original_graph, pattern_graph)
+            for match_filter in match_filters
+        )
+    ]
+
+    replacement_placeholders = [
+        n for n in replacement_graph.nodes if n.op == "placeholder"
+    ]
+
+    # As we progressively replace nodes, we'll need to keep track of how the match results should change
+    match_changed_node: Dict[Node, Node] = {}
+
+    match_and_replacements = []
+    for match in _matches:
+
+        # Build connecting between replacement graph's input and original graph input producer node
+
+        # Initialize `val_map` with mappings from placeholder nodes in
+        # `replacement` to their corresponding node in `original_graph`
+        assert len(match.placeholder_nodes) == len(replacement_placeholders)
+        val_map: Dict[Node, Node] = {}
+        for rn, gn in zip(replacement_placeholders, match.placeholder_nodes):
+            if isinstance(gn, Node):
+                val_map[rn] = match_changed_node.get(gn, gn)
+            else:
+                val_map[rn] = gn
+
+        # Copy the replacement graph over
+        user_nodes: Set[Node] = set()
+        for n in match.returning_nodes:
+            for user in n.users:
+                user_nodes.add(user)
+        assert user_nodes, "The returning_nodes should have at least one user node"
+
+        if len(user_nodes) == 1:
+            first_user_node = list(user_nodes)[0]
+        else:
+            # If there are multiple user nodes, we need to find the first user node
+            # in the current execution order of the `original_graph`
+            for n in original_graph.nodes:
+                if n in user_nodes:
+                    first_user_node = n
+                    break
+
+        with original_graph.inserting_before(first_user_node):
+            copied_returning_nodes = original_graph.graph_copy(
+                replacement_graph, val_map
+            )
+
+        if isinstance(copied_returning_nodes, Node):
+            copied_returning_nodes = (copied_returning_nodes,)
+
+        # Get a list of nodes that have been replaced into the graph
+        replacement_nodes = []
+
+        def get_replacement_nodes(curr_node: Node):
+            nonlocal replacement_nodes
+            for arg in curr_node.args:
+                if isinstance(arg, Node):
+                    if arg not in val_map.values():
+                        get_replacement_nodes(arg)
+            replacement_nodes.append(curr_node)
+
+        for ret_node in copied_returning_nodes:
+            get_replacement_nodes(ret_node)
+
+        # Hook the output Node of the replacement subgraph in to the
+        # original Graph at the correct location
+        assert len(match.returning_nodes) == len(copied_returning_nodes)
+        for gn, copied_node in zip(match.returning_nodes, copied_returning_nodes):
+            gn.replace_all_uses_with(copied_node)
+            match_changed_node[gn] = copied_node
+        # Remove the original nodes
+        logger.info(f"Remove pattern node from original graph, match={match}")
+        for node in reversed(pattern_graph.nodes):
+            if (
+                node.op != "placeholder"
+                and node.op != "output"
+                and node.target != torch.ops.aten.sym_size
+            ):
+
+                gn = match.nodes_map[node]
+                gm.graph.erase_node(gn)
+        match_and_replacements.append(
+            ReplacedPatterns(
+                anchor=match.anchors[0],
+                nodes_map=match.nodes_map,
+                replacements=replacement_nodes,
+            )
+        )
+
+    # Update the passed-in GraphModule to reflect the new state of
+    # `original_graph`
+    gm.graph.eliminate_dead_code()
+    gm.recompile()
+    # If `replacement` was an nn.Module, we'll need to make sure that
+    # all the submodules have been copied over correctly
+    # if isinstance(replacement, torch.nn.Module):
+    #     _replace_submodules(gm, replacement)
+
+    return match_and_replacements


### PR DESCRIPTION
Summary:
1. fix some lib related path issues
2. add composition test for bmm
3. adopt the customize the `replace_pattern` from fx. The considerations are 1) simply some cases where we need to do pattern replacement. For ex., there are some MHA implementations which we want to recognize them and map to our MHA converter. 2) avoid sym_size comparison. For ex. we hope these two patterns are the same. One pattern is
`a = view(b, [sym_size_1, sym_size_2]) `
while the other pattern is
`a = view(b, [sym_size_1, 60]) `
5. getitem(slice) changed the trace behavior compared with our test in Dec.. It has more than 1 user in internmediate slice.Tensor. For ex. slice_5 has 2 users while it used to have 1.
```
slice_5 = torch.ops.aten.slice.Tensor(permute_pooled_embs_auto_grad, 0, 0, 9223372036854775807);  permute_pooled_embs_auto_grad = None
slice_6 = torch.ops.aten.slice.Tensor(slice_5, 1, 188, 2636)
sym_size = torch.ops.aten.sym_size(slice_5, 0);
```
After this diff,
```
aten_compose_getitem_slice_2 = fx2ait_passes_lower_basic_pass_aten_aten_compose_getitem_slice(permute_pooled_embs_auto_grad, [(0, 0, 9223372036854775807), (1, 188, 2636)]);
sym_size = torch.ops.aten.sym_size(aten_compose_getitem_slice_2, 0);
```

Reviewed By: wushirong, tissue3

Differential Revision: D43016248

