### PR TITLE
[Stable Diffusion][Bug] Check if target resolution can be divided by 64 

### DIFF
--- a/examples/05_stable_diffusion/scripts/compile.py
+++ b/examples/05_stable_diffusion/scripts/compile.py
@@ -55,11 +55,8 @@ def compile_diffusers(
     ).to("cuda")
 
     assert (
-        width % 64 == 0
-    ), "Width must be divisible by 64, otherwise, the compilation process will fail."
-    assert (
-        height % 64 == 0
-    ), "Height must be divisible by 64, otherwise, the compilation process will fail."
+        height % 64 == 0 and width % 64 == 0
+    ), "Height and Width must be multiples of 64, otherwise, the compilation process will fail."
 
     ww = width // 8
     hh = height // 8

--- a/examples/05_stable_diffusion/scripts/compile.py
+++ b/examples/05_stable_diffusion/scripts/compile.py
@@ -56,7 +56,7 @@ def compile_diffusers(
 
     assert (
         height % 64 == 0 and width % 64 == 0
-    ), "Height and Width must be multiples of 64, otherwise, the compilation process will fail."
+    ), f"Height and Width must be multiples of 64, otherwise, the compilation process will fail. Got {height=} {width=}"
 
     ww = width // 8
     hh = height // 8

--- a/examples/05_stable_diffusion/scripts/compile.py
+++ b/examples/05_stable_diffusion/scripts/compile.py
@@ -15,12 +15,9 @@
 import logging
 
 import click
-
 import torch
-
 from aitemplate.testing import detect_target
 from aitemplate.utils.import_path import import_parent
-
 from diffusers import StableDiffusionPipeline
 
 if __name__ == "__main__":
@@ -56,6 +53,13 @@ def compile_diffusers(
         revision="fp16",
         torch_dtype=torch.float16,
     ).to("cuda")
+
+    assert (
+        width % 64 == 0
+    ), "Width must be divisible by 64, otherwise, the compilation process will fail."
+    assert (
+        height % 64 == 0
+    ), "Height must be divisible by 64, otherwise, the compilation process will fail."
 
     ww = width // 8
     hh = height // 8


### PR DESCRIPTION
If the target resolution cannot be divided by 64, the compilation process fails on the UNet step.
This PR asserts the width and height immediately instead of compiling the CLIP model and failing a few minutes in.

closes #345 