### PR TITLE
Adding a configurable directory for saving compiled model artifacts

### DIFF
--- a/examples/05_stable_diffusion/scripts/compile.py
+++ b/examples/05_stable_diffusion/scripts/compile.py
@@ -27,6 +27,7 @@ if __name__ == "__main__":
 from src.compile_lib.compile_clip import compile_clip
 from src.compile_lib.compile_unet import compile_unet
 from src.compile_lib.compile_vae import compile_vae
+from src.compile_lib.util import get_work_dir_location_diffusers
 
 
 @click.command()
@@ -47,20 +48,15 @@ def compile_diffusers(
     torch.manual_seed(4896)
     
     """
-        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
-        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
-        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
-        current working directory. 
-    """
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the it will look for compiled artifacts under 
+    tmp/ folder of the current working directory. 
     
-    env_name = "AITEMPLATE_WORK_DIR"
-    try:
-        if os.environ[env_name]:
-            local_dir = os.path.join(os.environ[env_name], 'diffusers-pipeline', 'stabilityai','stable-diffusion-v2')
-            print("The value of", env_name, " is ", local_dir)
-    except KeyError:
-        print("AITEMPLATE_WORK_DIR environment variable is not set. Using default local dir as ",local_dir)
-
+    """
+    local_dir = get_work_dir_location_diffusers()
+    
     if detect_target().name() == "rocm":
         convert_conv_to_gemm = False
 

--- a/examples/05_stable_diffusion/scripts/compile.py
+++ b/examples/05_stable_diffusion/scripts/compile.py
@@ -15,7 +15,6 @@
 import logging
 
 import click
-import os
 import torch
 from aitemplate.testing import detect_target
 from aitemplate.utils.import_path import import_parent
@@ -47,14 +46,6 @@ def compile_diffusers(
     logging.getLogger().setLevel(logging.INFO)
     torch.manual_seed(4896)
     
-    """
-    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
-    Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the it will look for compiled artifacts under 
-    tmp/ folder of the current working directory. 
-    
-    """
     local_dir = get_work_dir_location_diffusers()
     
     if detect_target().name() == "rocm":

--- a/examples/05_stable_diffusion/scripts/compile.py
+++ b/examples/05_stable_diffusion/scripts/compile.py
@@ -30,18 +30,13 @@ from src.compile_lib.util import get_work_dir_location_diffusers
 
 
 @click.command()
-@click.option(
-    "--local-dir",
-    default="./tmp/diffusers-pipeline/stabilityai/stable-diffusion-v2",
-    help="the local diffusers pipeline directory",
-)
 @click.option("--width", default=512, help="Width of generated image")
 @click.option("--height", default=512, help="Height of generated image")
 @click.option("--batch-size", default=1, help="batch size")
 @click.option("--use-fp16-acc", default=True, help="use fp16 accumulation")
 @click.option("--convert-conv-to-gemm", default=True, help="convert 1x1 conv to gemm")
 def compile_diffusers(
-    local_dir, width, height, batch_size, use_fp16_acc=True, convert_conv_to_gemm=True
+    width, height, batch_size, use_fp16_acc=True, convert_conv_to_gemm=True
 ):
     logging.getLogger().setLevel(logging.INFO)
     torch.manual_seed(4896)

--- a/examples/05_stable_diffusion/scripts/compile.py
+++ b/examples/05_stable_diffusion/scripts/compile.py
@@ -15,6 +15,7 @@
 import logging
 
 import click
+import os
 import torch
 from aitemplate.testing import detect_target
 from aitemplate.utils.import_path import import_parent
@@ -44,6 +45,21 @@ def compile_diffusers(
 ):
     logging.getLogger().setLevel(logging.INFO)
     torch.manual_seed(4896)
+    
+    """
+        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
+        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
+        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
+        current working directory. 
+    """
+    
+    env_name = "AITEMPLATE_WORK_DIR"
+    try:
+        if os.environ[env_name]:
+            local_dir = os.path.join(os.environ[env_name], 'diffusers-pipeline', 'stabilityai','stable-diffusion-v2')
+            print("The value of", env_name, " is ", local_dir)
+    except KeyError:
+        print("AITEMPLATE_WORK_DIR environment variable is not set. Using default local dir as ",local_dir)
 
     if detect_target().name() == "rocm":
         convert_conv_to_gemm = False

--- a/examples/05_stable_diffusion/scripts/demo.py
+++ b/examples/05_stable_diffusion/scripts/demo.py
@@ -15,6 +15,7 @@
 
 import click
 import torch
+import os
 
 from aitemplate.testing.benchmark_pt import benchmark_torch_function
 from aitemplate.utils.import_path import import_parent
@@ -39,6 +40,25 @@ from src.pipeline_stable_diffusion_ait import StableDiffusionAITPipeline
     "--benchmark", type=bool, default=False, help="run stable diffusion e2e benchmark"
 )
 def run(local_dir, width, height, prompt, benchmark):
+    
+    
+    """
+        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
+        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
+        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
+        current working directory. 
+    """
+
+    env_name = "AITEMPLATE_WORK_DIR"
+    try:
+        if os.environ[env_name]:
+            local_dir = os.path.join(os.environ[env_name], 'diffusers-pipeline', 'stabilityai','stable-diffusion-v2')
+            print("The value of", env_name, " is ", local_dir)
+    except KeyError:
+        print("AITEMPLATE_WORK_DIR environment variable is not set. Using default local dir as ",local_dir)
+
+    
+    
     pipe = StableDiffusionAITPipeline.from_pretrained(
         local_dir,
         scheduler=EulerDiscreteScheduler.from_pretrained(

--- a/examples/05_stable_diffusion/scripts/demo.py
+++ b/examples/05_stable_diffusion/scripts/demo.py
@@ -28,18 +28,13 @@ from src.compile_lib.util import get_work_dir_location_diffusers
 
 
 @click.command()
-@click.option(
-    "--local-dir",
-    default="./tmp/diffusers-pipeline/stabilityai/stable-diffusion-v2",
-    help="the local diffusers pipeline directory",
-)
 @click.option("--width", default=512, help="Width of generated image")
 @click.option("--height", default=512, help="Height of generated image")
 @click.option("--prompt", default="A vision of paradise, Unreal Engine", help="prompt")
 @click.option(
     "--benchmark", type=bool, default=False, help="run stable diffusion e2e benchmark"
 )
-def run(local_dir, width, height, prompt, benchmark):
+def run(width, height, prompt, benchmark):
     
     local_dir = get_work_dir_location_diffusers()  
     

--- a/examples/05_stable_diffusion/scripts/demo.py
+++ b/examples/05_stable_diffusion/scripts/demo.py
@@ -15,7 +15,6 @@
 
 import click
 import torch
-import os
 
 from aitemplate.testing.benchmark_pt import benchmark_torch_function
 from aitemplate.utils.import_path import import_parent
@@ -42,16 +41,6 @@ from src.compile_lib.util import get_work_dir_location_diffusers
 )
 def run(local_dir, width, height, prompt, benchmark):
     
-    
-    """
-    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
-    Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the it will look for compiled artifacts under 
-    tmp/ folder of the current working directory. 
-    
-    """
-
     local_dir = get_work_dir_location_diffusers()  
     
     pipe = StableDiffusionAITPipeline.from_pretrained(

--- a/examples/05_stable_diffusion/scripts/demo.py
+++ b/examples/05_stable_diffusion/scripts/demo.py
@@ -25,6 +25,7 @@ if __name__ == "__main__":
     import_parent(filepath=__file__, level=1)
 
 from src.pipeline_stable_diffusion_ait import StableDiffusionAITPipeline
+from src.compile_lib.util import get_work_dir_location_diffusers
 
 
 @click.command()
@@ -43,21 +44,15 @@ def run(local_dir, width, height, prompt, benchmark):
     
     
     """
-        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
-        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
-        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
-        current working directory. 
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the it will look for compiled artifacts under 
+    tmp/ folder of the current working directory. 
+    
     """
 
-    env_name = "AITEMPLATE_WORK_DIR"
-    try:
-        if os.environ[env_name]:
-            local_dir = os.path.join(os.environ[env_name], 'diffusers-pipeline', 'stabilityai','stable-diffusion-v2')
-            print("The value of", env_name, " is ", local_dir)
-    except KeyError:
-        print("AITEMPLATE_WORK_DIR environment variable is not set. Using default local dir as ",local_dir)
-
-    
+    local_dir = get_work_dir_location_diffusers()  
     
     pipe = StableDiffusionAITPipeline.from_pretrained(
         local_dir,

--- a/examples/05_stable_diffusion/scripts/demo_img2img.py
+++ b/examples/05_stable_diffusion/scripts/demo_img2img.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 #
 from io import BytesIO
-
+import os
 import click
 import requests
 import torch
@@ -43,6 +43,22 @@ from src.pipeline_stable_diffusion_img2img_ait import StableDiffusionImg2ImgAITP
     "--benchmark", type=bool, default=False, help="run stable diffusion e2e benchmark"
 )
 def run(local_dir, width, height, prompt, benchmark):
+
+     
+    """
+        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
+        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
+        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
+        current working directory. 
+    """
+
+    env_name = "AITEMPLATE_WORK_DIR"
+    try:
+        if os.environ[env_name]:
+            local_dir = os.path.join(os.environ[env_name], 'diffusers-pipeline', 'stabilityai','stable-diffusion-v2')
+            print("The value of", env_name, " is ", local_dir)
+    except KeyError:
+        print("AITEMPLATE_WORK_DIR environment variable is not set. Using default local dir as ",local_dir)
 
     # load the pipeline
     device = "cuda"

--- a/examples/05_stable_diffusion/scripts/demo_img2img.py
+++ b/examples/05_stable_diffusion/scripts/demo_img2img.py
@@ -29,11 +29,6 @@ from src.compile_lib.util import get_work_dir_location_diffusers
 
 
 @click.command()
-@click.option(
-    "--local-dir",
-    default="./tmp/diffusers-pipeline/stabilityai/stable-diffusion-v2",
-    help="the local diffusers pipeline directory",
-)
 @click.option("--width", default=512, help="Width of generated image")
 @click.option("--height", default=512, help="Height of generated image")
 @click.option(
@@ -42,7 +37,7 @@ from src.compile_lib.util import get_work_dir_location_diffusers
 @click.option(
     "--benchmark", type=bool, default=False, help="run stable diffusion e2e benchmark"
 )
-def run(local_dir, width, height, prompt, benchmark):
+def run(width, height, prompt, benchmark):
 
     local_dir = get_work_dir_location_diffusers()    
 

--- a/examples/05_stable_diffusion/scripts/demo_img2img.py
+++ b/examples/05_stable_diffusion/scripts/demo_img2img.py
@@ -26,6 +26,7 @@ if __name__ == "__main__":
     import_parent(filepath=__file__, level=1)
 
 from src.pipeline_stable_diffusion_img2img_ait import StableDiffusionImg2ImgAITPipeline
+from src.compile_lib.util import get_work_dir_location_diffusers
 
 
 @click.command()
@@ -46,19 +47,15 @@ def run(local_dir, width, height, prompt, benchmark):
 
      
     """
-        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
-        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
-        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
-        current working directory. 
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the it will look for compiled artifacts under 
+    tmp/ folder of the current working directory. 
+    
     """
-
-    env_name = "AITEMPLATE_WORK_DIR"
-    try:
-        if os.environ[env_name]:
-            local_dir = os.path.join(os.environ[env_name], 'diffusers-pipeline', 'stabilityai','stable-diffusion-v2')
-            print("The value of", env_name, " is ", local_dir)
-    except KeyError:
-        print("AITEMPLATE_WORK_DIR environment variable is not set. Using default local dir as ",local_dir)
+    
+    local_dir = get_work_dir_location_diffusers()    
 
     # load the pipeline
     device = "cuda"

--- a/examples/05_stable_diffusion/scripts/demo_img2img.py
+++ b/examples/05_stable_diffusion/scripts/demo_img2img.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 #
 from io import BytesIO
-import os
 import click
 import requests
 import torch
@@ -45,16 +44,6 @@ from src.compile_lib.util import get_work_dir_location_diffusers
 )
 def run(local_dir, width, height, prompt, benchmark):
 
-     
-    """
-    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
-    Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the it will look for compiled artifacts under 
-    tmp/ folder of the current working directory. 
-    
-    """
-    
     local_dir = get_work_dir_location_diffusers()    
 
     # load the pipeline

--- a/examples/05_stable_diffusion/scripts/download_pipeline.py
+++ b/examples/05_stable_diffusion/scripts/download_pipeline.py
@@ -16,7 +16,8 @@ import click
 import torch
 from diffusers import StableDiffusionPipeline
 from aitemplate.utils.import_path import import_parent
-import_parent(filepath=__file__, level=1)
+if __name__ == "__main__":
+    import_parent(filepath=__file__, level=1)
 from src.compile_lib.util import get_work_dir_location_diffusers
 
 

--- a/examples/05_stable_diffusion/scripts/download_pipeline.py
+++ b/examples/05_stable_diffusion/scripts/download_pipeline.py
@@ -16,6 +16,9 @@ import click
 import torch
 import os
 from diffusers import StableDiffusionPipeline
+from aitemplate.utils.import_path import import_parent
+import_parent(filepath=__file__, level=1)
+from src.compile_lib.util import get_work_dir_location_diffusers
 
 
 @click.command()
@@ -28,19 +31,15 @@ from diffusers import StableDiffusionPipeline
 def download_pipeline_files(token, save_directory) -> None:
     
     """
-        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
-        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
-        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
-        current working directory. 
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the it will look for compiled artifacts under 
+    tmp/ folder of the current working directory. 
+    
     """
 
-    env_name = "AITEMPLATE_WORK_DIR"
-    try:
-        if os.environ[env_name]:
-            save_directory = os.path.join(os.environ[env_name], 'diffusers-pipeline', 'stabilityai','stable-diffusion-v2')
-            print("The value of", env_name, " is ", save_directory)
-    except KeyError:
-        print("AITEMPLATE_WORK_DIR environment variable is not set. Using default local dir as ",save_directory)
+    save_directory = get_work_dir_location_diffusers()  
 
     StableDiffusionPipeline.from_pretrained(
         "stabilityai/stable-diffusion-2-1-base",

--- a/examples/05_stable_diffusion/scripts/download_pipeline.py
+++ b/examples/05_stable_diffusion/scripts/download_pipeline.py
@@ -23,7 +23,6 @@ from src.compile_lib.util import get_work_dir_location_diffusers
 
 @click.command()
 @click.option("--token", default="", help="access token")
-
 def download_pipeline_files(token) -> None:
     
     save_directory = get_work_dir_location_diffusers()  

--- a/examples/05_stable_diffusion/scripts/download_pipeline.py
+++ b/examples/05_stable_diffusion/scripts/download_pipeline.py
@@ -14,6 +14,7 @@
 #
 import click
 import torch
+import os
 from diffusers import StableDiffusionPipeline
 
 
@@ -25,6 +26,22 @@ from diffusers import StableDiffusionPipeline
     help="pipeline files local directory",
 )
 def download_pipeline_files(token, save_directory) -> None:
+    
+    """
+        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
+        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
+        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
+        current working directory. 
+    """
+
+    env_name = "AITEMPLATE_WORK_DIR"
+    try:
+        if os.environ[env_name]:
+            save_directory = os.path.join(os.environ[env_name], 'diffusers-pipeline', 'stabilityai','stable-diffusion-v2')
+            print("The value of", env_name, " is ", save_directory)
+    except KeyError:
+        print("AITEMPLATE_WORK_DIR environment variable is not set. Using default local dir as ",save_directory)
+
     StableDiffusionPipeline.from_pretrained(
         "stabilityai/stable-diffusion-2-1-base",
         revision="fp16",

--- a/examples/05_stable_diffusion/scripts/download_pipeline.py
+++ b/examples/05_stable_diffusion/scripts/download_pipeline.py
@@ -23,12 +23,8 @@ from src.compile_lib.util import get_work_dir_location_diffusers
 
 @click.command()
 @click.option("--token", default="", help="access token")
-@click.option(
-    "--save_directory",
-    default="./tmp/diffusers-pipeline/stabilityai/stable-diffusion-v2",
-    help="pipeline files local directory",
-)
-def download_pipeline_files(token, save_directory) -> None:
+
+def download_pipeline_files(token) -> None:
     
     save_directory = get_work_dir_location_diffusers()  
 

--- a/examples/05_stable_diffusion/scripts/download_pipeline.py
+++ b/examples/05_stable_diffusion/scripts/download_pipeline.py
@@ -14,7 +14,6 @@
 #
 import click
 import torch
-import os
 from diffusers import StableDiffusionPipeline
 from aitemplate.utils.import_path import import_parent
 import_parent(filepath=__file__, level=1)
@@ -30,15 +29,6 @@ from src.compile_lib.util import get_work_dir_location_diffusers
 )
 def download_pipeline_files(token, save_directory) -> None:
     
-    """
-    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
-    Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the it will look for compiled artifacts under 
-    tmp/ folder of the current working directory. 
-    
-    """
-
     save_directory = get_work_dir_location_diffusers()  
 
     StableDiffusionPipeline.from_pretrained(

--- a/examples/05_stable_diffusion/src/benchmark.py
+++ b/examples/05_stable_diffusion/src/benchmark.py
@@ -19,7 +19,6 @@ import click
 
 
 import numpy as np
-import os
 import torch
 from aitemplate.compiler import Model
 from aitemplate.testing import detect_target
@@ -29,9 +28,9 @@ from diffusers import StableDiffusionPipeline
 from torch import autocast
 from transformers import CLIPTokenizer
 from compile_lib.util import get_work_dir_location_diffusers
-from compile_lib.util import get_file_location_CLIP
-from compile_lib.util import get_file_location_Autoencoder
-from compile_lib.util import get_file_location_Unet
+from compile_lib.util import get_file_location_clip
+from compile_lib.util import get_file_location_autoencoder
+from compile_lib.util import get_file_location_unet
 
 
 USE_CUDA = detect_target().name() == "cuda"
@@ -63,15 +62,7 @@ def benchmark_unet(
     verify=False,
 ):
 
-    """
-    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
-    Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the it will look for compiled artifacts under 
-    tmp/ folder of the current working directory. 
-    """
-
-    file_name = get_file_location_Unet()
+    file_name = get_file_location_unet()
     
     exe_module = Model(file_name)
     if exe_module is None:
@@ -148,16 +139,7 @@ def benchmark_clip(
 ):
     mask_seq = 0
 
-    """
-    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
-    Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the it will look for compiled artifacts under 
-    tmp/ folder of the current working directory. 
-    
-    """
-    
-    file_name = get_file_location_CLIP()
+    file_name = get_file_location_clip()
         
     exe_module = Model(file_name)
     
@@ -234,15 +216,7 @@ def benchmark_vae(
 
     latent_channels = 4
 
-    """
-    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
-    Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the it will look for compiled artifacts under 
-    tmp/ folder of the current working directory. 
-    
-    """
-    file_name = get_file_location_Autoencoder()
+    file_name = get_file_location_autoencoder()
         
     exe_module = Model(file_name)
     if exe_module is None:
@@ -321,14 +295,6 @@ def benchmark_diffusers(local_dir, batch_size, verify, benchmark_pt):
     np.random.seed(0)
     torch.manual_seed(4896)
 
-    """
-    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
-    Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the it will look for compiled artifacts under 
-    tmp/ folder of the current working directory. 
-    
-    """
     local_dir = get_work_dir_location_diffusers()
 
     pipe = StableDiffusionPipeline.from_pretrained(

--- a/examples/05_stable_diffusion/src/benchmark.py
+++ b/examples/05_stable_diffusion/src/benchmark.py
@@ -16,6 +16,7 @@
 import logging
 
 import click
+import os
 
 import numpy as np
 import torch
@@ -56,7 +57,22 @@ def benchmark_unet(
     verify=False,
 ):
 
-    exe_module = Model("./tmp/UNet2DConditionModel/test.so")
+    """
+        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
+        has AITemplate compiled artifacts the model(s). Make sure the OS user running this script has read and write 
+        permissions to this directory. By default, the it will look for compiled artifacts under tmp/ folder of the 
+        current working directory. 
+    """
+
+    env_name = "AITEMPLATE_WORK_DIR"
+    try:
+        if os.environ[env_name]:
+            file_name = os.path.join(os.environ[env_name], 'UNet2DConditionModel', 'test.so')
+            print("The value of", env_name, " is ", file_name)
+    except KeyError:
+        file_name = "./tmp/UNet2DConditionModel/test.so"
+        print("The value of", env_name, " is ", file_name)
+    exe_module = Model(file_name)
     if exe_module is None:
         print("Error!! Cannot find compiled module for UNet2DConditionModel.")
         exit(-1)
@@ -131,7 +147,17 @@ def benchmark_clip(
 ):
     mask_seq = 0
 
-    exe_module = Model("./tmp/CLIPTextModel/test.so")
+    env_name = "AITEMPLATE_WORK_DIR"
+    try:
+        if os.environ[env_name]:
+            file_name = os.path.join(os.environ[env_name], 'CLIPTextModel', 'test.so')
+            print("The value of", env_name, " is ", file_name)
+    except KeyError:
+        file_name = "./tmp/CLIPTextModel/test.so"
+        print("The value of", env_name, " is ", file_name)
+        
+    exe_module = Model(file_name)
+    
     if exe_module is None:
         print("Error!! Cannot find compiled module for CLIPTextModel.")
         exit(-1)
@@ -205,7 +231,16 @@ def benchmark_vae(
 
     latent_channels = 4
 
-    exe_module = Model("./tmp/AutoencoderKL/test.so")
+    env_name = "AITEMPLATE_WORK_DIR"
+    try:
+        if os.environ[env_name]:
+            file_name = os.path.join(os.environ[env_name], 'AutoencoderKL', 'test.so')
+            print("The value of", env_name, " is ", file_name)
+    except KeyError:
+        file_name = "./tmp/AutoencoderKL/test.so"
+        print("The value of", env_name, " is ", file_name)
+        
+    exe_module = Model(file_name)
     if exe_module is None:
         print("Error!! Cannot find compiled module for AutoencoderKL.")
         exit(-1)
@@ -281,6 +316,13 @@ def benchmark_diffusers(local_dir, batch_size, verify, benchmark_pt):
     logging.getLogger().setLevel(logging.INFO)
     np.random.seed(0)
     torch.manual_seed(4896)
+    env_name = "AITEMPLATE_WORK_DIR"
+    try:
+        if os.environ[env_name]:
+            local_dir = os.path.join(os.environ[env_name], 'diffusers-pipeline', 'stabilityai','stable-diffusion-v2')
+            print("The value of", env_name, " is ", local_dir)
+    except KeyError:
+        print("AITEMPLATE_WORK_DIR environment variable is not set. Using default local dir as ",local_dir)
 
     pipe = StableDiffusionPipeline.from_pretrained(
         local_dir,

--- a/examples/05_stable_diffusion/src/benchmark.py
+++ b/examples/05_stable_diffusion/src/benchmark.py
@@ -16,9 +16,10 @@
 import logging
 
 import click
-import os
+
 
 import numpy as np
+import os
 import torch
 from aitemplate.compiler import Model
 from aitemplate.testing import detect_target
@@ -27,6 +28,11 @@ from diffusers import StableDiffusionPipeline
 
 from torch import autocast
 from transformers import CLIPTokenizer
+from compile_lib.util import get_work_dir_location_diffusers
+from compile_lib.util import get_file_location_CLIP
+from compile_lib.util import get_file_location_Autoencoder
+from compile_lib.util import get_file_location_Unet
+
 
 USE_CUDA = detect_target().name() == "cuda"
 
@@ -58,20 +64,15 @@ def benchmark_unet(
 ):
 
     """
-        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
-        has AITemplate compiled artifacts the model(s). Make sure the OS user running this script has read and write 
-        permissions to this directory. By default, the it will look for compiled artifacts under tmp/ folder of the 
-        current working directory. 
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the it will look for compiled artifacts under 
+    tmp/ folder of the current working directory. 
     """
 
-    env_name = "AITEMPLATE_WORK_DIR"
-    try:
-        if os.environ[env_name]:
-            file_name = os.path.join(os.environ[env_name], 'UNet2DConditionModel', 'test.so')
-            print("The value of", env_name, " is ", file_name)
-    except KeyError:
-        file_name = "./tmp/UNet2DConditionModel/test.so"
-        print("The value of", env_name, " is ", file_name)
+    file_name = get_file_location_Unet()
+    
     exe_module = Model(file_name)
     if exe_module is None:
         print("Error!! Cannot find compiled module for UNet2DConditionModel.")
@@ -147,14 +148,16 @@ def benchmark_clip(
 ):
     mask_seq = 0
 
-    env_name = "AITEMPLATE_WORK_DIR"
-    try:
-        if os.environ[env_name]:
-            file_name = os.path.join(os.environ[env_name], 'CLIPTextModel', 'test.so')
-            print("The value of", env_name, " is ", file_name)
-    except KeyError:
-        file_name = "./tmp/CLIPTextModel/test.so"
-        print("The value of", env_name, " is ", file_name)
+    """
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the it will look for compiled artifacts under 
+    tmp/ folder of the current working directory. 
+    
+    """
+    
+    file_name = get_file_location_CLIP()
         
     exe_module = Model(file_name)
     
@@ -231,14 +234,15 @@ def benchmark_vae(
 
     latent_channels = 4
 
-    env_name = "AITEMPLATE_WORK_DIR"
-    try:
-        if os.environ[env_name]:
-            file_name = os.path.join(os.environ[env_name], 'AutoencoderKL', 'test.so')
-            print("The value of", env_name, " is ", file_name)
-    except KeyError:
-        file_name = "./tmp/AutoencoderKL/test.so"
-        print("The value of", env_name, " is ", file_name)
+    """
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the it will look for compiled artifacts under 
+    tmp/ folder of the current working directory. 
+    
+    """
+    file_name = get_file_location_Autoencoder()
         
     exe_module = Model(file_name)
     if exe_module is None:
@@ -316,13 +320,16 @@ def benchmark_diffusers(local_dir, batch_size, verify, benchmark_pt):
     logging.getLogger().setLevel(logging.INFO)
     np.random.seed(0)
     torch.manual_seed(4896)
-    env_name = "AITEMPLATE_WORK_DIR"
-    try:
-        if os.environ[env_name]:
-            local_dir = os.path.join(os.environ[env_name], 'diffusers-pipeline', 'stabilityai','stable-diffusion-v2')
-            print("The value of", env_name, " is ", local_dir)
-    except KeyError:
-        print("AITEMPLATE_WORK_DIR environment variable is not set. Using default local dir as ",local_dir)
+
+    """
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the it will look for compiled artifacts under 
+    tmp/ folder of the current working directory. 
+    
+    """
+    local_dir = get_work_dir_location_diffusers()
 
     pipe = StableDiffusionPipeline.from_pretrained(
         local_dir,

--- a/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
@@ -14,9 +14,11 @@
 #
 import numpy as np
 import torch
+import os
 from aitemplate.compiler import compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
+
 
 from ..modeling.clip import CLIPTextTransformer as ait_CLIPTextTransformer
 from .util import mark_output
@@ -117,4 +119,20 @@ def compile_clip(
     target = detect_target(
         use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm
     )
-    compile_model(Y, target, "./tmp", "CLIPTextModel", constants=params_ait)
+    """
+        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
+        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
+        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
+        current working directory. 
+    """
+
+    env_name = "AITEMPLATE_WORK_DIR"
+    try:
+        if os.environ[env_name]:
+            workdir = os.environ[env_name]
+            print("The value of", env_name, " is ", workdir)
+    except KeyError:
+        workdir = "tmp/"
+        print("The value of", env_name, " is ", workdir)   
+    
+    compile_model(Y, target, workdir, "CLIPTextModel", constants=params_ait)

--- a/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
@@ -21,6 +21,7 @@ from aitemplate.testing import detect_target
 
 
 from ..modeling.clip import CLIPTextTransformer as ait_CLIPTextTransformer
+from .util import get_work_dir_location
 from .util import mark_output
 
 
@@ -119,20 +120,14 @@ def compile_clip(
     target = detect_target(
         use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm
     )
-    """
-        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
-        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
-        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
-        current working directory. 
-    """
 
-    env_name = "AITEMPLATE_WORK_DIR"
-    try:
-        if os.environ[env_name]:
-            workdir = os.environ[env_name]
-            print("The value of", env_name, " is ", workdir)
-    except KeyError:
-        workdir = "tmp/"
-        print("The value of", env_name, " is ", workdir)   
+    """
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the artifacts will be saved under tmp/ folder of 
+    the current working directory. 
+    """
+    workdir = get_work_dir_location()  
     
     compile_model(Y, target, workdir, "CLIPTextModel", constants=params_ait)

--- a/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
@@ -14,7 +14,6 @@
 #
 import numpy as np
 import torch
-import os
 from aitemplate.compiler import compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -121,13 +120,6 @@ def compile_clip(
         use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm
     )
 
-    """
-    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
-    Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the artifacts will be saved under tmp/ folder of 
-    the current working directory. 
-    """
     workdir = get_work_dir_location()  
     
     compile_model(Y, target, workdir, "CLIPTextModel", constants=params_ait)

--- a/examples/05_stable_diffusion/src/compile_lib/compile_unet.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_unet.py
@@ -22,6 +22,7 @@ import os
 from ..modeling.unet_2d_condition import (
     UNet2DConditionModel as ait_UNet2DConditionModel,
 )
+from .util import get_work_dir_location
 from .util import mark_output
 
 
@@ -86,19 +87,14 @@ def compile_unet(
     target = detect_target(
         use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm
     )
+    
     """
-        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
-        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
-        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
-        current working directory. 
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the artifacts will be saved under tmp/ folder of 
+    the current working directory. 
     """
-
-    env_name = "AITEMPLATE_WORK_DIR"
-    try:
-        if os.environ[env_name]:
-            workdir = os.environ[env_name]
-            print("The value of", env_name, " is ", workdir)
-    except KeyError:
-        workdir = "tmp/"
-        print("The value of", env_name, " is ", workdir)   
-    compile_model(Y, target,workdir, "UNet2DConditionModel", constants=params_ait)
+    workdir = get_work_dir_location()
+    
+    compile_model(Y, target, workdir, "UNet2DConditionModel", constants=params_ait)

--- a/examples/05_stable_diffusion/src/compile_lib/compile_unet.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_unet.py
@@ -17,6 +17,7 @@ import torch
 from aitemplate.compiler import compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
+import os
 
 from ..modeling.unet_2d_condition import (
     UNet2DConditionModel as ait_UNet2DConditionModel,
@@ -85,4 +86,19 @@ def compile_unet(
     target = detect_target(
         use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm
     )
-    compile_model(Y, target, "./tmp", "UNet2DConditionModel", constants=params_ait)
+    """
+        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
+        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
+        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
+        current working directory. 
+    """
+
+    env_name = "AITEMPLATE_WORK_DIR"
+    try:
+        if os.environ[env_name]:
+            workdir = os.environ[env_name]
+            print("The value of", env_name, " is ", workdir)
+    except KeyError:
+        workdir = "tmp/"
+        print("The value of", env_name, " is ", workdir)   
+    compile_model(Y, target,workdir, "UNet2DConditionModel", constants=params_ait)

--- a/examples/05_stable_diffusion/src/compile_lib/compile_unet.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_unet.py
@@ -17,7 +17,6 @@ import torch
 from aitemplate.compiler import compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
-import os
 
 from ..modeling.unet_2d_condition import (
     UNet2DConditionModel as ait_UNet2DConditionModel,
@@ -88,13 +87,6 @@ def compile_unet(
         use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm
     )
     
-    """
-    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
-    Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the artifacts will be saved under tmp/ folder of 
-    the current working directory. 
-    """
     workdir = get_work_dir_location()
     
     compile_model(Y, target, workdir, "UNet2DConditionModel", constants=params_ait)

--- a/examples/05_stable_diffusion/src/compile_lib/compile_vae.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_vae.py
@@ -15,7 +15,6 @@
 from collections import OrderedDict
 
 import numpy as np
-import os
 import torch
 from aitemplate.compiler import compile_model
 from aitemplate.frontend import Tensor
@@ -132,15 +131,6 @@ def compile_vae(
     target = detect_target(
         use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm
     )
-    
-    
-    """
-    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
-    Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the artifacts will be saved under tmp/ folder of 
-    the current working directory. 
-    """
     
     workdir = get_work_dir_location()
         

--- a/examples/05_stable_diffusion/src/compile_lib/compile_vae.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_vae.py
@@ -15,7 +15,7 @@
 from collections import OrderedDict
 
 import numpy as np
-
+import os
 import torch
 from aitemplate.compiler import compile_model
 from aitemplate.frontend import Tensor
@@ -131,10 +131,28 @@ def compile_vae(
     target = detect_target(
         use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm
     )
+    
+    
+    """
+        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
+        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
+        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
+        current working directory. 
+    """
+
+    env_name = "AITEMPLATE_WORK_DIR"
+    try:
+        if os.environ[env_name]:
+            workdir = os.environ[env_name]
+            print("The value of", env_name, " is ", workdir)
+    except KeyError:
+        workdir = "tmp/"
+        print("The value of", env_name, " is ", workdir)   
+        
     compile_model(
         Y,
         target,
-        "./tmp",
+        workdir,
         "AutoencoderKL",
         constants=params_ait,
     )

--- a/examples/05_stable_diffusion/src/compile_lib/compile_vae.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_vae.py
@@ -22,6 +22,7 @@ from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 
 from ..modeling.vae import AutoencoderKL as ait_AutoencoderKL
+from .util import get_work_dir_location
 from .util import mark_output
 
 
@@ -134,20 +135,14 @@ def compile_vae(
     
     
     """
-        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
-        will be used to save the AIT compiled model artifacts. Make sure the OS user running this script has read and write 
-        permissions to this directory. By default, the artifacts will be saved under tmp/ folder of the 
-        current working directory. 
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the artifacts will be saved under tmp/ folder of 
+    the current working directory. 
     """
-
-    env_name = "AITEMPLATE_WORK_DIR"
-    try:
-        if os.environ[env_name]:
-            workdir = os.environ[env_name]
-            print("The value of", env_name, " is ", workdir)
-    except KeyError:
-        workdir = "tmp/"
-        print("The value of", env_name, " is ", workdir)   
+    
+    workdir = get_work_dir_location()
         
     compile_model(
         Y,

--- a/examples/05_stable_diffusion/src/compile_lib/util.py
+++ b/examples/05_stable_diffusion/src/compile_lib/util.py
@@ -48,9 +48,8 @@ def get_work_dir_location_diffusers():
     Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
     path to a directory which has AITemplate compiled artifacts the model(s). 
     Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the it will look for compiled artifacts under 
+    this directory. By default, it will look for compiled artifacts under 
     tmp/ folder of the current working directory. 
-    
     """
     
     env_name = "AITEMPLATE_WORK_DIR"
@@ -62,14 +61,13 @@ def get_work_dir_location_diffusers():
     print("The value of {} is {}".format(env_name, local_dir)) 
     return local_dir
 
-def get_file_location_CLIP():
+def get_file_location_clip():
     """
     Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
     path to a directory which has AITemplate compiled artifacts the model(s). 
     Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the it will look for compiled artifacts under 
+    this directory. By default, it will look for compiled artifacts under 
     tmp/ folder of the current working directory. 
-    
     """
     
     env_name = "AITEMPLATE_WORK_DIR"
@@ -81,15 +79,14 @@ def get_file_location_CLIP():
     print("The value of {} is {}".format(env_name, file_name)) 
     return file_name
 
-def get_file_location_Autoencoder():
+def get_file_location_autoencoder():
     
     """
     Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
     path to a directory which has AITemplate compiled artifacts the model(s). 
     Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the it will look for compiled artifacts under 
+    this directory. By default, it will look for compiled artifacts under 
     tmp/ folder of the current working directory. 
-    
     """
     
     env_name = "AITEMPLATE_WORK_DIR"
@@ -102,13 +99,13 @@ def get_file_location_Autoencoder():
     
     return file_name
 
-def get_file_location_Unet():
+def get_file_location_unet():
     
     """
     Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
     path to a directory which has AITemplate compiled artifacts the model(s). 
     Make sure the OS user running this script has read and write permissions to 
-    this directory. By default, the it will look for compiled artifacts under 
+    this directory. By default, it will look for compiled artifacts under 
     tmp/ folder of the current working directory. 
     """
 

--- a/examples/05_stable_diffusion/src/compile_lib/util.py
+++ b/examples/05_stable_diffusion/src/compile_lib/util.py
@@ -27,7 +27,7 @@ def get_work_dir_location():
     
     """
     Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
+    path to a directory which has AITemplate compiled artifacts of the model(s). 
     Make sure the OS user running this script has read and write permissions to 
     this directory. By default, the artifacts will be saved under tmp/ folder of 
     the current working directory. 
@@ -46,7 +46,7 @@ def get_work_dir_location_diffusers():
     
     """
     Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
+    path to a directory which has AITemplate compiled artifacts of the model(s). 
     Make sure the OS user running this script has read and write permissions to 
     this directory. By default, it will look for compiled artifacts under 
     tmp/ folder of the current working directory. 
@@ -64,7 +64,7 @@ def get_work_dir_location_diffusers():
 def get_file_location_clip():
     """
     Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
+    path to a directory which has AITemplate compiled artifacts of the model(s). 
     Make sure the OS user running this script has read and write permissions to 
     this directory. By default, it will look for compiled artifacts under 
     tmp/ folder of the current working directory. 
@@ -83,7 +83,7 @@ def get_file_location_autoencoder():
     
     """
     Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
+    path to a directory which has AITemplate compiled artifacts of the model(s). 
     Make sure the OS user running this script has read and write permissions to 
     this directory. By default, it will look for compiled artifacts under 
     tmp/ folder of the current working directory. 
@@ -103,7 +103,7 @@ def get_file_location_unet():
     
     """
     Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-    path to a directory which has AITemplate compiled artifacts the model(s). 
+    path to a directory which has AITemplate compiled artifacts of the model(s). 
     Make sure the OS user running this script has read and write permissions to 
     this directory. By default, it will look for compiled artifacts under 
     tmp/ folder of the current working directory. 

--- a/examples/05_stable_diffusion/src/compile_lib/util.py
+++ b/examples/05_stable_diffusion/src/compile_lib/util.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import os
+
 def mark_output(y):
     if type(y) is not tuple:
         y = (y,)
@@ -20,3 +22,102 @@ def mark_output(y):
         y[i]._attrs["name"] = "output_%d" % (i)
         y_shape = [d._attrs["values"][0] for d in y[i]._attrs["shape"]]
         print("AIT output_{} shape: {}".format(i, y_shape))
+        
+def get_work_dir_location():
+    
+    """
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the artifacts will be saved under tmp/ folder of 
+    the current working directory. 
+    """
+        
+    env_name = "AITEMPLATE_WORK_DIR"
+    workdir = "tmp/"    
+    if env_name in os.environ:
+        workdir = os.environ[env_name]     
+            
+    print("The value of {} is {}".format(env_name, workdir))  
+    
+    return workdir
+
+def get_work_dir_location_diffusers():
+    
+    """
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the it will look for compiled artifacts under 
+    tmp/ folder of the current working directory. 
+    
+    """
+    
+    env_name = "AITEMPLATE_WORK_DIR"
+    local_dir = "./tmp/diffusers-pipeline/stabilityai/stable-diffusion-v2"
+    
+    if env_name in os.environ:
+        local_dir = os.path.join(os.environ[env_name], 'diffusers-pipeline', 'stabilityai', 'stable-diffusion-v2')
+          
+    print("The value of {} is {}".format(env_name, local_dir)) 
+    return local_dir
+
+def get_file_location_CLIP():
+    """
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the it will look for compiled artifacts under 
+    tmp/ folder of the current working directory. 
+    
+    """
+    
+    env_name = "AITEMPLATE_WORK_DIR"
+    file_name = "./tmp/CLIPTextModel/test.so"
+    
+    if env_name in os.environ:
+        file_name = os.path.join(os.environ[env_name], 'CLIPTextModel', 'test.so')
+          
+    print("The value of {} is {}".format(env_name, file_name)) 
+    return file_name
+
+def get_file_location_Autoencoder():
+    
+    """
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the it will look for compiled artifacts under 
+    tmp/ folder of the current working directory. 
+    
+    """
+    
+    env_name = "AITEMPLATE_WORK_DIR"
+    file_name = "./tmp/AutoencoderKL/test.so"
+    
+    if env_name in os.environ:
+        file_name = os.path.join(os.environ[env_name], 'AutoencoderKL', 'test.so')
+          
+    print("The value of {} is {}".format(env_name, file_name))   
+    
+    return file_name
+
+def get_file_location_Unet():
+    
+    """
+    Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+    path to a directory which has AITemplate compiled artifacts the model(s). 
+    Make sure the OS user running this script has read and write permissions to 
+    this directory. By default, the it will look for compiled artifacts under 
+    tmp/ folder of the current working directory. 
+    """
+
+    env_name = "AITEMPLATE_WORK_DIR"
+    file_name = "./tmp/UNet2DConditionModel/test.so"
+    
+    if env_name in os.environ:
+        file_name = os.path.join(os.environ[env_name], 'UNet2DConditionModel', 'test.so')
+          
+    print("The value of {} is {}".format(env_name, file_name))  
+    
+    return file_name

--- a/examples/05_stable_diffusion/src/pipeline_stable_diffusion_ait.py
+++ b/examples/05_stable_diffusion/src/pipeline_stable_diffusion_ait.py
@@ -14,10 +14,10 @@
 #
 import inspect
 
-import os
+
 import warnings
 from typing import List, Optional, Union
-
+import os
 import torch
 from aitemplate.compiler import Model
 
@@ -39,6 +39,7 @@ from diffusers.pipelines.stable_diffusion import (
 )
 
 from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
+from src.compile_lib.util import get_work_dir_location
 
 
 class StableDiffusionAITPipeline(StableDiffusionPipeline):
@@ -97,21 +98,15 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
             feature_extractor=feature_extractor,
             requires_safety_checker=requires_safety_checker,
         )
+        
         """
-        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
-        has AITemplate compiled artifacts the model(s). Make sure the OS user running this script has read and write 
-        permissions to this directory. By default, the it will look for compiled artifacts under tmp/ folder of the 
-        current working directory. 
+        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+        path to a directory which has AITemplate compiled artifacts the model(s). 
+        Make sure the OS user running this script has read and write permissions to 
+        this directory. By default, the it will look for compiled artifacts under 
+        tmp/ folder of the current working directory. 
         """
-
-        env_name = "AITEMPLATE_WORK_DIR"
-        try:
-            if os.environ[env_name]:
-                workdir = os.environ[env_name]
-                print("The value of", env_name, " is ", workdir)
-        except KeyError:
-            workdir = "tmp/"
-            print("The value of", env_name, " is ", workdir)
+        workdir = get_work_dir_location() 
 
         self.clip_ait_exe = self.init_ait_module(
             model_name="CLIPTextModel", workdir=workdir

--- a/examples/05_stable_diffusion/src/pipeline_stable_diffusion_ait.py
+++ b/examples/05_stable_diffusion/src/pipeline_stable_diffusion_ait.py
@@ -97,8 +97,22 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
             feature_extractor=feature_extractor,
             requires_safety_checker=requires_safety_checker,
         )
+        """
+        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
+        has AITemplate compiled artifacts the model(s). Make sure the OS user running this script has read and write 
+        permissions to this directory. By default, the it will look for compiled artifacts under tmp/ folder of the 
+        current working directory. 
+        """
 
-        workdir = "tmp/"
+        env_name = "AITEMPLATE_WORK_DIR"
+        try:
+            if os.environ[env_name]:
+                workdir = os.environ[env_name]
+                print("The value of", env_name, " is ", workdir)
+        except KeyError:
+            workdir = "tmp/"
+            print("The value of", env_name, " is ", workdir)
+
         self.clip_ait_exe = self.init_ait_module(
             model_name="CLIPTextModel", workdir=workdir
         )

--- a/examples/05_stable_diffusion/src/pipeline_stable_diffusion_ait.py
+++ b/examples/05_stable_diffusion/src/pipeline_stable_diffusion_ait.py
@@ -98,14 +98,7 @@ class StableDiffusionAITPipeline(StableDiffusionPipeline):
             feature_extractor=feature_extractor,
             requires_safety_checker=requires_safety_checker,
         )
-        
-        """
-        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-        path to a directory which has AITemplate compiled artifacts the model(s). 
-        Make sure the OS user running this script has read and write permissions to 
-        this directory. By default, the it will look for compiled artifacts under 
-        tmp/ folder of the current working directory. 
-        """
+
         workdir = get_work_dir_location() 
 
         self.clip_ait_exe = self.init_ait_module(

--- a/examples/05_stable_diffusion/src/pipeline_stable_diffusion_img2img_ait.py
+++ b/examples/05_stable_diffusion/src/pipeline_stable_diffusion_img2img_ait.py
@@ -110,14 +110,6 @@ class StableDiffusionImg2ImgAITPipeline(StableDiffusionImg2ImgPipeline):
             feature_extractor=feature_extractor,
         )
 
-        """
-        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
-        path to a directory which has AITemplate compiled artifacts the model(s). 
-        Make sure the OS user running this script has read and write permissions to 
-        this directory. By default, the it will look for compiled artifacts under 
-        tmp/ folder of the current working directory. 
-        """
-        
         workdir = get_work_dir_location() 
             
         self.clip_ait_exe = self.init_ait_module(

--- a/examples/05_stable_diffusion/src/pipeline_stable_diffusion_img2img_ait.py
+++ b/examples/05_stable_diffusion/src/pipeline_stable_diffusion_img2img_ait.py
@@ -37,6 +37,7 @@ from diffusers.pipelines.stable_diffusion import (
     StableDiffusionSafetyChecker,
 )
 from transformers import CLIPFeatureExtractor, CLIPTextModel, CLIPTokenizer
+from src.compile_lib.util import get_work_dir_location
 
 
 def preprocess(image):
@@ -110,20 +111,14 @@ class StableDiffusionImg2ImgAITPipeline(StableDiffusionImg2ImgPipeline):
         )
 
         """
-        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
-        has AITemplate compiled artifacts the model(s). Make sure the OS user running this script has read and write 
-        permissions to this directory. By default, the it will look for compiled artifacts under tmp/ folder of the 
-        current working directory. 
+        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute
+        path to a directory which has AITemplate compiled artifacts the model(s). 
+        Make sure the OS user running this script has read and write permissions to 
+        this directory. By default, the it will look for compiled artifacts under 
+        tmp/ folder of the current working directory. 
         """
-
-        env_name = "AITEMPLATE_WORK_DIR"
-        try:
-            if os.environ[env_name]:
-                workdir = os.environ[env_name]
-                print("The value of", env_name, " is ", workdir)
-        except KeyError:
-            workdir = "tmp/"
-            print("The value of", env_name, " is ", workdir)
+        
+        workdir = get_work_dir_location() 
             
         self.clip_ait_exe = self.init_ait_module(
             model_name="CLIPTextModel", workdir=workdir

--- a/examples/05_stable_diffusion/src/pipeline_stable_diffusion_img2img_ait.py
+++ b/examples/05_stable_diffusion/src/pipeline_stable_diffusion_img2img_ait.py
@@ -109,7 +109,22 @@ class StableDiffusionImg2ImgAITPipeline(StableDiffusionImg2ImgPipeline):
             feature_extractor=feature_extractor,
         )
 
-        workdir = "tmp/"
+        """
+        Set the OS environment variable AITEMPLATE_WORK_DIR to point to an absolute path to a directory which 
+        has AITemplate compiled artifacts the model(s). Make sure the OS user running this script has read and write 
+        permissions to this directory. By default, the it will look for compiled artifacts under tmp/ folder of the 
+        current working directory. 
+        """
+
+        env_name = "AITEMPLATE_WORK_DIR"
+        try:
+            if os.environ[env_name]:
+                workdir = os.environ[env_name]
+                print("The value of", env_name, " is ", workdir)
+        except KeyError:
+            workdir = "tmp/"
+            print("The value of", env_name, " is ", workdir)
+            
         self.clip_ait_exe = self.init_ait_module(
             model_name="CLIPTextModel", workdir=workdir
         )


### PR DESCRIPTION
Issue: https://github.com/facebookincubator/AITemplate/issues/396
StableDiffusionAITPipeline and StableDiffusionImg2ImgAITPipeline in pipeline_stable_diffusion_ait.py and [pipeline_stable_diffusion_img2img_ait.py has workdir hardcoded to "tmp/" which might create problems where the file system locations are either read-only or users have restricted permissions in the current working directory. Examples include managed ML services in Cloud that might have file permission restrictions.

Desired behavior: User should be given flexibility to specify the custom location as workdir where AITemplate .so files are downloaded.