### PR TITLE
Add CELU activation function

### DIFF
--- a/python/aitemplate/backend/backend_spec.py
+++ b/python/aitemplate/backend/backend_spec.py
@@ -300,6 +300,13 @@ class GPUBackendSpec(BackendSpec):
                 "bfloat16": "floor_div",
                 "bfloat16_2": "floor_div",
             },
+            FuncEnum.CELU: {
+                "float": "fcelu",
+                "half": "hcelu",
+                "half2": "h2celu",
+                "bfloat16": "hcelu",
+                "bfloat16_2": "h2celu",
+            },
         }
     )
 

--- a/python/aitemplate/backend/cuda/elementwise/custom_math.cuh
+++ b/python/aitemplate/backend/cuda/elementwise/custom_math.cuh
@@ -978,4 +978,36 @@ __device__ bfloat16_2 floor_div(const bfloat16_2 a, const bfloat16_2 b) {
 #endif
 }
 
+__device__ float fcelu(const float a, const float alpha) {
+  return a > 0.f ? a : alpha * (expf(a / alpha) - 1.0f);
+}
+
+__device__ half hcelu(const half a, const half alpha) {
+  return __hgt(a, CUDA_FP16_ZERO)
+      ? a
+      : __hmul(alpha, __hsub(hexp(__hdiv(a, alpha)), CUDA_FP16_ONE));
+}
+
+__device__ bfloat16 hcelu(const bfloat16 a, const bfloat16 alpha) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+  return __hgt(a, CUDA_BF16_ZERO)
+      ? a
+      : __hmul(alpha, __hsub(hexp(__hdiv(a, alpha)), CUDA_BF16_ONE));
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
+
+__device__ half2 h2celu(const half2 a, const half2 alpha) {
+  return half2(hcelu(a.x, alpha.x), hcelu(a.y, alpha.y));
+}
+
+__device__ bfloat16_2 h2celu(const bfloat16_2 a, const bfloat16_2 alpha) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+  return bfloat16_2(hcelu(a.x, alpha.x), hcelu(a.y, alpha.y));
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
+
 #endif

--- a/python/aitemplate/compiler/ops/common/epilogue.py
+++ b/python/aitemplate/compiler/ops/common/epilogue.py
@@ -64,3 +64,4 @@ class FuncEnum(Enum):
     ELU = 26
     SOFTSIGN = 27
     FLOOR_DIV = 28
+    CELU = 29

--- a/python/aitemplate/compiler/ops/common/math.py
+++ b/python/aitemplate/compiler/ops/common/math.py
@@ -113,3 +113,7 @@ def softsign(tensor: Any) -> Tensor:
 
 def floor_div(tensor: Any) -> Tensor:
     return OP_REGISTRY.get("FLOOR_DIV")(tensor)
+
+
+def celu(tensor: Any) -> Tensor:
+    return OP_REGISTRY.get("CELU")(tensor)


### PR DESCRIPTION
Summary:
New activation function CELU is implemented as follows:
1. Backend device-level implementations for all dtypes added
2. New enum member for new op added
3. By-type enum member added
4. Frontend function for op in Python added
5. Unittests are extended to include new op

Differential Revision: D43852704

