### PR TITLE
Added permute ops before and after group_norm

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -887,6 +887,7 @@ def acc_ops_group_norm(
     name: str,
 ) -> ConverterOutput:
     input_val = kwargs["input"]
+    input_val = ait_nchw2nhwc(kwargs["input"])
     num_groups = kwargs["num_groups"]
     weight_val = kwargs["weight"]
     bias_val = kwargs["bias"]
@@ -895,7 +896,8 @@ def acc_ops_group_norm(
         raise RuntimeError(f"Non-tensor inputs for {name}: {input_val}")
     num_channels = input_val.shape()[-1].value()
     op = group_norm(num_groups, num_channels)
-    return op(input_val, weight_val, bias_val, eps_val)
+    result = op(input_val, weight_val, bias_val, eps_val)
+    return ait_nhwc2nchw(result)
 
 
 @ait_converter(acc_ops.layer_norm)

--- a/fx2ait/fx2ait/test/converters/test_ait_group_norm.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_group_norm.py
@@ -40,6 +40,4 @@ class TestGroupNormTensor(AITTestCase):
             mod,
             inputs,
             expected_ops={},
-            permute_inputs=[0, 2, 3, 1],
-            permute_outputs=[0, 3, 1, 2],
         )


### PR DESCRIPTION
Summary:
Similar to what we have done for conv/pooling/batch_norm ops which
take different tensor layout from pytorch, we need to do adjust
layouts for group_norm, too.

Differential Revision: D43726397

