### PR TITLE
Set the leftmost most frequent dim as batch size

### DIFF
--- a/fx2ait/fx2ait/test/test_tensor_spec.py
+++ b/fx2ait/fx2ait/test/test_tensor_spec.py
@@ -77,6 +77,14 @@ class TestTensorSpec(unittest.TestCase):
                     ([10, 3, 40, 5], torch.float32),
                 ],
             ),
+            (
+                "leftmost_bs_dim",
+                [
+                    ([10, 20, 30], torch.float16),
+                    ([10, 30, 20], torch.float16),
+                    ([20, 10, 30], torch.float32),
+                ],
+            ),
         ]
     )
     def test_input_list_with_batch_size(self, _, settings):


### PR DESCRIPTION
Summary:
If there is more than one most frequent dimension in the input shapes, the leftmost one: the one with the lowest position score (sum of position indices in the shapes) is picked as the batch size.

If there are multiple most frequent dimensions with the same position score, the choice is still arbitrary.

Differential Revision: D43755669

