### PR TITLE
Fix map_clip_params in 05_stable_diffusion example

### DIFF
--- a/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
@@ -23,14 +23,7 @@ from .util import mark_output
 
 
 def map_clip_params(pt_mod, batch_size, seqlen, depth):
-
-    params_pt = list(pt_mod.named_parameters())
-
     params_ait = {}
-    pt_params = {}
-    for key, arr in params_pt:
-        pt_params[key.replace("text_model.", "")] = arr
-
     pt_params = dict(pt_mod.named_parameters())
     for key, arr in pt_params.items():
         name = key.replace("text_model.", "")
@@ -67,11 +60,11 @@ def map_clip_params(pt_mod, batch_size, seqlen, depth):
             continue
         params_ait[ait_name] = arr
 
-        if detect_target().name() == "cuda":
-            for i in range(depth):
-                prefix = "encoder_layers_%d_self_attn_cu_length" % (i)
-                cu_len = np.cumsum([0] + [seqlen] * batch_size).astype("int32")
-                params_ait[prefix] = torch.from_numpy(cu_len).cuda()
+    if detect_target().name() == "cuda":
+        for i in range(depth):
+            prefix = f"encoder_layers_{i}_self_attn_cu_length"
+            cu_len = np.cumsum([0] + [seqlen] * batch_size).astype("int32")
+            params_ait[prefix] = torch.from_numpy(cu_len).cuda()
 
     return params_ait
 


### PR DESCRIPTION
Fixes:
- Remove unnecessary code lines around `params_pt`.
- The block which adds `encoder_layers_%d_self_attn_cu_length` to `params_ait` was accidentally added under "for loop" which maps `pt_params` to `params_ait`. This PR moves the block out from the for loop.