### PR TITLE
Add an option to shorten tensor names for plotting

### DIFF
--- a/docs/source/reference/env.rst
+++ b/docs/source/reference/env.rst
@@ -42,3 +42,5 @@ Miscellaneous
 -------------
 
 **LOGLEVEL**: It is used to control the logging level in Python. The default value is "INFO". "DEBUG" is useful for debugging.
+
+**AIT_PLOT_SHORTEN_TENSOR_NAMES**: If set to "1", shorten too long tensor names for a plot of a model graph, thus making a plot much easier to analyze visually. "0" by default.

--- a/python/aitemplate/utils/environ.py
+++ b/python/aitemplate/utils/environ.py
@@ -58,3 +58,11 @@ def time_compilation() -> bool:
     Requires to install "time".
     """
     return os.getenv("AIT_TIME_COMPILATION", "0") == "1"
+
+
+def shorten_tensor_names_for_plots() -> bool:
+    """
+    When enabled, long tensor names will be replaced with a hash string,
+    making the graph representation significantly simpler.
+    """
+    return os.getenv("AIT_PLOT_SHORTEN_TENSOR_NAMES", "0") == "1"

--- a/python/aitemplate/utils/misc.py
+++ b/python/aitemplate/utils/misc.py
@@ -15,6 +15,7 @@
 """
 miscellaneous utilities
 """
+import hashlib
 import logging
 import os
 
@@ -41,3 +42,11 @@ def setup_logger(name):
     )
     root_logger.setLevel(LOG_LEVEL)
     return root_logger
+
+
+def short_str(s, length=8) -> str:
+    """
+    Returns a hashed string, somewhat similar to URL shortener.
+    """
+    hash_str = hashlib.sha256(s.encode()).hexdigest()
+    return hash_str[0:length]

--- a/python/aitemplate/utils/visualization/plot.py
+++ b/python/aitemplate/utils/visualization/plot.py
@@ -19,6 +19,8 @@ import json
 import os
 
 from aitemplate import compiler
+from aitemplate.utils.environ import shorten_tensor_names_for_plots
+from aitemplate.utils.misc import short_str
 from aitemplate.utils.visualization import op_attr_factory, pydot
 from aitemplate.utils.visualization.op_attr_factory import op_to_content
 from aitemplate.utils.visualization.web_template import (
@@ -124,6 +126,10 @@ def plot_graph(tensors, file_path: str) -> None:
     for tensor in sorted_graph:
         tensor_node = None
         tensor_name = tensor._attrs["name"]
+        if shorten_tensor_names_for_plots():
+            if tensor_name is not None and len(tensor_name) > 30:
+                tensor_name = short_str(tensor_name)
+
         if tensor in tensor_set:
             tensor_node = tensor_set[tensor]
         else:


### PR DESCRIPTION
Summary: Setting AIT_PLOT_SHORTEN_TENSOR_NAMES=1 environment variable makes AITemplate to replace tensors with long names with shortened names (like URL shortener does) during building a plot.

Differential Revision: D43918759

