### PR TITLE
add priority toposort

### DIFF
--- a/python/aitemplate/compiler/transform/toposort.py
+++ b/python/aitemplate/compiler/transform/toposort.py
@@ -15,7 +15,8 @@
 """
 Graph pass for topological sort.
 """
-from typing import List, Union
+import heapq
+from typing import List, Tuple, Union
 
 from aitemplate.compiler.base import Tensor
 
@@ -35,6 +36,10 @@ def toposort(nodes: Union[Tensor, List[Tensor]]) -> List[Tensor]:
     List[Tensor]
         Sorted graph
     """
+    return _priSort(nodes, SizePriTensorHelper())
+
+
+def _dfsSort(nodes: Union[Tensor, List[Tensor]]) -> List[Tensor]:
     visited = set()
     sorted_graph = []
     stack = []
@@ -68,5 +73,80 @@ def toposort(nodes: Union[Tensor, List[Tensor]]) -> List[Tensor]:
             for idx in visit_seq:
                 arg = args[idx]
                 stack.append((arg, False))
+    return sorted_graph
 
+
+class PriTensorHelper:
+    def __init__(self) -> None:
+        self.entry_cnt = -1
+
+    def get_heap_input(self, node: Tensor) -> Tuple[float, int, Tensor]:
+        # input is built based on heapq doc suggestion:
+        # https://docs.python.org/3/library/heapq.html#priority-queue-implementation-notes
+        # the return tuple is: (
+        #   priority_ (less is more important),
+        #   entry_cnt (so earlier entered item is chosen if same priority),
+        #   element (here is tensor)
+        # )
+        self.entry_cnt += 1
+        return (
+            self.get_priority(node),
+            self.entry_cnt,
+            node,
+        )
+
+    def get_tensor_from_heap_output(
+        self, heap_output: Tuple[float, int, Tensor]
+    ) -> Tensor:
+        return heap_output[2]
+
+    def get_priority(self, node: Tensor) -> float:
+        # please implement your own priority function
+        # note that smaller value would be in higher-pri
+        pass
+
+
+class SizePriTensorHelper(PriTensorHelper):
+    def get_priority(self, node: Tensor) -> float:
+        # use negative byte size since
+        # we'd like to pop larger size first
+        return -node.size_bytes()
+
+
+def _priSort(
+    nodes: Union[Tensor, List[Tensor]], pri_tensor_helper: PriTensorHelper
+) -> List[Tensor]:
+    # do a DFS to get all nodes in a list
+    nodes = _dfsSort(nodes)
+    # number of src tensors
+    in_degree = {}
+    for node in nodes:
+        in_degree[node] = 0
+        for src_op in node.src_ops():
+            # sometimes it'd have 2 same nodes in one list
+            # change to set to de-dupe these nodes
+            in_degree[node] += len(set(src_op._attrs["inputs"]))
+
+    queue = []
+    sorted_graph = []
+    for node in nodes:
+        if in_degree[node] == 0:
+            # input nodes need to be in the original order,
+            # hence add them to the sorted graph here
+            # instead of going through the pri heap
+            sorted_graph.append(node)
+            heapq.heappush(queue, pri_tensor_helper.get_heap_input(node))
+
+    while queue:
+        node = pri_tensor_helper.get_tensor_from_heap_output(heapq.heappop(queue))
+        if node not in sorted_graph:
+            sorted_graph.append(node)
+
+        for dst_op in node.dst_ops():
+            for next_node in set(dst_op._attrs["outputs"]):
+                if next_node not in in_degree:
+                    continue
+                in_degree[next_node] -= 1
+                if in_degree[next_node] == 0:
+                    heapq.heappush(queue, pri_tensor_helper.get_heap_input(next_node))
     return sorted_graph

--- a/tests/unittest/compiler/test_transform_toposort.py
+++ b/tests/unittest/compiler/test_transform_toposort.py
@@ -18,10 +18,29 @@ import torch
 from aitemplate.compiler import compile_model, ops
 from aitemplate.compiler.base import Tensor
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
+from aitemplate.compiler.transform.toposort import (
+    _dfsSort,
+    _priSort,
+    SizePriTensorHelper,
+)
 from aitemplate.testing import detect_target
 
 
 class TestTopoSort(unittest.TestCase):
+    def _get_diff_size_graph(self):
+        X1 = Tensor(shape=[10, 50], dtype="float16", name="in_10_50")
+        X2 = Tensor(shape=[50, 1000], dtype="float16", name="in_50_1000")
+        X3 = Tensor(shape=[1000, 5], dtype="float16", name="in_1000_5")
+        X4 = Tensor(shape=[5, 5], dtype="float16", name="in_5_5")
+        X5 = ops.gemm_rrr()(X1, X2)
+        X5._attrs["name"] = "MUL_10_1000"
+        X6 = ops.gemm_rrr()(X3, X4)
+        X6._attrs["name"] = "MUL_1000_5"
+        X7 = ops.gemm_rrr()(X5, X6)
+        X7._attrs["name"] = "MUL_10_5"
+        X7._attrs["is_output"] = True
+        return X7
+
     def test_very_deep_toposort(self):
         x = Tensor(
             [2, 10],
@@ -45,6 +64,27 @@ class TestTopoSort(unittest.TestCase):
         module.run_with_tensors({"x": x_pt}, {"output": out_ait})
 
         self.assertTrue(torch.equal(out_ait, out_pt))
+
+    def test_size_pri_toposort(self):
+        tensor = self._get_diff_size_graph()
+        expected_order = [
+            "in_10_50",
+            "in_50_1000",
+            "in_1000_5",
+            "in_5_5",
+            "MUL_10_1000",
+            "MUL_1000_5",
+            "MUL_10_5",
+        ]
+        self.assertEqual(
+            [node._attrs["name"] for node in _priSort(tensor, SizePriTensorHelper())],
+            expected_order,
+        )
+
+        # dfs don't follow size pri order
+        self.assertNotEqual(
+            [node._attrs["name"] for node in _dfsSort(tensor)], expected_order
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Following the suggestion in T147269828,
Use Kahn's algorithm with a priority queue, the priority definition of the priority queue would be the order of the sorted graph.

Following this note: https://fb.workplace.com/notes/1322142898565804 , added a "SizePriTensorHelper" , which larger size tensor would be in the top rank of the sorted graph.

In the future if we'd like to test different types of priority, simply add a new class inherited from "PriTensorHelper", overwrite the function "get_priority"

Differential Revision: D43994537

