### PR TITLE
Make JaggedIntVar hashable

### DIFF
--- a/python/aitemplate/compiler/base.py
+++ b/python/aitemplate/compiler/base.py
@@ -387,6 +387,9 @@ class JaggedIntVar(IntVar):
             and self.jagged_dims() == another.jagged_dims()
         )
 
+    def __hash__(self) -> int:
+        return hash((self._attrs["name"], tuple(self._attrs["values"])))
+
     def total_length(self) -> IntVar:
         """The total_length dimension the JaggedIntVar is based on."""
         return self._total_length


### PR DESCRIPTION
Summary:
Turns out, `JaggedIntVar` wasn't hashable. This created problems for some passes (e.g., [here](https://github.com/facebookincubator/AITemplate/blob/75f54510d8e02114e013200a66ea9a5d433e5f81/python/aitemplate/compiler/transform/transform_strided_op_and_view_op.py#L44-L48)).

This diff adds a `__hash__` function to `JaggedIntVar`. And because it should pretend to be a regular `IntVar` by default, the new `__hash__` function has the structure of the `IntVar.__hash__`.

Differential Revision: D43857198

