### PR TITLE
Fix code in py_design.rst

### DIFF
--- a/docs/source/runtime/py_design.rst
+++ b/docs/source/runtime/py_design.rst
@@ -37,7 +37,7 @@ If PyTorch is not available, `Model` provides a set of functions for copying, al
     # Arguments as a dictionary
     module.run(
       {"input0": in0_ait, "input1": in1_ait},
-      {"output0": out0_ait, "output1": out0_ait},
+      {"output0": out0_ait, "output1": out1_ait},
     )
 
     # Arguments as an ordered list. Note that you might need to query
@@ -45,8 +45,8 @@ If PyTorch is not available, `Model` provides a set of functions for copying, al
     input_name_to_idx = module.get_input_name_to_index_map()
     output_name_to_idx = module.get_output_name_to_index_map()
 
-    inputs = [None for i in range(len(input_name_to_idx))]
-    outputs = [None for i in range(len(input_name_to_idx))]
+    inputs = [None] * len(input_name_to_idx)
+    outputs = [None] * len(output_name_to_idx)
 
     for name in input_name_to_idx:
       inputs[input_name_to_idx[name]] = ait_inputs[name]

--- a/static/README.md
+++ b/static/README.md
@@ -55,7 +55,7 @@ If PyTorch is not available, `Model` provides a set of functions for copying, al
 # Arguments as a dictionary
 module.run(
   {"input0": in0_ait, "input1": in1_ait},
-  {"output0": out0_ait, "output1": out0_ait},
+  {"output0": out0_ait, "output1": out1_ait},
 )
 
 # Arguments as an ordered list. Note that you might need to query
@@ -63,8 +63,8 @@ module.run(
 input_name_to_idx = module.get_input_name_to_index_map()
 output_name_to_idx = module.get_output_name_to_index_map()
 
-inputs = [None for i in range(len(input_name_to_idx))]
-outputs = [None for i in range(len(input_name_to_idx))]
+inputs = [None] * len(input_name_to_idx)
+outputs = [None] * len(output_name_to_idx)
 
 for name in input_name_to_idx:
   inputs[input_name_to_idx[name]] = ait_inputs[name]


### PR DESCRIPTION
Fixes:
-  fix typo `"output1": out0_ait` -> `"output1": out1_ait`
- `outputs` array is created based on `len(input_name_to_idx)`. but it should use `len(output_name_to_idx)` instead.
- simpler code to create fixed size array