### PR TITLE
Fix softmax dimension raise logic.

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -427,10 +427,22 @@ def acc_ops_softmax(
     if dim < 0:
         dim = rank + dim
     if dim != rank - 1:
-        for i in range(rank, dim):
-            if input_val.shape()[i].value() != 1:
+        for i in range(dim + 1, rank):
+            unsupported = False
+            if isinstance(input_val.shape()[i], IntImm):
+                if input_val.shape()[i].value() != 1:
+                    unsupported = True
+            elif isinstance(input_val.shape()[i], IntVar):
+                unsupported = True
+            else:
                 raise RuntimeError(
-                    f"AIT softmax only supports dim=rank-1, got dim={dim}, rank={rank}"
+                    f"unknown dimension type={type(i)} in AITTensor={input_val}"
+                )
+
+            if unsupported:
+                raise ValueError(
+                    f"AIT softmax only supports dim=rank-1, got AITTensor={input_val}, "
+                    f"where dim={dim}, rank={rank}"
                 )
         reshape_dim = size()(input_val)[: dim + 1]
         reshape_val = reshape()(input_val, reshape_dim)

--- a/fx2ait/fx2ait/test/converters/test_ait_softmax.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_softmax.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-import unittest
 
 import torch
 from fx2ait.acc_tracer import acc_ops
@@ -83,7 +82,6 @@ class TestSoftmaxConverter(AITTestCase):
             param("neg", dim=-3),
         ]
     )
-    @unittest.expectedFailure
     def test_softmax_expected_failure(self, name, dim=None):
         class TestModule(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -94,7 +92,8 @@ class TestSoftmaxConverter(AITTestCase):
         inputs = [
             torch.randn(2, 3, 5, 2, 1).half().cuda(),
         ]
-        self.run_test(model, inputs, expected_ops={acc_ops.softmax})
+        with self.assertRaises(ValueError):
+            self.run_test(model, inputs, expected_ops={acc_ops.softmax})
 
     @parameterized.expand(
         [
@@ -102,7 +101,6 @@ class TestSoftmaxConverter(AITTestCase):
             param("neg", dim=-3),
         ]
     )
-    @unittest.expectedFailure
     def test_softmax_expected_failure_dynamic(self, name, dim=None):
         class TestModule(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -121,8 +119,9 @@ class TestSoftmaxConverter(AITTestCase):
                 torch.float16,
             ],
         )
-        self.run_test_with_dynamic_shape(
-            model,
-            inputs_spec,
-            expected_ops={acc_ops.softmax},
-        )
+        with self.assertRaises(ValueError):
+            self.run_test_with_dynamic_shape(
+                model,
+                inputs_spec,
+                expected_ops={acc_ops.softmax},
+            )


### PR DESCRIPTION
Summary: Fix some issues in D43968603. The judgement of dimension with 1 wasn't correct. For AITTensor, dimension can be IntVar and IntImm, and judgement code should change accordingly.

Differential Revision: D44040761

