### PR TITLE
export ScaledDotProductAttention from frontend.nn

### DIFF
--- a/python/aitemplate/frontend/nn/__init__.py
+++ b/python/aitemplate/frontend/nn/__init__.py
@@ -30,6 +30,7 @@ from aitemplate.frontend.nn.attention import (
     CrossAttention,
     FlashAttention,
     MultiheadAttention,
+    ScaledDotProductAttention,
 )
 from aitemplate.frontend.nn.identity import Identity
 from aitemplate.frontend.nn.multiscale_attention import MultiScaleBlock


### PR DESCRIPTION
Summary:
We need to export ScaledDotProductAttention. Otherwise
the converter would fail.

Differential Revision: D43988076

