### PR TITLE
Eliminate permute over singleton dims

### DIFF
--- a/python/aitemplate/compiler/transform/optimize_graph.py
+++ b/python/aitemplate/compiler/transform/optimize_graph.py
@@ -40,6 +40,9 @@ from aitemplate.compiler.transform.transform_memory_ops import transform_memory_
 from aitemplate.compiler.transform.transform_odd_alignment import (
     transform_odd_alignment,
 )
+from aitemplate.compiler.transform.transform_permute_to_reshape import (
+    transform_permute_to_reshape,
+)
 from aitemplate.compiler.transform.transform_special_ops import transform_special_ops
 from aitemplate.compiler.transform.transform_strided_ops import transform_strided_ops
 
@@ -95,6 +98,7 @@ def optimize_graph(sorted_graph: List[Tensor], workdir: str) -> List[Tensor]:
         split_large_slice_scatter_ops,
         split_large_concat_ops,
         split_large_split_ops,
+        transform_permute_to_reshape,
         transform_memory_ops,
     ]
 

--- a/python/aitemplate/compiler/transform/transform_permute_to_reshape.py
+++ b/python/aitemplate/compiler/transform/transform_permute_to_reshape.py
@@ -1,0 +1,124 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Transform permute to reshape wherever applicable.
+"""
+from typing import List
+
+from ...utils import graph_utils
+from ..base import IntImm, Operator, Tensor
+from ..ops import reshape
+from . import transform_utils
+from .toposort import toposort
+
+
+def _check_permute_to_reshape(op: Operator) -> bool:
+    """Check if applicable to replace permute with reshape.
+
+    Args:
+        op (Operator): reshape op
+
+    Returns:
+        bool: False if operation is not a permute or a permute with memory
+            layout modification otherwise True.
+    """
+    if not op._attrs["op"].startswith("permute"):
+        return False
+
+    inputs = op._attrs["inputs"]
+
+    assert (
+        len(inputs) == 1
+    ), "Permute operation {} should have 1 input, got {} instead".format(
+        op._attrs["op"], len(inputs)
+    )
+
+    input_shape = inputs[0].shape()
+
+    if op._attrs["op"] == "permute":
+        permutation = list(op._attrs["dims"])
+    elif op._attrs["op"] == "permute021":
+        n_dims = len(input_shape)
+        permutation = list(range(n_dims - 2)) + [n_dims - 1, n_dims - 2]
+    elif op._attrs["op"] == "permute102":
+        permutation = [1, 0, 2]
+    elif op._attrs["op"] == "permute210":
+        permutation = [2, 1, 0]
+    elif op._attrs["op"] == "permute0213":
+        permutation = [0, 2, 1, 3]
+    else:
+        raise NotImplementedError(
+            f"Not implemented for permute operation: {op._attrs['op']}"
+        )
+
+    # Get non-singular dimension indices
+    permutation = [
+        dim_idx
+        for dim_idx in permutation
+        if not isinstance(input_shape[dim_idx], IntImm)
+        or input_shape[dim_idx].value() != 1
+    ]
+    is_reshape = permutation == sorted(permutation)
+    return is_reshape
+
+
+def transform_permute_to_reshape(
+    sorted_graph: List[Tensor], workdir: str = None
+) -> List[Tensor]:
+    """Convert permute to reshape wherever applicable.
+
+    When permute op involves moving one or more dimensions with size
+    1 around where the order of non-singular dimensions is preserved,
+    it's basically a reshape op, i.e. the underlying memory layout
+    does not change.
+
+    Example:
+        [256x5x1x32] -> [256x5x32x1] (with 0132) is a reshape
+        [256x1x5x1x32] -> [256x5x32x1x1] (with 02431) is a reshape
+        [256x5x1x32] -> [256x32x5x1] (with 0312) is not a reshape
+
+    Args:
+        sorted_graph (List[Tensor]): input graph
+        workdir (str, optional): current workdir for dumping debug info. Defaults to None.
+
+    Returns:
+        List[Tensor]: optimized graph
+    """
+    sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+
+    has_modified = False
+    for op in sorted_ops:
+        if not _check_permute_to_reshape(op):
+            continue
+
+        has_modified = True
+
+        permute_input = op._attrs["inputs"][0]
+        permute_output = op._attrs["outputs"][0]
+        output_shape = permute_output.shape()
+
+        transform_utils.remove_dst_op_from_tensor(permute_input, op)
+
+        reshape_op = reshape()
+        reshape_output = reshape_op(permute_input, output_shape)
+
+        transform_utils.replace_tensor(permute_output, reshape_output)
+
+        sorted_graph.append(reshape_output)
+
+    if has_modified:
+        sorted_graph = toposort(sorted_graph)
+        transform_utils.sanitize_sorted_graph(sorted_graph)
+    return sorted_graph

--- a/tests/unittest/compiler/test_transform_permute_to_reshape.py
+++ b/tests/unittest/compiler/test_transform_permute_to_reshape.py
@@ -1,0 +1,117 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import unittest
+
+import torch
+
+from aitemplate.compiler import compile_model, ops
+
+from aitemplate.compiler.base import IntVar, Tensor
+from aitemplate.testing import detect_target, test_utils
+from aitemplate.testing.test_utils import get_random_torch_tensor
+
+from parameterized import parameterized
+
+_PERMUTE_OPS = (
+    "permute",
+    "permute021",
+    "permute102",
+    "permute210",
+    "permute0213",
+)
+
+
+def _generate_model_name(shape, permutation, is_reshape, dtype, is_complex):
+    model_name = "_".join(
+        [
+            ("test_permute_complex" if is_complex else "test_permute"),
+            ("to_reshape" if is_reshape else "not_to_reshape"),
+            "x".join([str(s) for s in shape]),
+            "".join([str(s) for s in permutation]),
+            dtype,
+        ]
+    )
+    return model_name
+
+
+class TransformPermuteToReshapeTestCase(unittest.TestCase):
+    @parameterized.expand(
+        [
+            # no singleton
+            ([32, 51, 12], [1, 2, 0], False, "float16"),
+            ([32, 51, 12], [1, 2, 0], False, "float32"),
+            # one singleton dimension
+            ([32, 51, 1], [0, 2, 1], True, "float16"),
+            ([32, 51, 1], [0, 2, 1], True, "float32"),
+            ([32, 51, 1], [1, 2, 0], False, "float16"),
+            ([32, 51, 1], [1, 2, 0], False, "float32"),
+            # two same sized dimensions
+            ([32, 32, 1], [2, 0, 1], True, "float16"),
+            ([32, 32, 1], [2, 0, 1], True, "float32"),
+            ([32, 32, 1], [1, 0, 2], False, "float16"),
+            ([32, 32, 1], [1, 0, 2], False, "float32"),
+            # double singleton dimension
+            ([32, 1, 51, 1], [3, 0, 2, 1], True, "float16"),
+            ([32, 1, 51, 1], [3, 0, 2, 1], True, "float32"),
+            ([32, 1, 51, 1], [2, 3, 1, 0], False, "float16"),
+            ([32, 1, 51, 1], [2, 3, 1, 0], False, "float32"),
+            # IntVar dimension
+            ([IntVar([1, 10]), 32, 1, 51], [0, 2, 1, 3], True, "float16"),
+            ([IntVar([1, 10]), 32, 1, 51], [0, 2, 1, 3], True, "float32"),
+            ([IntVar([1, 10]), 32, 1, 51], [2, 3, 0, 1], False, "float16"),
+            ([IntVar([1, 10]), 32, 1, 51], [2, 3, 0, 1], False, "float32"),
+            # other
+            ([3, 1, 113, 15, 64], [0, 1, 2, 4, 3], False, "float16"),
+            ([3, 1, 113, 15, 64], [0, 1, 2, 4, 3], False, "float32"),
+        ]
+    )
+    def test_permute_to_reshape(self, shape, permutation, is_reshape, dtype):
+        target = detect_target()
+
+        X = Tensor(shape, dtype=dtype, is_input=True, name="x")
+        Z = ops.softmax()(ops.permute()(X, dims=permutation), -1)
+        Z._attrs["is_output"] = True
+        Z._attrs["name"] = "z"
+
+        model_name = _generate_model_name(
+            shape, permutation, is_reshape, dtype, is_complex=False
+        )
+        module = compile_model(Z, target, "./tmp", model_name)
+        has_permute_op = any(
+            test_utils.graph_has_op(module.debug_sorted_graph, op_name)
+            for op_name in _PERMUTE_OPS
+        )
+        has_reshape_op = test_utils.graph_has_op(module.debug_sorted_graph, "reshape")
+
+        if is_reshape:
+            self.assertFalse(has_permute_op)
+            self.assertTrue(has_reshape_op)
+        else:
+            self.assertTrue(has_permute_op)
+            self.assertFalse(has_reshape_op)
+
+        shape = [dim.upper_bound() if isinstance(dim, IntVar) else dim for dim in shape]
+
+        x_pt = get_random_torch_tensor(shape, dtype)
+        z_pt = torch.softmax(torch.permute(x_pt, tuple(permutation)), dim=-1)
+        z_ait = torch.empty_like(z_pt)
+        module.run_with_tensors({"x": x_pt}, {"z": z_ait})
+
+        torch.testing.assert_close(z_ait, z_pt, atol=1e-1, rtol=1e-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    unittest.main()


### PR DESCRIPTION
Summary: Since when permute operation moves only a (or multiple) singleton dimension(s) memory layout does not change, it can be replaced with a reshape operation. New transform function for detecting and replacing operators in such cases is implemented. It's added among compiler optimization functions list. Unittests for this new functionality is added.

Differential Revision: D43878517

