### PR TITLE
Remove redundant DeviceToDeviceCopies call

### DIFF
--- a/python/aitemplate/backend/main_templates.py
+++ b/python/aitemplate/backend/main_templates.py
@@ -99,7 +99,6 @@ class {{model_name}} : public ModelBase<{{model_name}}> {
   {{ func }}
       DeviceCheckLastError(__FILE__, __LINE__);
   {% endfor %}
-      DeviceToDeviceCopies(stream);
     }
 
     void ProfileImpl(StreamType stream, size_t iters, const std::string& filename) {


### PR DESCRIPTION
Summary: As `model->DeviceToDeviceCopies()` is called from the `ModelBase::Run`, in this diff we remove the redundant call from the end of the generated `Model::RunImpl()` function body in the `MODEL_TEMPLATE`. Redundant call has caused an overhead of unnecessary double copying of the same data in cases when the generated body of `DeviceToDeviceCopies` wasn't empty.

Differential Revision: D44074465

