### PR TITLE
make input accessors for all inputs for perm021_fc_ccr_bias

### DIFF
--- a/python/aitemplate/compiler/ops/gemm_universal/perm021fc_ccr_bias_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/perm021fc_ccr_bias_permute.py
@@ -55,7 +55,9 @@ class perm021fc_ccr_bias_permute(perm021fc_ccr_bias):
     def __call__(self, a: Tensor, b: Tensor, bias: Tensor) -> Tensor:
         a, b = self._align_ab(a, b)
         self._attrs["inputs"] = [a, b, bias]
-        self._attrs["input_accessors"] = [TensorAccessor(a), TensorAccessor(b)]
+        self._attrs["input_accessors"] = [
+            TensorAccessor(tensor) for tensor in self._attrs["inputs"]
+        ]
         self._set_depth()
         self._sanity_check(a, b)
         output_shape = self._infer_shapes(a, b, bias)


### PR DESCRIPTION
This changes make the op have the consistent behavior with all other ops with input accessors, i.e. we have an input accessor for each input. It would simplify our input-accessor-related passes because we don't have to check the input index for accessing input accessors.