### PR TITLE
Add an env to guard collecting compilation time breakdowns

### DIFF
--- a/python/aitemplate/backend/builder.py
+++ b/python/aitemplate/backend/builder.py
@@ -32,6 +32,8 @@ from typing import Optional
 
 import jinja2
 
+from aitemplate.utils import environ
+
 from aitemplate.utils.debug_settings import AITDebugSettings
 
 from ..utils.misc import is_debug
@@ -54,7 +56,11 @@ def _augment_for_trace(cmd):
 
 
 def _time_cmd(cmd):
-    return f"exec time -f 'exit_status=%x elapsed_sec=%e argv=\"%C\"' {cmd}"
+    return (
+        f"exec time -f 'exit_status=%x elapsed_sec=%e argv=\"%C\"' {cmd}"
+        if environ.time_compilation()
+        else cmd
+    )
 
 
 def _log_error_context(
@@ -368,7 +374,6 @@ class Builder(object):
         self._runner.pull()
 
     def gen_makefile(self, file_pairs, dll_name, workdir, test_name, debug_settings):
-
         makefile_template = jinja2.Template(
             """
 CC = {{cc}}

--- a/python/aitemplate/utils/environ.py
+++ b/python/aitemplate/utils/environ.py
@@ -49,3 +49,12 @@ def force_profiler_cache() -> bool:
         ), "cannot specify both AIT_FORCE_PROFILER_CACHE and FORCE_PROFILE"
     _LOGGER.info(f"{force_cache=}")
     return force_cache
+
+
+def time_compilation() -> bool:
+    """
+    When enabled, time each make command at compilation time.
+    This helps us doing compilation time analysis.
+    Requires to install "time".
+    """
+    return os.getenv("AIT_TIME_COMPILATION", "0") == "1"


### PR DESCRIPTION
Summary: ATT, to fix issue https://github.com/facebookincubator/AITemplate/issues/329.

Differential Revision: D43687047

