### PR TITLE
Adopt softmax to wider dimension with reshape

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -423,6 +423,21 @@ def acc_ops_softmax(
         raise RuntimeError(f"Unexpected input for {name}: {input_val}")
 
     dim = kwargs["dim"]
+    rank = len(input_val.shape())
+    if dim < 0:
+        dim = rank + dim
+    if dim != rank - 1:
+        for i in range(rank, dim):
+            if input_val.shape()[i].value() != 1:
+                raise RuntimeError(
+                    f"AIT softmax only supports dim=rank-1, got dim={dim}, rank={rank}"
+                )
+        reshape_dim = size()(input_val)[: dim + 1]
+        reshape_val = reshape()(input_val, reshape_dim)
+        softmax_val = softmax()(reshape_val, -1)
+        return reshape()(
+            softmax_val, reshape_dim + [IntVarTensor(IntImm(1))] * (rank - dim - 1)
+        )
 
     return softmax()(input_val, dim)
 

--- a/fx2ait/fx2ait/test/converters/test_ait_softmax.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_softmax.py
@@ -12,8 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import unittest
+
 import torch
 from fx2ait.acc_tracer import acc_ops
+from fx2ait.tensor_spec import TensorSpec
 from fx2ait.tools.common_fx2ait import AITTestCase
 from parameterized import param, parameterized
 
@@ -36,3 +39,90 @@ class TestSoftmaxConverter(AITTestCase):
         ]
 
         self.run_test(model, inputs, expected_ops={acc_ops.softmax})
+
+    @parameterized.expand(
+        [
+            param("default", dim=2),
+            param("neg", dim=-3),
+        ]
+    )
+    def test_softmax_not_last_dim(self, name, dim=None):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return torch.nn.functional.softmax(x, dim=dim)
+
+        model = TestModule().cuda().half()
+
+        # Test static use case
+        inputs = [
+            torch.randn(2, 3, 5, 1, 1).half().cuda(),
+        ]
+        self.run_test(model, inputs, expected_ops={acc_ops.softmax})
+
+        # Test dynamic use case
+        inputs_spec = TensorSpec.create_spec_from_shapes(
+            inputs_min=[
+                [2, 3, 5, 1, 1],
+            ],
+            inputs_max=[
+                [20, 10, 5, 1, 1],
+            ],
+            dtype_list=[
+                torch.float16,
+            ],
+        )
+        self.run_test_with_dynamic_shape(
+            model,
+            inputs_spec,
+            expected_ops={acc_ops.softmax},
+        )
+
+    @parameterized.expand(
+        [
+            param("default", dim=2),
+            param("neg", dim=-3),
+        ]
+    )
+    @unittest.expectedFailure
+    def test_softmax_expected_failure(self, name, dim=None):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return torch.nn.functional.softmax(x, dim=dim)
+
+        model = TestModule().cuda().half()
+
+        inputs = [
+            torch.randn(2, 3, 5, 2, 1).half().cuda(),
+        ]
+        self.run_test(model, inputs, expected_ops={acc_ops.softmax})
+
+    @parameterized.expand(
+        [
+            param("default", dim=2),
+            param("neg", dim=-3),
+        ]
+    )
+    @unittest.expectedFailure
+    def test_softmax_expected_failure_dynamic(self, name, dim=None):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return torch.nn.functional.softmax(x, dim=dim)
+
+        model = TestModule().cuda().half()
+
+        inputs_spec = TensorSpec.create_spec_from_shapes(
+            inputs_min=[
+                [2, 3, 5, 2, 1],
+            ],
+            inputs_max=[
+                [20, 10, 5, 4, 1],
+            ],
+            dtype_list=[
+                torch.float16,
+            ],
+        )
+        self.run_test_with_dynamic_shape(
+            model,
+            inputs_spec,
+            expected_ops={acc_ops.softmax},
+        )


### PR DESCRIPTION
Summary:
AIT only support dim=rank-1 softmax. But sometimes softmax will happen in dim < dim, e.g. in IFR model: https://fburl.com/code/pjfety5f

Luckily, in most of these cases, all i in range(dim, rank) are 1s. So we can replace the original input with a reshaped input to flatten the last few dims with value 1 and perform softmax on the last dim.
Because reshape doesn't cost any memory I/O, such change won't result in degraded performance

Differential Revision: D43968603

