### PR TITLE
Add fast_tanh(half2) fallback for CUDA_ARCH < 75

### DIFF
--- a/python/aitemplate/backend/cuda/elementwise/custom_math.cuh
+++ b/python/aitemplate/backend/cuda/elementwise/custom_math.cuh
@@ -97,7 +97,8 @@ __device__ half2 fast_tanh(half2 x) {
   return x;
 
 #else
-  NOT_IMPLEMENTED();
+  return half2(
+      {cutlass::fast_tanh(float(x.x)), cutlass::fast_tanh(float(x.y))});
 #endif
 }
 


### PR DESCRIPTION
Summary: Fallback for input type half2 version of fast_tanh in CUDA_ARCH < 75 case is implemented.

Differential Revision: D43871666

