### PR TITLE
Set batch_dim in make_jagged if zero

### DIFF
--- a/python/aitemplate/compiler/transform/name_graph.py
+++ b/python/aitemplate/compiler/transform/name_graph.py
@@ -99,11 +99,6 @@ def name_graph(sorted_graph: List[Tensor]) -> None:
                 dim_name = "{tname}_dim_{idx}".format(tname=tensor_name, idx=i)
                 dim._attrs["name"] = dim_name
 
-    dim_names_in_shapes = set()
-    for tensor in sorted_graph:
-        for dim in tensor._attrs["shape"]:
-            dim_names_in_shapes.add(dim._attrs["name"])
-
     for tensor in sorted_graph:
         if tensor.is_jagged():
             jagged_int_var = tensor._attrs["shape"][0]
@@ -113,18 +108,13 @@ def name_graph(sorted_graph: List[Tensor]) -> None:
             # the name in the JaggedIntVar class. as a result, we must resort to a hack here
             # to reset the name of the JaggedIntVar to the name of the total_length after
             # the latter might have been changed (e.g., from None) by the code above.
-            # TODO: wrap _attrs["name"] (and other frequently used _attrs members) in
-            # @properties and override the "name" property in the JaggedIntVar to return
-            # total_length().name.
+            # TODO (T146653032): wrap _attrs["name"] (and other frequently used _attrs
+            # members) in @properties and override the "name" property in the JaggedIntVar
+            # to return total_length().name.
             jagged_int_var._attrs["name"] = jagged_int_var.total_length()._attrs["name"]
 
             batch_dim = jagged_int_var.batch_dim()
-            if batch_dim._attrs["name"] not in dim_names_in_shapes:
-                # The batch_dim set inside the jagged_int_var is not present in any other
-                # Tensor's shape directly. We mark it as isolated batch dim here to set
-                # the dim to "offsets.length[0] - 1" in the make_jagged backend code.
-                batch_dim._attrs["isolated"] = True
-                if batch_dim._attrs["name"] is None:
-                    # the batch_dim wasn't named above, so we name it here
-                    jagged_int_var_name = jagged_int_var._attrs["name"]
-                    batch_dim._attrs["name"] = f"{jagged_int_var_name}_jagged_batch_dim"
+            if batch_dim._attrs["name"] is None:
+                # the batch_dim wasn't named above, so we name it here
+                jagged_int_var_name = jagged_int_var._attrs["name"]
+                batch_dim._attrs["name"] = f"{jagged_int_var_name}_jagged_batch_dim"


### PR DESCRIPTION
Summary:
Previously, `make_jagged`'s back-end was relying on whether the `batch_dim` is present in any Tesnor's `_attrs["shape"]`, to decide if the `batch_dim` must be set (to `offsets.lengths[0] - 1`) or validated (to be equal to that).

This is problematic for the cases, where the `batch_dim` is present in a Tensor shape in the downstream graph, hence is supposed to be set by `make_jagged` instead of being validated. One such case arises in the `jagged_to_dense` op, where the output dense Tensor's first `batch_dim` dimension is not known to the runtime until the input jagged Tensor is "unwrapped". In this case, `make_jagged` must assign the `batch_dim` present inside jagged Tensor's `JaggedIntVar`, instead of validating it, so that it gets the value by the time the output dense Tensor with the `batch_dim` in its `_attrs["shape"]` is processed further.

To mitigate this, in this diff the `make_jagged`'s condition to set vs. validate the `batch_dim` is changed to whether `batch_dim` is equal zero or not in the runtime. Being equal to zero means that the `batch_dim` has not yet been initialized (dynamic dimensions in the runtime are set to zero on declaration), which, in turn, means it must be set. If the `batch_dim` is not equal to zero, this means it has already been set, hence must be validated.

Differential Revision: D43712183

