### PR TITLE
Add allow list to splitter

### DIFF
--- a/fx2ait/fx2ait/ait_splitter.py
+++ b/fx2ait/fx2ait/ait_splitter.py
@@ -67,7 +67,10 @@ def _decline_if_would_trigger_extra_copies(
 
 
 def create_ait_operator_support(
-    use_implicit_batch_dim=True, op_lowering_disallow_list=None, allow_int_inputs=False
+    use_implicit_batch_dim=True,
+    op_lowering_disallow_list=None,
+    allow_int_inputs=False,
+    allow_op_supports=None,
 ) -> ops.OperatorSupportBase:
     """Creates an `OperatorSupportBase` instance used for AIT splitting purpose."""
     # Create an `OperatorSupport` that declares a node supported if it
@@ -102,7 +105,8 @@ def create_ait_operator_support(
         # optimization.
         _decline_if_would_trigger_extra_copies(supported_if_converter_registered),
     ]
-
+    if allow_op_supports:
+        return ops.any_chain(ops.chain(*chained_not_supported_ops), *allow_op_supports)
     return ops.chain(*chained_not_supported_ops)
 
 

--- a/fx2ait/fx2ait/test/test_ait_splitter.py
+++ b/fx2ait/fx2ait/test/test_ait_splitter.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 #
 import torch
-from fx2ait.acc_tracer import acc_tracer
+from fx2ait.acc_tracer import acc_ops, acc_tracer
 from fx2ait.ait_splitter import (  # @manual=//aitemplate/AITemplate/fx2ait/fx2ait:fx2ait
     AITSplitter,
     AITSplitterSettings,
@@ -21,6 +21,7 @@ from fx2ait.ait_splitter import (  # @manual=//aitemplate/AITemplate/fx2ait/fx2a
 )
 from fx2ait.tools.common_fx2ait import AITTestCase
 from torch.fx.passes import operator_support as op_support
+from torch.fx.passes.operator_support import OperatorSupportBase
 
 
 class TestSplit(AITTestCase):
@@ -178,5 +179,57 @@ class TestSplit(AITTestCase):
         self.assertTrue(len(split_results_int_allowed), 1)
         self.assertEqual(
             dict(split_results_int_allowed.split_module.named_children()).keys(),
+            {"_run_on_acc_0"},
+        )
+
+    def test_accept_if_allow_op_support(self):
+        operator_support = create_ait_operator_support()
+
+        class TestModule(torch.nn.Module):
+            def forward(self, a):
+                b = torch.relu(a)
+                return b
+
+        test_mod = TestModule().cuda().eval()
+        x = torch.randn(2, 3)
+        settings = AITSplitterSettings()
+        settings.min_acc_module_size = 0
+
+        # nodes w/ int input should not be lowered
+        mod = acc_tracer.trace(test_mod, [x])
+        splitter = AITSplitter(
+            mod,
+            (x.int().cuda(),),
+            operator_support,
+            settings,
+        )
+        split_results_int = splitter.generate_split_results()
+        self.assertTrue(len(split_results_int), 1)
+        self.assertEqual(
+            dict(split_results_int.split_module.named_children()).keys(),
+            {"_run_on_gpu_0"},
+        )
+
+        class JaggedOperatorSupport(OperatorSupportBase):
+            def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
+                return node.op == "call_function" and node.target in [
+                    acc_ops.relu,
+                ]
+
+        operator_support = create_ait_operator_support(
+            allow_op_supports=[JaggedOperatorSupport()]
+        )
+        # node relu should be lowered
+        mod = acc_tracer.trace(test_mod, [x])
+        splitter = AITSplitter(
+            mod,
+            (x.int().cuda(),),
+            operator_support,
+            settings,
+        )
+        split_results_relu_allowed = splitter.generate_split_results()
+        self.assertTrue(len(split_results_relu_allowed), 1)
+        self.assertEqual(
+            dict(split_results_relu_allowed.split_module.named_children()).keys(),
             {"_run_on_acc_0"},
         )


### PR DESCRIPTION
Summary:
Currently splitter only rejects nodes, but doesn't have allowed node list. Then there are some special ops hard to adapt to general rules.

Example:
torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output should be supported after AIT adds it, but the second input of the op is offset, which is int64 type. But AIT in general only support float32 and float64 calculation.
There we just want to enable that op.

We added an allow_list to splitter so that if any op is in the allow_list, the splitter will split it into acc graph, rather than gpu graph.

Now, we can write
```
    class JaggedOperatorSupport(OperatorSupportBase):
        def is_node_supported(self, submodules, node: torch.fx.Node) -> bool:
            return node.op == "call_function" and node.target in [
                torch.ops.fbgemm.jagged_to_padded_dense,
                torch.ops.fbgemm.jagged_dense_dense_elementwise_add_jagged_output,
            ]

    op_lowering_disallow_list = []
    op_support = create_ait_operator_support(
        op_lowering_disallow_list=op_lowering_disallow_list,
        allow_op_supports=[JaggedOperatorSupport()],
    )

```
and we will get the same splitter but with one specific op get excluded!

Reviewed By: wushirong

Differential Revision: D44036284

