### PR TITLE
Fix json serialization & visualization of multiple operators with the same name

### DIFF
--- a/python/aitemplate/utils/graph_utils.py
+++ b/python/aitemplate/utils/graph_utils.py
@@ -50,10 +50,8 @@ def sorted_graph_debug_str(tensors) -> str:
 
 
 def sorted_graph_debug_json(tensors) -> str:
-    import json
-
     from aitemplate.compiler.base import Tensor
-    from aitemplate.utils.json_utils import GraphJsonEncoder
+    from aitemplate.utils.json_utils import gen_unique_op_names, GraphJsonEncoder
 
     if isinstance(tensors, Tensor):
         tensors = [tensors]
@@ -62,7 +60,10 @@ def sorted_graph_debug_json(tensors) -> str:
     json_dict["Tensors"] = tensors
     json_dict["Operators"] = get_sorted_ops(tensors)
 
-    return json.dumps(json_dict, cls=GraphJsonEncoder)
+    op_names = gen_unique_op_names(tensors)
+    encoder = GraphJsonEncoder(op_names)
+
+    return encoder.encode(json_dict)
 
 
 def sorted_graph_pseudo_code(tensors, with_shape=True) -> str:


### PR DESCRIPTION
Summary:
This change handles the situation when multiple Operator instances have the same name, because the same operator is used several times for graph operations. Say, if operator named `foo_123` was used twice, then two nodes `foo_123 0` and `foo_123 1` will be generated for the json serialization and the visualization.

Json-serialized Operator instances gain an additional field called `_original_op_name`.

Also, this change finally allows to properly traverse the json-serialized graph using various graph-based algorithms.

Differential Revision: D44066254

