### PR TITLE
Add int_elementwise support in fx2ait

### DIFF
--- a/fx2ait/fx2ait/converters/utils.py
+++ b/fx2ait/fx2ait/converters/utils.py
@@ -21,6 +21,7 @@ from aitemplate.compiler.base import IntImm, IntVar, IntVarTensor
 from aitemplate.compiler.public import (
     elementwise,
     FuncEnum,
+    int_elementwise,
     permute,
     Tensor as AITTensor,
 )
@@ -83,6 +84,14 @@ def create_binary_op(
         )
         return res
 
+    if isinstance(lhs, IntVarTensor) or isinstance(rhs, IntVarTensor):
+        lhs = IntVarTensor(IntImm(lhs)) if isinstance(lhs, int) else lhs
+        rhs = IntVarTensor(IntImm(rhs)) if isinstance(rhs, int) else rhs
+
+        if not (isinstance(lhs, IntVarTensor) and isinstance(rhs, IntVarTensor)):
+            raise RuntimeError(f"Unexpected right operand {type(rhs)} on {name}: {rhs}")
+
+        return int_elementwise(op_type)(lhs, rhs)
     return elementwise(op_type)(lhs, rhs)
 
 


### PR DESCRIPTION
Summary:
We had int_elementwise support  for dynamic shape in aten2ait, but didn't add it to fx2ait. Fx2ait were able to calculate static shape, but recently IFR model requests dynamic shape calculation: https://fburl.com/code/7eag5h8a

Therefore added the support.

Reviewed By: khabinov, wushirong

Differential Revision: D43964418

