### PR TITLE
Use first dim as batch size if same in every input

### DIFF
--- a/fx2ait/fx2ait/test/test_tensor_spec.py
+++ b/fx2ait/fx2ait/test/test_tensor_spec.py
@@ -69,6 +69,14 @@ class TestTensorSpec(unittest.TestCase):
                     ([4, 10, 9], torch.float16),
                 ],
             ),
+            (
+                "same_shapes",
+                [
+                    ([10, 3, 40, 5], torch.float16),
+                    ([10, 3, 40, 5], torch.float16),
+                    ([10, 3, 40, 5], torch.float32),
+                ],
+            ),
         ]
     )
     def test_input_list_with_batch_size(self, _, settings):


### PR DESCRIPTION
Summary:
If all input tensors have the same shape (in particular, the same first batch dimension), the current frequency calculation code can pick arbitrary dimension as `batch_size`.

This diff adds a special handling of the case when all inputs' first dimensions are the same. This guarantees that the first dimension is the most frequent one (or at least one of the most frequent ones). In such a case it is probably reasonable to declare the first input dimension as `batch_size` (because it typically is).

Differential Revision: D43716722

