### PR TITLE
AIT Splitter with allow_int_inputs option

### DIFF
--- a/fx2ait/fx2ait/ait_splitter.py
+++ b/fx2ait/fx2ait/ait_splitter.py
@@ -67,7 +67,7 @@ def _decline_if_would_trigger_extra_copies(
 
 
 def create_ait_operator_support(
-    use_implicit_batch_dim=True, op_lowering_disallow_list=None
+    use_implicit_batch_dim=True, op_lowering_disallow_list=None, allow_int_inputs=False
 ) -> ops.OperatorSupportBase:
     """Creates an `OperatorSupportBase` instance used for AIT splitting purpose."""
     # Create an `OperatorSupport` that declares a node supported if it
@@ -81,11 +81,17 @@ def create_ait_operator_support(
     op_lowering_disallow_set = (
         set() if op_lowering_disallow_list is None else set(op_lowering_disallow_list)
     )
-    return ops.chain(
+    chained_not_supported_ops = (
+        []
+        if allow_int_inputs
+        else [
+            ops.OpSupports.decline_if_input_dtype(torch.int64),
+            ops.OpSupports.decline_if_input_dtype(torch.int32),
+        ]
+    )
+    chained_not_supported_ops += [
         ops.OpSupports.decline_if_node_in_names(op_lowering_disallow_set),
         # 1. We only support subgraphs with torch.Tensor inputs for now
-        ops.OpSupports.decline_if_input_dtype(torch.int64),
-        ops.OpSupports.decline_if_input_dtype(torch.int32),
         ops.OpSupports.decline_if_input_dtype(torch.float64),
         ops.OpSupports.decline_if_input_dtype(dict),
         # 2. Node is supported if it has AIT converter:
@@ -95,15 +101,20 @@ def create_ait_operator_support(
         # Note that this is not required for correctness, it is merely an
         # optimization.
         _decline_if_would_trigger_extra_copies(supported_if_converter_registered),
-    )
+    ]
+
+    return ops.chain(*chained_not_supported_ops)
 
 
 class AITSplitterSettings(splitter_base._SplitterSettingBase):
     # TODO: Fix this once pytorch nightly is updated
-    def __init__(self, min_acc_module_size=DEFAULT_MIN_ACC_MODULE_SIZE):
+    def __init__(
+        self, min_acc_module_size=DEFAULT_MIN_ACC_MODULE_SIZE, allow_int_inputs=False
+    ):
         super().__init__()
         self.min_acc_module_size = min_acc_module_size
         self.exclude_support_node_name: set = set()
+        self.allow_int_inputs: bool = allow_int_inputs
 
 
 class AITSplitter(splitter_base._SplitterBase):
@@ -118,7 +129,8 @@ class AITSplitter(splitter_base._SplitterBase):
             settings = AITSplitterSettings()
         if not operator_support:
             operator_support = create_ait_operator_support(
-                op_lowering_disallow_list=settings.exclude_support_node_name
+                op_lowering_disallow_list=settings.exclude_support_node_name,
+                allow_int_inputs=settings.allow_int_inputs,
             )
         else:
             operator_support = ops.chain(

--- a/fx2ait/fx2ait/lower/lower.py
+++ b/fx2ait/fx2ait/lower/lower.py
@@ -100,7 +100,8 @@ def default_split_function(
     model: fx.GraphModule, inputs: Input, lower_settings: LowerSettings
 ) -> SplitResult:
     settings = AITSplitterSettings(
-        min_acc_module_size=lower_settings.min_acc_module_size
+        min_acc_module_size=lower_settings.min_acc_module_size,
+        allow_int_inputs=lower_settings.allow_int_inputs,
     )
     splitter = AITSplitter(model, inputs, settings=settings)
     splitter.node_support_preview()

--- a/fx2ait/fx2ait/lower/lower_settings.py
+++ b/fx2ait/fx2ait/lower/lower_settings.py
@@ -48,6 +48,7 @@ class LowerSettings:
         use_fp16_acc=False uses fp32 accumulation for gemm ops.
         Set use_fp16_acc=True for better perf; set use_fp16_acc=False for better accuracy.
         For LowerPrecision.FP32, use_fp16_acc is invalid.
+    allow_int_inputs: If AIT acc subgraph accept integer inputs.
     leaf_module_list: The list of modules that acc_tracer will not trace into.
     output_precision: The AITemplate output precision level.
     additional_inputs: The additional input to help determine input batch_size dimension range.
@@ -68,6 +69,7 @@ class LowerSettings:
     # If None, infer the dtypes from the sample inputs.
     precision: Optional[LowerPrecision] = LowerPrecision.FP16
     use_fp16_acc: bool = True  # only valid for precision == FP16
+    allow_int_inputs: bool = False  # If AIT acc subgraph accept integer inputs
     ast_rewriter_allow_list: Optional[Set[Type[nn.Module]]] = None
     leaf_module_list: Optional[Set[Type[nn.Module]]] = None
     # If None, infer the dtypes from the sample inputs.


### PR DESCRIPTION
Summary:
There are some ops involves in tensors e.g. jagged offset tensors that are intergers. Now AITSplitter reject any op involves integer type.
To enable IFR ESUHM module, added allow_int_inputs to LowerSetting and AITSplitterSettings so that splitter won't reject ops involving integer types.

Differential Revision: D43859425

