### PR TITLE
Add jagged Tensor support to fused_elementwise back-end

### DIFF
--- a/python/aitemplate/testing/jagged_utils.py
+++ b/python/aitemplate/testing/jagged_utils.py
@@ -1,0 +1,314 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import random
+from itertools import product
+from typing import List, Tuple
+
+import torch
+
+from aitemplate.testing.test_utils import get_torch_full_tensor
+from aitemplate.utils.torch_utils import string_to_torch_dtype, torch_dtype_to_string
+
+
+def _check_offsets(
+    offsets_list: List[List[int]],
+) -> None:
+    offsets_len = len(offsets_list[0])
+    for offsets in offsets_list:
+        assert offsets[0] == 0
+        assert len(offsets) == offsets_len
+        for j in range(1, len(offsets)):
+            assert offsets[j] >= offsets[j - 1]
+        offsets_len = offsets[-1] + 1
+
+
+def _get_preceding_offset_idx(
+    idx: int,
+    offsets: List[int],
+) -> Tuple[int, int]:
+    result = None
+    left, right = 0, len(offsets) - 1
+    while left <= right:
+        mid = (left + right) // 2
+        offset = offsets[mid]
+        if offset <= idx:
+            result = mid
+            left = mid + 1
+        else:
+            right = mid - 1
+
+    return result, offsets[result]
+
+
+def _jagged_idx_to_dense_idx(
+    jagged_idx: int,
+    offsets_list: List[List[int]],
+) -> List[int]:
+    assert jagged_idx < offsets_list[-1][-1]
+
+    result = []
+    for offsets in reversed(offsets_list):
+        offset_idx, offset = _get_preceding_offset_idx(
+            idx=jagged_idx,
+            offsets=offsets,
+        )
+        result.append(jagged_idx - offset)
+        jagged_idx = offset_idx
+    result.append(jagged_idx)
+
+    return list(reversed(result))
+
+
+def jagged_to_dense(
+    jagged: torch.Tensor,
+    offsets_list: List[torch.Tensor],
+    dense_shape: List[int],
+    padding_value: float = 0.0,
+) -> torch.Tensor:
+    """
+    Convert a jagged Tensor (with the offsets) into a dense Tensor.
+
+    The function converts a jagged Tensor (and the offsets) to
+    a rectangular dense Tensor, using the padding_value at the
+    positions of the resulting dense Tensor where the input
+    jagged Tensor doesn't have elements.
+
+    Parameters
+    ----------
+    jagged : torch.Tensor
+        The jagged Tensor with the shape `[total_length, D1, ..., Dm]`,
+        The first dimension, `total_length`, encodes the `batch_dim` and
+        the jagged dims of the jagged Tensor. The following m dimensions,
+        `D1, ..., Dm`, are regular dense dimensions following the jagged
+        dimensions of the jagged Tensor.
+
+    offsets_list : List[torch.Tensor]
+        A list of rank-1 Tensors, each representing the offsets along one
+        of the jagged dimensions of the jagged Tensor. The number of offsets
+        Tensors in the list must correspond to the number of jagged dimensions
+        encoded in the first `total_length` dimension of `jagged`. The offsets
+        Tensors must be consistent with the offset specification:
+
+            - batch_dim == len(offsets[0]) - 1
+            - offsets[i][-1] == len(offsets[i+1])) - 1
+            - offsets[-1][-1] == total_length
+
+    dense_shape : List[int]
+        The shape of the resulting dense Tensor. The last m dimensions in
+        the `dense_shape` must be equal to `[D1, ..., Dm]` in the jagged
+        Tensor shape. The first dimension must be the `batch_dim`. The
+        following n dimensions must correspond to the n jagged dimensions
+        of the jagged Tensor, with the values equal to the maximum possible
+        values of the jagged dimensions.
+
+    padding_value : float
+        The value to fill the dense Tensor with at the positions where
+        there are no elements in the jagged Tensor. Default: 0.0.
+
+    Returns
+    -------
+    torch.Tensor
+        The dense tensor with the `dense_shape` converted from the
+        `jagged` Tensor, with the `padding_value` at other positions.
+    """
+    assert all(t.dim() == 1 for t in offsets_list)
+    offsets_list = [list(t.cpu().numpy()) for t in offsets_list]
+
+    _check_offsets(offsets_list)
+    assert len(dense_shape) - len(jagged.shape) == len(offsets_list)
+    assert jagged.shape[1:] == tuple(dense_shape[1 + len(offsets_list) :])
+    for i, offsets in enumerate(offsets_list):
+        dense_dim = dense_shape[i + 1]
+        for j in range(1, len(offsets)):
+            assert offsets[j] - offsets[j - 1] <= dense_dim
+
+    dtype = torch_dtype_to_string(jagged.dtype)
+    result = get_torch_full_tensor(
+        shape=dense_shape,
+        fill_value=padding_value,
+        dtype=dtype,
+    )
+
+    total_length = jagged.shape[0]
+    for jagged_idx in range(total_length):
+        dense_idx = _jagged_idx_to_dense_idx(
+            jagged_idx=jagged_idx,
+            offsets_list=offsets_list,
+        )
+        result[tuple(dense_idx)] = jagged[jagged_idx]
+
+    return result
+
+
+def _dense_idx_to_jagged_idx(
+    dense_idx: List[int],
+    offsets_list: List[List[int]],
+) -> int:
+    assert len(dense_idx) == 1 + len(offsets_list)
+
+    offset = 0
+    for i, (d, offsets) in enumerate(zip(dense_idx, offsets_list)):
+        prev_offset, next_offset = offsets[offset + d : offset + d + 2]
+        group_size = next_offset - prev_offset
+        if dense_idx[i + 1] >= group_size:
+            return -1
+        offset = prev_offset
+    offset += dense_idx[-1]
+
+    return offset
+
+
+def dense_to_jagged(
+    dense: torch.Tensor,
+    offsets_list: List[torch.Tensor],
+    padding_value: float = 0.0,
+) -> torch.Tensor:
+    """
+    Convert a dense Tensor into a jagged Tensor (using the offsets).
+
+    The function converts a rectangular dense Tensor to a compactly
+    represented subset of its values: a jagged Tensor, using the offsets.
+    The padding_value is used at the positions of the resulting jagged
+    Tensor where the input dense Tensor doesn't have elements.
+
+    Parameters
+    ----------
+    dense : torch.Tensor
+        A Tensor with the shape `[batch_dim, N1, ..., Nn, D1, ..., Dm]`.
+        The first n+1 dimensions of the dense Tensor are encoded into
+        the first `total_length` dimension of the resulting jagged
+        Tensor, using the specified offsets. Importantly, the values in
+        the dense Tensor outside of what the offsets specify are omitted
+        in the resulting jagged Tensor.
+
+    offsets_list : List[torch.Tensor]
+        A list of rank-1 Tensors, each representing the offsets along one
+        of the jagged dimensions of the jagged Tensor. The number of offsets
+        Tensors in the list must correspond to the number of jagged dimensions
+        encoded in the first `total_length` dimension of the resulting jagged
+        Tensor. The offsets Tensors must be consistent with the offset
+        specification:
+
+            - batch_dim == len(offsets[0]) - 1
+            - offsets[i][-1] == len(offsets[i+1])) - 1
+            - offsets[-1][-1] == total_length
+
+    padding_value : float
+        The value to fill the jagged Tensor with at the positions where
+        there are no elements in the dense Tensor (e.g., the consecutive
+        offset difference is longer than the corresponding N dimension
+        in the dense Tensor input). Default: 0.0.
+
+    Returns
+    -------
+    torch.Tensor
+        The jagged tensor converted from the `dense` Tensor using
+        the offsets, with the `padding_value` at the positions
+        not available in the `dense` Tensor.
+    """
+    assert all(t.dim() == 1 for t in offsets_list)
+    offsets_list = [list(t.cpu().numpy()) for t in offsets_list]
+
+    _check_offsets(offsets_list)
+    assert len(offsets_list) < len(dense.shape)
+
+    total_length = offsets_list[-1][-1]
+    inner_shape = dense.shape[1 + len(offsets_list) :]
+    jagged_shape = [total_length, *inner_shape]
+
+    dtype = torch_dtype_to_string(dense.dtype)
+    result = get_torch_full_tensor(
+        shape=jagged_shape,
+        fill_value=padding_value,
+        dtype=dtype,
+    )
+
+    for dense_idx in product(*[range(d) for d in dense.shape[: 1 + len(offsets_list)]]):
+        jagged_idx = _dense_idx_to_jagged_idx(
+            dense_idx=dense_idx,
+            offsets_list=offsets_list,
+        )
+        if jagged_idx != -1:
+            result[jagged_idx] = dense[tuple(dense_idx)]
+
+    return result
+
+
+def generate_offsets(
+    batch_size: int,
+    max_seq_len: int,
+    load_factor: float,
+    offsets_dtype: str,
+    spread_radius: float = 0.1,
+) -> torch.Tensor:
+    """
+    Generate a rank-1 Tensor of offsets for the given load factor.
+
+    This function generates a single linear offset Tensor for a
+    single jagged dimension in a jagged Tensor with the batch_dim
+    equal to `batch_size` and maximum value along the jagged
+    dimension equal to `max_seq_len`. The `load_factor` in [0, 1]
+    specifies how "full" should the jagged Tensor described by
+    the resulting offsets should be, compared to the corresponding
+    dense Tensor with a rectangular shape [batch_size, max_seq_len,
+    D1, ..., Dm]. The offset differences (== the lengths along the
+    jagged dimensions) are sampled randomly, to arrive close (but not
+    necessarily equal) to the specified `load_factor` in total.
+
+    When sampled out of the [0, N] interval, the offset differences
+    are clamed to stay within the [0, N] interval.
+
+    Parameters
+    ----------
+    batch_size : int
+        The batch_dim of the jagged Tensor specified by the offsets.
+    max_seq_len : int
+        The maximum length along the jagged dimension specified by
+        the offsets.
+    load_factor : float
+        The fraction of the [batch_size, max_seq_len, D1, ..., Dm]-
+        shaped dense Tensor that the total (compactly represented)
+        jagged Tensor data should correspond to.
+    offsets_dtype : str
+        The type of the resulting offsets Tensor.
+    spread_radius : float
+        The radius of the spread around int(max_seq_len * load_factor)
+        that the offset differences should be randomly sampled from.
+        Default: 0.1.
+
+    Returns
+    -------
+    torch.Tensor
+        The resulting rank-1 Tensor of offsets.
+    """
+    assert 0 <= load_factor <= 1
+    assert 0 <= spread_radius <= 1
+
+    if load_factor < 1:
+        spread = int(max_seq_len * spread_radius)
+        mean = int(max_seq_len * load_factor)
+        lengths = [
+            mean + random.randint(-spread, spread + 1) for _ in range(batch_size)
+        ]
+        lengths = [max(min(L, max_seq_len), 0) for L in lengths]
+    else:
+        lengths = [max_seq_len] * batch_size
+
+    offsets = [0]
+    for length in lengths:
+        offsets.append(offsets[-1] + length)
+
+    torch_offsets_dtype = string_to_torch_dtype(offsets_dtype)
+    return torch.tensor(offsets, dtype=torch_offsets_dtype).cuda()

--- a/tests/unittest/ops/test_jagged_elementwise.py
+++ b/tests/unittest/ops/test_jagged_elementwise.py
@@ -1,0 +1,591 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import json
+import random
+import tempfile
+import unittest
+from typing import List
+
+import torch
+
+from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler.base import JaggedDim
+from aitemplate.compiler.ops.common.epilogue import FuncEnum
+from aitemplate.frontend import IntImm, IntVar, Tensor
+from aitemplate.testing import detect_target
+from aitemplate.testing.jagged_utils import (
+    dense_to_jagged,
+    generate_offsets,
+    jagged_to_dense,
+)
+from aitemplate.testing.test_utils import get_random_torch_tensor
+from aitemplate.utils.torch_utils import string_to_torch_dtype
+from parameterized import param, parameterized
+
+
+def _add_jagged_dense_ref(
+    jagged: torch.Tensor,
+    offsets_list: List[torch.Tensor],
+    dense: torch.Tensor,
+    jagged_max_shape: List[int] = None,
+) -> torch.Tensor:
+    """The reference function for jagged / dense elementwise add."""
+    if jagged_max_shape is None:
+        jagged_max_shape = dense.shape
+
+    assert len(jagged.shape) + len(offsets_list) >= len(dense.shape)
+    assert len(jagged_max_shape) == len(jagged.shape) + len(offsets_list)
+
+    return dense_to_jagged(
+        dense=(
+            dense
+            + jagged_to_dense(
+                jagged=jagged,
+                offsets_list=offsets_list,
+                dense_shape=jagged_max_shape,
+                padding_value=0.0,
+            )
+        ),
+        offsets_list=offsets_list,
+        padding_value=-1.0,
+    )
+
+
+class JaggedElementwiseTestCase(unittest.TestCase):
+    def _test_jagged_dense_elementwise_add(
+        self,
+        jagged_max_shape: List[int],
+        offsets_list: List[List[int]],
+        dense_shape: List[int],
+        dtype: str = "float16",
+        offsets_dtype: str = "int32",
+        use_jagged_space_indexing: bool = False,
+        test_suffix: str = "",
+    ):
+        batch_size = jagged_max_shape[0]
+        batch_dim = IntVar(values=[1, batch_size * 2], name="batch_size")
+
+        jagged_dims_max_values = jagged_max_shape[1 : 1 + len(offsets_list)]
+        jagged_dims = [
+            JaggedDim(min_value=0, max_value=max_value)
+            for max_value in jagged_dims_max_values
+        ]
+
+        total_length = offsets_list[-1][-1]
+        total_length_dim = IntVar(values=[1, total_length * 2], name="total_length")
+
+        jagged_inner_shape = jagged_max_shape[1 + len(offsets_list) :]
+        jagged_inner_dims = [IntImm(dim) for dim in jagged_inner_shape]
+        jagged_input_shape = [total_length] + jagged_inner_shape
+
+        offsets_dims = [
+            IntVar(values=[2, len(offsets) * 2]) for offsets in offsets_list
+        ]
+
+        assert len(dense_shape) <= len(jagged_max_shape)
+        dense_dims = [IntImm(dim) for dim in dense_shape]
+        if len(dense_shape) == len(jagged_max_shape):
+            assert dense_shape[0] == jagged_max_shape[0]
+            dense_dims[0] = batch_dim
+
+        SOURCE = Tensor(
+            shape=[
+                total_length_dim,
+                *jagged_inner_dims,
+            ],
+            name="source",
+            dtype=dtype,
+            is_input=True,
+        )
+        OFFSETS_LIST = [
+            Tensor(
+                shape=[
+                    offsets_dim,
+                ],
+                name=f"offsets{i}",
+                dtype=offsets_dtype,
+                is_input=True,
+            )
+            for i, offsets_dim in enumerate(offsets_dims)
+        ]
+        DENSE = Tensor(
+            shape=dense_dims,
+            name="dense",
+            dtype=dtype,
+            is_input=True,
+        )
+
+        JAGGED = ops.make_jagged(
+            batch_dim=batch_dim,
+            jagged_dims=jagged_dims,
+        )(SOURCE, OFFSETS_LIST)
+
+        RESULT = ops.elementwise(FuncEnum.ADD)(JAGGED, DENSE)
+
+        RESULT._attrs["name"] = "result"
+        RESULT._attrs["is_output"] = True
+
+        assert not SOURCE.is_jagged()
+        assert not DENSE.is_jagged()
+        assert JAGGED.is_jagged()
+        assert RESULT.is_jagged()
+
+        model = compile_model(
+            [RESULT],
+            detect_target(use_jagged_space_indexing=use_jagged_space_indexing),
+            "./tmp",
+            f"test_jagged_dense_elementwise_add_{test_suffix}",
+        )
+
+        torch_offsets_dtype = string_to_torch_dtype(offsets_dtype)
+        offsets_pt = {
+            f"offsets{i}": torch.tensor(offsets, dtype=torch_offsets_dtype).cuda()
+            for i, offsets in enumerate(offsets_list)
+        }
+        source_pt = get_random_torch_tensor(jagged_input_shape, dtype)
+        dense_pt = get_random_torch_tensor(dense_shape, dtype)
+        result_pt = _add_jagged_dense_ref(
+            jagged=source_pt,
+            offsets_list=list(offsets_pt.values()),
+            jagged_max_shape=jagged_max_shape,
+            dense=dense_pt,
+        )
+        result = torch.empty_like(result_pt)
+
+        inputs = {"source": source_pt, "dense": dense_pt, **offsets_pt}
+        model.run_with_tensors(inputs, [result])
+
+        torch.testing.assert_close(result, result_pt)
+
+    @parameterized.expand(
+        [
+            param(1, "int32", [4, 3, 4], [4, 3, 4]),
+            param(2, "int32", [4, 3, 2], [4, 3, 1]),
+            param(3, "int32", [4, 3, 1], [4, 3, 2]),
+            param(4, "int32", [4, 3, 2], [4, 1, 1]),
+            param(5, "int32", [4, 3, 2], [3, 1]),
+            param(6, "int64", [4, 3, 1], [2]),
+            param(7, "int64", [4, 3, 5, 6, 8], [4, 3, 5, 6, 8]),
+            param(8, "int64", [4, 3, 1, 6, 1], [4, 3, 5, 1, 8]),
+            param(9, "int64", [4, 3, 1, 6, 1], [4, 1, 1, 1, 1]),
+            param(10, "int64", [4, 3, 1, 1, 2], [3, 5, 6, 2]),
+        ]
+    )
+    def test_jagged_dense_elementise_add_single_offsets_fp16(
+        self,
+        i,
+        offsets_dtype,
+        jagged_max_shape,
+        dense_shape,
+    ):
+        for use_jagged_space_indexing in [False, True]:
+            self._test_jagged_dense_elementwise_add(
+                jagged_max_shape=jagged_max_shape,
+                offsets_list=[[0, 1, 4, 6, 7]],
+                dense_shape=dense_shape,
+                dtype="float16",
+                offsets_dtype=offsets_dtype,
+                use_jagged_space_indexing=use_jagged_space_indexing,
+                test_suffix=f"single_offsets_fp16_{i}_{use_jagged_space_indexing}",
+            )
+
+    @parameterized.expand(
+        [
+            param(1, "int32", [3, 4, 5, 150, 3, 4], [3, 4, 5, 150, 3, 4]),
+            param(2, "int32", [3, 4, 5, 150, 1, 4], [3, 4, 5, 150, 3, 1]),
+            param(3, "int32", [3, 4, 5, 150, 3, 4], [1]),
+            param(4, "int64", [3, 4, 5, 150, 1, 1], [150, 3, 4]),
+            param(5, "int64", [3, 4, 5, 150, 3, 4], [3, 1, 1, 1, 1, 1]),
+        ]
+    )
+    def test_jagged_dense_elementise_add_multiple_offsets_fp16(
+        self,
+        i,
+        offsets_dtype,
+        jagged_max_shape,
+        dense_shape,
+    ):
+        for use_jagged_space_indexing in [False, True]:
+            self._test_jagged_dense_elementwise_add(
+                jagged_max_shape=jagged_max_shape,
+                offsets_list=[
+                    [0, 1, 3, 5],
+                    [0, 2, 4, 7, 9, 10],
+                    [0, 6, 8, 19, 23, 45, 67, 98, 123, 256, 321],
+                ],
+                dense_shape=dense_shape,
+                dtype="float16",
+                offsets_dtype=offsets_dtype,
+                use_jagged_space_indexing=use_jagged_space_indexing,
+                test_suffix=f"multiple_offsets_fp16_{i}_{use_jagged_space_indexing}",
+            )
+
+    @parameterized.expand(
+        [
+            param(1, "int32", [4, 3, 2], [4, 3, 2]),
+            param(2, "int64", [4, 3, 5, 6, 7], [4, 3, 5, 6, 7]),
+            param(3, "int64", [4, 3, 1, 1, 1], [3, 5, 6, 7]),
+        ]
+    )
+    def test_jagged_dense_elementise_add_single_offsets_fp32(
+        self,
+        i,
+        offsets_dtype,
+        jagged_max_shape,
+        dense_shape,
+    ):
+        self._test_jagged_dense_elementwise_add(
+            jagged_max_shape=jagged_max_shape,
+            offsets_list=[[0, 1, 4, 6, 7]],
+            dense_shape=dense_shape,
+            dtype="float32",
+            offsets_dtype=offsets_dtype,
+            use_jagged_space_indexing=False,
+            test_suffix=f"single_offsets_fp32_{i}",
+        )
+
+    @parameterized.expand(
+        [
+            param(1, "int32", [3, 4, 5, 150, 3, 4], [3, 4, 5, 150, 3, 4]),
+            param(2, "int64", [3, 4, 5, 150, 1, 1], [150, 3, 4]),
+        ]
+    )
+    def test_jagged_dense_elementise_add_multiple_offsets_fp32(
+        self,
+        i,
+        offsets_dtype,
+        jagged_max_shape,
+        dense_shape,
+    ):
+        self._test_jagged_dense_elementwise_add(
+            jagged_max_shape=jagged_max_shape,
+            offsets_list=[
+                [0, 1, 3, 5],
+                [0, 2, 4, 7, 9, 10],
+                [0, 6, 8, 19, 23, 45, 67, 98, 123, 256, 321],
+            ],
+            dense_shape=dense_shape,
+            dtype="float32",
+            offsets_dtype=offsets_dtype,
+            use_jagged_space_indexing=False,
+            test_suffix=f"multiple_offsets_fp32_{i}",
+        )
+
+    def _test_jagged_jagged_elementwise_add(
+        self,
+        jagged_max_prefix_shape: List[int],
+        jagged1_inner_shape: List[int],
+        jagged2_inner_shape: List[int],
+        offsets_list: List[List[int]],
+        dtype: str = "float16",
+        offsets_dtype: str = "int32",
+        test_suffix: str = "",
+    ):
+        assert len(jagged1_inner_shape) == len(jagged2_inner_shape)
+
+        batch_size = jagged_max_prefix_shape[0]
+        batch_dim = IntVar(values=[1, batch_size * 2], name="batch_size")
+
+        jagged_dims_max_values = jagged_max_prefix_shape[1 : 1 + len(offsets_list)]
+        jagged_dims = [
+            JaggedDim(min_value=0, max_value=max_value)
+            for max_value in jagged_dims_max_values
+        ]
+
+        total_length = offsets_list[-1][-1]
+        total_length_dim = IntVar(values=[1, total_length * 2], name="total_length")
+
+        jagged1_inner_dims = [IntImm(dim) for dim in jagged1_inner_shape]
+        jagged1_input_shape = [total_length] + jagged1_inner_shape
+        jagged2_inner_dims = [IntImm(dim) for dim in jagged2_inner_shape]
+        jagged2_input_shape = [total_length] + jagged2_inner_shape
+
+        offsets_dims = [
+            IntVar(values=[2, len(offsets) * 2]) for offsets in offsets_list
+        ]
+
+        SOURCE1 = Tensor(
+            shape=[
+                total_length_dim,
+                *jagged1_inner_dims,
+            ],
+            name="source1",
+            dtype=dtype,
+            is_input=True,
+        )
+        SOURCE2 = Tensor(
+            shape=[
+                total_length_dim,
+                *jagged2_inner_dims,
+            ],
+            name="source2",
+            dtype=dtype,
+            is_input=True,
+        )
+        OFFSETS_LIST = [
+            Tensor(
+                shape=[
+                    offsets_dim,
+                ],
+                name=f"offsets{i}",
+                dtype=offsets_dtype,
+                is_input=True,
+            )
+            for i, offsets_dim in enumerate(offsets_dims)
+        ]
+
+        JAGGED1 = ops.make_jagged(
+            batch_dim=batch_dim,
+            jagged_dims=jagged_dims,
+        )(SOURCE1, OFFSETS_LIST)
+        JAGGED2 = ops.make_jagged(
+            batch_dim=batch_dim,
+            jagged_dims=jagged_dims,
+        )(SOURCE2, OFFSETS_LIST)
+
+        RESULT = ops.elementwise(FuncEnum.ADD)(JAGGED1, JAGGED2)
+
+        RESULT._attrs["name"] = "result"
+        RESULT._attrs["is_output"] = True
+
+        assert not SOURCE1.is_jagged()
+        assert not SOURCE2.is_jagged()
+        assert JAGGED1.is_jagged()
+        assert JAGGED2.is_jagged()
+        assert RESULT.is_jagged()
+
+        model = compile_model(
+            [RESULT],
+            detect_target(),
+            "./tmp",
+            f"test_jagged_jagged_elementwise_add_{test_suffix}",
+        )
+
+        torch_offsets_dtype = string_to_torch_dtype(offsets_dtype)
+        offsets_pt = {
+            f"offsets{i}": torch.tensor(offsets, dtype=torch_offsets_dtype).cuda()
+            for i, offsets in enumerate(offsets_list)
+        }
+        source1_pt = get_random_torch_tensor(jagged1_input_shape, dtype)
+        source2_pt = get_random_torch_tensor(jagged2_input_shape, dtype)
+        result_pt = source1_pt + source2_pt  # jagged inputs are treated as dense
+        result = torch.empty_like(result_pt)
+
+        inputs = {"source1": source1_pt, "source2": source2_pt, **offsets_pt}
+        model.run_with_tensors(inputs, [result])
+
+        torch.testing.assert_close(result, result_pt)
+
+    @parameterized.expand(
+        [
+            param(1, "int32", [4, 3], [5], [5]),
+            param(2, "int32", [4, 3], [5], [1]),
+            param(3, "int64", [4, 3], [1], [5]),
+            param(4, "int64", [4, 3], [5, 1, 7], [1, 6, 1]),
+        ]
+    )
+    def test_jagged_jagged_elementise_add_single_offsets_fp16(
+        self,
+        i,
+        offsets_dtype,
+        jagged_max_prefix_shape,
+        jagged1_inner_shape,
+        jagged2_inner_shape,
+    ):
+        self._test_jagged_jagged_elementwise_add(
+            jagged_max_prefix_shape=jagged_max_prefix_shape,
+            jagged1_inner_shape=jagged1_inner_shape,
+            jagged2_inner_shape=jagged2_inner_shape,
+            offsets_list=[[0, 1, 4, 6, 7]],
+            dtype="float16",
+            offsets_dtype=offsets_dtype,
+            test_suffix=f"single_offsets_fp16_{i}",
+        )
+
+    @parameterized.expand(
+        [
+            param(1, "int32", [3, 4, 5, 200], [10], [10]),
+            param(2, "int32", [3, 4, 5, 200], [1, 2], [2, 1]),
+            param(3, "int64", [3, 4, 5, 150], [6, 7, 8], [6, 7, 8]),
+            param(4, "int64", [3, 4, 5, 150], [6, 1, 8], [1, 7, 1]),
+        ]
+    )
+    def test_jagged_jagged_elementise_add_multiple_offsets_fp16(
+        self,
+        i,
+        offsets_dtype,
+        jagged_max_prefix_shape,
+        jagged1_inner_shape,
+        jagged2_inner_shape,
+    ):
+        self._test_jagged_jagged_elementwise_add(
+            jagged_max_prefix_shape=jagged_max_prefix_shape,
+            jagged1_inner_shape=jagged1_inner_shape,
+            jagged2_inner_shape=jagged2_inner_shape,
+            offsets_list=[
+                [0, 1, 3, 5],
+                [0, 2, 4, 7, 9, 10],
+                [0, 6, 8, 19, 23, 45, 67, 98, 123, 256, 321],
+            ],
+            dtype="float16",
+            offsets_dtype=offsets_dtype,
+            test_suffix=f"multiple_offsets_fp16_{i}",
+        )
+
+    def _benchmark_jagged_dense_elementwise_add(
+        self,
+        B: int,
+        N: int,
+        D: int,
+        num_dense_inputs: int,
+        dtype: str = "float16",
+        offsets_dtype: str = "int32",
+        use_jagged_space_indexing: bool = False,
+        test_suffix: str = "",
+        num_iters: int = 1000,
+    ):
+        batch_dim = IntVar(values=[1, B], name="batch_size")
+        jagged_dim = JaggedDim(min_value=0, max_value=N)
+        total_length_dim = IntVar(values=[1, B * N], name="total_length")
+        sequence_dim = IntImm(value=N, name="sequence_dim")
+        embedding_dim = IntImm(value=D, name="embedding_dim")
+        offsets_dim = IntVar(values=[2, B + 1], name="offsets_dim")
+
+        SOURCE = Tensor(
+            shape=[
+                total_length_dim,
+                embedding_dim,
+            ],
+            name="source",
+            dtype=dtype,
+            is_input=True,
+        )
+        OFFSETS_LIST = [
+            Tensor(
+                shape=[
+                    offsets_dim,
+                ],
+                name="offsets",
+                dtype=offsets_dtype,
+                is_input=True,
+            )
+        ]
+        DENSE_INPUTS = [
+            Tensor(
+                shape=[
+                    batch_dim,
+                    sequence_dim,
+                    embedding_dim,
+                ],
+                name=f"dense_{i}",
+                dtype=dtype,
+                is_input=True,
+            )
+            for i in range(num_dense_inputs)
+        ]
+
+        JAGGED = ops.make_jagged(
+            batch_dim=batch_dim,
+            jagged_dims=[jagged_dim],
+        )(SOURCE, OFFSETS_LIST)
+
+        RESULT = JAGGED
+        for DENSE in DENSE_INPUTS:
+            RESULT = ops.elementwise(FuncEnum.ADD)(RESULT, DENSE)
+
+        RESULT._attrs["name"] = "result"
+        RESULT._attrs["is_output"] = True
+
+        model = compile_model(
+            [RESULT],
+            detect_target(use_jagged_space_indexing=use_jagged_space_indexing),
+            "./tmp",
+            f"benchmark_jagged_dense_elementwise_add_{test_suffix}",
+        )
+
+        random.seed(0)
+        load_factors = [i / 20 for i in range(1, 21)]
+        offset_tensors = [
+            generate_offsets(
+                batch_size=B,
+                max_seq_len=N,
+                load_factor=load_factor,
+                offsets_dtype=offsets_dtype,
+            )
+            for load_factor in load_factors
+        ]
+
+        results = []
+        for load_factor, offsets_pt in zip(load_factors, offset_tensors):
+            total_length = offsets_pt[-1].item()
+            dense_inputs_pt = {
+                f"dense_{i}": get_random_torch_tensor([B, N, D], dtype)
+                for i in range(num_dense_inputs)
+            }
+            source_pt = get_random_torch_tensor([total_length, D], dtype)
+            inputs = {"source": source_pt, **dense_inputs_pt, "offsets": offsets_pt}
+            outputs = [torch.empty_like(source_pt)]
+
+            with tempfile.NamedTemporaryFile("r") as f:
+                model.profile_with_tensors(
+                    inputs=inputs,
+                    outputs=outputs,
+                    num_iters=num_iters,
+                    filename=f.name,
+                )
+                profiling_data = json.loads(f.read())
+                fused_elementwise_records = [
+                    profiling_data[func_name]
+                    for func_name in profiling_data
+                    if func_name.startswith("fused_elementwise")
+                ]
+                assert len(fused_elementwise_records) == 1
+                runtime_ms = fused_elementwise_records[0]["ms_per_iter"]
+
+            items = total_length * D  # total items to read / write: the jagged volume
+            size = 2 if dtype == "float16" else 4  # size of individual data value
+            io_num = num_dense_inputs + 2  # num_dense_inputs + 1 inputs, 1 output
+            bandwidth = io_num * items * size / (runtime_ms * 1e-3 * 1e9)  # GB/s
+            results.append([load_factor, runtime_ms, bandwidth])
+
+        print()
+        print(f"{B=}, {N=}, {D=}, {num_dense_inputs=}, {dtype=}:")
+        print()
+
+        for load_factor, runtime_ms, bandwidth in results:
+            print(
+                f"load factor: {int(load_factor * 100)}%, "
+                f"runtime: {round(runtime_ms, 6)} ms, "
+                f"bandwidth: {round(bandwidth, 3)} GB/s"
+            )
+
+    def _test_benchmark_jagged_dense_elementise_add(self):
+        # ESUHM use case: "jagged + dense + dense = jagged",
+        # with dtype=float16; https://fburl.com/code/1e9z83fb
+        self._benchmark_jagged_dense_elementwise_add(
+            B=1024,
+            N=260,
+            D=256,
+            num_dense_inputs=2,
+            dtype="float16",
+            offsets_dtype="int32",
+            use_jagged_space_indexing=False,
+            test_suffix="esuhm",
+        )
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    unittest.main()


### PR DESCRIPTION
Summary:
In this diff, the `fused_elementwise` back-end is extended to support mixed jagged Tensor / dense Tensor inputs, along with all the pre-existing features of the back-end (broadcasting, vectorized I/O, nested expression generation, etc.). The added functionality should be orthogonal to the existing one. The diff also adds a few Python / PyTorch-based tools in the `testing/jagged_utils.py` that can be used for reference computation in future jagged-aware ops' unit tests.

## Implementation Details

When `fused_elementwise` has are only jagged inputs, only dense inputs, or the highest-rank dense input shape does not overlap with the jagged dimensions of the jagged inputs (i.e., with the `JaggedIntVar` in the jagged input shape), all jagged inputs are treated as dense (with the first `total_length` dimension followed by non-jagged dimensions), and the implementation relies on the pre-existing back-end implementation for simplicity and efficiency.

For the cases when the shape of at least one of the dense inputs overlaps with the jagged dimensions of the jagged inputs, the semantics of the elementwise operation is that the elements of the jagged inputs are used in computation together with the elements of the dense inputs at the corresponding positions. Consequently, the elements in the dense inputs not having the counterparts in the jagged inputs are ignored. (It is assumed that the dense inputs can either be broadcasted to or always have elements where the jagged inputs do.)

This suggests at least two possible approaches to the kernel implementation, both of which are included in this diff:

- In the **dense space indexing**, the kernel is launched on the `num_elements` in the dense output volume: the smallest rectangular volume that fits the jagged outputs (as well as all the dense and jagged inputs, by assumption of the front-end). The flat `dense_idx` for accessing the dense inputs is readily available from the CUDA indices (`blockIdx` / `threadIdx`). The flat `jagged_idx` for accessing the jagged inputs and outputs is computed from the `dense_idx` using the `offsets` of the jagged inputs / outputs (see the `KERNEL_COMPUTE_DENSE_IDX_THEN_JAGGED_IDX_TEMPLATE` for the details of the index computation). The `jagged_idx` computation requires accessing the `offsets` only once (at two consecutive positions), which leads to `O(1)` reading of the `offsets`. If it turns out that the jagged output does not have an element corresponding to a certain `dense_idx`, the thread returns prematurely.

- In the **jagged space indexing**, the kernel is launched on the `num_elements` in the jagged output shape: the `total_length` dimension followed by the dense dimensions in the jagged output (there can be more than one). The flat `jagged_idx` is readily available from the CUDA indices. The flat `dense_idx` is computed from the `jagged_idx` using the `offsets` of the jagged inputs / outputs (see the `KERNEL_COMPUTE_JAGGED_IDX_THEN_DENSE_IDX_TEMPLATE` for the details of the index computation). The `dense_idx` is computed using binary search within the `offsets` array, hence the `offsets` are read `O(log n)` times in each thread (with `n` being the length of the `offsets`).

The two approaches offer a trade-off:

- The dense space indexing runs in the dense output volume. Therefore, the number of threads may, in general, be much larger than the number of elements in the jagged output Tensors; and there may be many threads that return prematurely without doing any work. The index computation, on the other hand, is simple and lightweight.

- The jagged space indexing runs in the jagged output shape. As a result, the number of threads equals (up to the fixed gap of `FUSED_ELE_THREAD_SIZE`) to the number of elements in the jagged output Tensors; and (almost) each thread does meaningful work. But the binary search-based index computation may be heavy.

Differential Revision: D43482363

