### PR TITLE
Add json-based serialization of graph, which allows to re-import the graph in a third-party python code.

### DIFF
--- a/python/aitemplate/utils/graph_utils.py
+++ b/python/aitemplate/utils/graph_utils.py
@@ -49,6 +49,22 @@ def sorted_graph_debug_str(tensors) -> str:
     return "Tensors: {}\n\nOperators: {}\n\n".format(tensor_str, op_str)
 
 
+def sorted_graph_debug_json(tensors) -> str:
+    import json
+
+    from aitemplate.compiler.base import Tensor
+    from aitemplate.utils.json_utils import GraphJsonEncoder
+
+    if isinstance(tensors, Tensor):
+        tensors = [tensors]
+
+    json_dict = {}
+    json_dict["Tensors"] = tensors
+    json_dict["Operators"] = get_sorted_ops(tensors)
+
+    return json.dumps(json_dict, cls=GraphJsonEncoder)
+
+
 def sorted_graph_pseudo_code(tensors, with_shape=True) -> str:
     from aitemplate.compiler.base import Tensor
 
@@ -72,11 +88,15 @@ def dump_graph_debug_str_to_file(tensors, workdir, name):
         # Dump graph and pseudo code for debug only
         prefix = os.path.join(workdir, name)
         graph_path = prefix + "_graph.txt"
+        graph_json_path = prefix + "_graph.json"
         pseudo_code_path = prefix + "_pseudo_code.txt"
         graph_visual_path = prefix + "_graph_vis.html"
         with open(graph_path, "w") as f:
             f.write(sorted_graph_debug_str(tensors))
             _LOGGER.debug(f"Dumped {name} graph to {graph_path}")
+        with open(graph_json_path, "w") as f:
+            f.write(sorted_graph_debug_json(tensors))
+            _LOGGER.debug(f"Dumped {name} graph to {graph_json_path}")
         with open(pseudo_code_path, "w") as f:
             f.write(sorted_graph_pseudo_code(tensors))
             _LOGGER.debug(f"Dumped {name} pseudo code to {pseudo_code_path}")

--- a/python/aitemplate/utils/json_utils.py
+++ b/python/aitemplate/utils/json_utils.py
@@ -1,0 +1,72 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import json
+
+from aitemplate.compiler.base import (
+    _HostConstantTensorData,
+    _NumpyConstantTensorData,
+    _TorchConstantTensorData,
+    IntImm,
+    IntVar,
+    Operator,
+    Tensor,
+)
+from aitemplate.compiler.ops.common.epilogue import FuncEnum
+from aitemplate.compiler.tensor_accessor import TensorAccessor
+
+
+class GraphJsonEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, FuncEnum):
+            return obj.name
+        if isinstance(obj, Tensor):
+            return self._jsonize_tensor(obj)
+        if isinstance(obj, Operator):
+            return self._jsonize_operator(obj)
+        if isinstance(obj, TensorAccessor):
+            return obj.__dict__
+        if isinstance(obj, IntImm):
+            return obj.__dict__
+        if isinstance(obj, IntVar):
+            return obj.__dict__
+        if isinstance(obj, _HostConstantTensorData):
+            return "_HostConstantTensorData"
+        if isinstance(obj, _TorchConstantTensorData):
+            return "_TorchConstantTensorData"
+        if isinstance(obj, _NumpyConstantTensorData):
+            return "_NumpyConstantTensorData"
+
+        return str(obj)
+
+    def _jsonize_tensor(self, tensor: Tensor):
+        output = {}
+        for key in tensor._attrs.keys():
+            if key in ("src_ops", "dst_ops") and tensor._attrs[key] is not None:
+                output[key] = [x._attrs["name"] for x in tensor._attrs[key]]
+            else:
+                output[key] = tensor._attrs[key]
+        return output
+
+    def _jsonize_operator(self, op: Operator):
+        output = {}
+        for key in op._attrs.keys():
+            if (
+                key in ("inputs", "args", "outputs", "original_inputs")
+                and op._attrs[key] is not None
+            ):
+                output[key] = [x._attrs["name"] for x in op._attrs[key]]
+            else:
+                output[key] = op._attrs[key]
+        return output


### PR DESCRIPTION
Summary: `_graph.json` files will be generated in addition to `_graph.txt` files under the same circumstances. Such a file can be loaded using `json.loads()` call.

Differential Revision: D43951586

