### PR TITLE
Add a util function to filter test cases by test environment.

### DIFF
--- a/python/aitemplate/testing/test_utils.py
+++ b/python/aitemplate/testing/test_utils.py
@@ -15,14 +15,85 @@
 """
 Utils for unit tests.
 """
-from typing import Any, Dict, List, Optional
+import itertools
+import unittest
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 import torch
 
 from aitemplate.compiler.base import IntImm, IntVar, Operator, Tensor
 from aitemplate.compiler.dtype import normalize_dtype
+from aitemplate.testing.detect_target import detect_target
 from aitemplate.utils.graph_utils import get_sorted_ops
 from aitemplate.utils.torch_utils import string_to_torch_dtype
+
+
+class TestEnv(Enum):
+    CUDA_LESS_THAN_SM80 = 1
+    CUDA_SM80 = 2
+    ROCM = 100
+
+
+def _ROCM_filter(method_name: str) -> bool:
+    return method_name.endswith("rocm")
+
+
+def _SM80_filter(method_name: str) -> bool:
+    return method_name.endswith("bf16") or method_name.endswith("sm80")
+
+
+_TEST_ENV_TO_FILTER_METHOD: Dict[str, Callable[[str], bool]] = {
+    TestEnv.CUDA_LESS_THAN_SM80: (
+        lambda method_name: not (_SM80_filter(method_name) or _ROCM_filter(method_name))
+    ),
+    TestEnv.CUDA_SM80: _SM80_filter,
+    TestEnv.ROCM: _ROCM_filter,
+}
+
+
+def _get_test_env(target) -> str:
+    test_env = ""
+    if target.name() == "cuda":
+        if int(target._arch) < 80:
+            test_env = TestEnv.CUDA_LESS_THAN_SM80
+        elif int(target._arch) == 80:
+            test_env = TestEnv.CUDA_SM80
+        else:
+            raise RuntimeError(
+                f"Unknown test env, target: {target.name}, {target._arch}"
+            )
+    elif target.name() == "rocm":
+        test_env = TestEnv.ROCM
+    else:
+        raise RuntimeError(f"Unknown test env, target: {target.name}, {target._arch}")
+    if test_env not in _TEST_ENV_TO_FILTER_METHOD:
+        raise RuntimeError(f"{test_env=} not defined in _TEST_ENV_TO_FILTER_METHOD")
+    return test_env
+
+
+def filter_test_cases_by_params(params: Dict[TestEnv, List[Tuple[Any]]]):
+    """Filters test cases to run by given params. Only takes effect in CI env."""
+    target = detect_target()
+    test_env = _get_test_env(target)
+    return (
+        params.get(test_env, [])
+        if target.in_ci_env()
+        else list(itertools.chain.from_iterable(params.values()))
+    )
+
+
+def filter_test_cases_by_test_env(cls: Type[unittest.TestCase]):
+    """Filters test cases to run by test case names implicitly. Only takes effect in CI env."""
+    target = detect_target()
+    test_env = _get_test_env(target)
+    for attr in list(cls.__dict__.keys()):
+        if (
+            attr.startswith("test_")
+            and target.in_ci_env()
+            and (not _TEST_ENV_TO_FILTER_METHOD.get(test_env)(attr))
+        ):
+            delattr(cls, attr)
 
 
 def _get_torch_tensor(torch_fn, shape, dtype):

--- a/tests/unittest/ops/test_layernorm.py
+++ b/tests/unittest/ops/test_layernorm.py
@@ -24,6 +24,7 @@ from aitemplate.compiler import compile_model, ops
 from aitemplate.compiler.base import IntImm, IntVar
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
+from aitemplate.testing.test_utils import filter_test_cases_by_test_env
 from aitemplate.utils.torch_utils import string_to_torch_dtype
 
 
@@ -181,6 +182,8 @@ class LayernormTestCase(unittest.TestCase):
             MS=(16, 8, 4), NS=(2, 4, 32), dtype="bfloat16", atol=1e-2, rtol=1e-2
         )
 
+
+filter_test_cases_by_test_env(LayernormTestCase)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest/ops/test_softmax.py
+++ b/tests/unittest/ops/test_softmax.py
@@ -23,6 +23,7 @@ from aitemplate.compiler import compile_model, ops
 from aitemplate.compiler.base import IntVar
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
+from aitemplate.testing.test_utils import filter_test_cases_by_params, TestEnv
 from aitemplate.utils.torch_utils import string_to_torch_dtype
 from parameterized import parameterized
 
@@ -63,52 +64,58 @@ class SoftmaxTestCase(unittest.TestCase):
             torch.testing.assert_close(y_pt, y, atol=1e-2, rtol=1e-2)
 
     @parameterized.expand(
-        [
-            ("dim_1_fp16", "float16", (1, 1024), (6,), 1),
-            ("odd_small_fp16", "float16", (1, 13), (11,)),
-            ("odd_mid_fp16", "float16", (1, 4096), (33,)),
-            ("odd_large_fp16", "float16", (2, 31), (1409,)),
-            ("k2_small_fp16", "float16", (1, 1024), (18,)),
-            ("k2_mid_fp16", "float16", (2, 21), (66,)),
-            ("k2_large_fp16", "float16", (2, 21), (1154,)),
-            ("k4_small_fp16", "float16", (10, 1025), (124,)),
-            ("k4_mid_fp16", "float16", (1, 17), (132,)),
-            ("k4_large_fp16", "float16", (1, 17), (1924,)),
-            ("k8_small_fp16", "float16", (10, 1025), (72,)),
-            ("k8_mid_fp16", "float16", (1, 17), (264,)),
-            ("k8_large_fp16", "float16", (1, 17), (3848,)),
-            ("no_smem_fp16", "float16", (1, 2), (12500,)),
-            ("2d", "float16", (1, 2), (100, 100)),
-            ("3d", "float16", (1, 2), (24, 2, 64)),
-            ("dim_1_fp32", "float32", (1, 2), (6,), 1),
-            ("odd_small_fp32", "float32", (1, 2), (11,)),
-            ("odd_mid_fp32", "float32", (1, 2), (33,)),
-            ("odd_large_fp32", "float32", (1, 2), (1409,)),
-            ("k2_small_fp32", "float32", (1, 2), (18,)),
-            ("k2_mid_fp32", "float32", (1, 2), (66,)),
-            ("k2_large_fp32", "float32", (1, 2), (1154,)),
-            ("k4_small_fp32", "float32", (1, 2), (124,)),
-            ("k4_mid_fp32", "float32", (1, 2), (132,)),
-            ("k4_large_fp32", "float32", (1, 2), (1924,)),
-            ("k8_small_fp32", "float32", (1, 2), (72,)),
-            ("k8_mid_fp32", "float32", (1, 2), (264,)),
-            ("k8_large_fp32", "float32", (1, 2), (3848,)),
-            ("no_smem_fp32", "float32", (1, 2), (12500,)),
-            ("dim_1_bf16", "bfloat16", (1, 2), (6,), 1),
-            ("odd_small_bf16", "bfloat16", (1, 2), (11,)),
-            ("odd_mid_bf16", "bfloat16", (1, 2), (33,)),
-            ("odd_large_bf16", "bfloat16", (1, 2), (1409,)),
-            ("k2_small_bf16", "bfloat16", (1, 2), (18,)),
-            ("k2_mid_bf16", "bfloat16", (1, 2), (66,)),
-            ("k2_large_bf16", "bfloat16", (1, 2), (1154,)),
-            ("k4_small_bf16", "bfloat16", (1, 2), (124,)),
-            ("k4_mid_bf16", "bfloat16", (1, 2), (132,)),
-            ("k4_large_bf16", "bfloat16", (1, 2), (1924,)),
-            ("k8_small_bf16", "bfloat16", (1, 2), (72,)),
-            ("k8_mid_bf16", "bfloat16", (1, 2), (264,)),
-            ("k8_large_bf16", "bfloat16", (1, 2), (3848,)),
-            ("no_smem_bf16", "bfloat16", (1, 2), (12500,)),
-        ]
+        filter_test_cases_by_params(
+            {
+                TestEnv.CUDA_LESS_THAN_SM80: [
+                    ("dim_1_fp16", "float16", (1, 1024), (6,), 1),
+                    ("odd_small_fp16", "float16", (1, 13), (11,)),
+                    ("odd_mid_fp16", "float16", (1, 4096), (33,)),
+                    ("odd_large_fp16", "float16", (2, 31), (1409,)),
+                    ("k2_small_fp16", "float16", (1, 1024), (18,)),
+                    ("k2_mid_fp16", "float16", (2, 21), (66,)),
+                    ("k2_large_fp16", "float16", (2, 21), (1154,)),
+                    ("k4_small_fp16", "float16", (10, 1025), (124,)),
+                    ("k4_mid_fp16", "float16", (1, 17), (132,)),
+                    ("k4_large_fp16", "float16", (1, 17), (1924,)),
+                    ("k8_small_fp16", "float16", (10, 1025), (72,)),
+                    ("k8_mid_fp16", "float16", (1, 17), (264,)),
+                    ("k8_large_fp16", "float16", (1, 17), (3848,)),
+                    ("no_smem_fp16", "float16", (1, 2), (12500,)),
+                    ("2d", "float16", (1, 2), (100, 100)),
+                    ("3d", "float16", (1, 2), (24, 2, 64)),
+                    ("dim_1_fp32", "float32", (1, 2), (6,), 1),
+                    ("odd_small_fp32", "float32", (1, 2), (11,)),
+                    ("odd_mid_fp32", "float32", (1, 2), (33,)),
+                    ("odd_large_fp32", "float32", (1, 2), (1409,)),
+                    ("k2_small_fp32", "float32", (1, 2), (18,)),
+                    ("k2_mid_fp32", "float32", (1, 2), (66,)),
+                    ("k2_large_fp32", "float32", (1, 2), (1154,)),
+                    ("k4_small_fp32", "float32", (1, 2), (124,)),
+                    ("k4_mid_fp32", "float32", (1, 2), (132,)),
+                    ("k4_large_fp32", "float32", (1, 2), (1924,)),
+                    ("k8_small_fp32", "float32", (1, 2), (72,)),
+                    ("k8_mid_fp32", "float32", (1, 2), (264,)),
+                    ("k8_large_fp32", "float32", (1, 2), (3848,)),
+                    ("no_smem_fp32", "float32", (1, 2), (12500,)),
+                ],
+                TestEnv.CUDA_SM80: [
+                    ("dim_1_bf16", "bfloat16", (1, 2), (6,), 1),
+                    ("odd_small_bf16", "bfloat16", (1, 2), (11,)),
+                    ("odd_mid_bf16", "bfloat16", (1, 2), (33,)),
+                    ("odd_large_bf16", "bfloat16", (1, 2), (1409,)),
+                    ("k2_small_bf16", "bfloat16", (1, 2), (18,)),
+                    ("k2_mid_bf16", "bfloat16", (1, 2), (66,)),
+                    ("k2_large_bf16", "bfloat16", (1, 2), (1154,)),
+                    ("k4_small_bf16", "bfloat16", (1, 2), (124,)),
+                    ("k4_mid_bf16", "bfloat16", (1, 2), (132,)),
+                    ("k4_large_bf16", "bfloat16", (1, 2), (1924,)),
+                    ("k8_small_bf16", "bfloat16", (1, 2), (72,)),
+                    ("k8_mid_bf16", "bfloat16", (1, 2), (264,)),
+                    ("k8_large_bf16", "bfloat16", (1, 2), (3848,)),
+                    ("no_smem_bf16", "bfloat16", (1, 2), (12500,)),
+                ],
+            }
+        )
     )
     def test_softmax(
         self,


### PR DESCRIPTION
Summary:
See test_softmax for example use cases. By calling
filter_test_cases_by_test_env(), we can define both A100 and V100 test cases in
the same file, and define separate buck targets to filter test cases by test
env.

Differential Revision: D43562998

