### PR TITLE
Add batched_dense_vec_jagged_2d_mul op

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_special/__init__.py
+++ b/python/aitemplate/backend/cuda/gemm_special/__init__.py
@@ -16,10 +16,16 @@
 special gemm ops
 """
 from aitemplate.backend.cuda.gemm_special import (
+    batched_dense_vec_jagged_2d_mul,
     bmm_rcr_n1,
     bmm_rrr_k1_tanh,
     gemm_rrr_small_nk,
 )
 
 
-__all__ = ["bmm_rcr_n1", "bmm_rrr_k1_tanh", "gemm_rrr_small_nk"]
+__all__ = [
+    "batched_dense_vec_jagged_2d_mul",
+    "bmm_rcr_n1",
+    "bmm_rrr_k1_tanh",
+    "gemm_rrr_small_nk",
+]

--- a/python/aitemplate/backend/cuda/gemm_special/batched_dense_vec_jagged_2d_mul.py
+++ b/python/aitemplate/backend/cuda/gemm_special/batched_dense_vec_jagged_2d_mul.py
@@ -1,0 +1,251 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Define batched_dense_vec_jagged_2d_mul codegen and CUDA kernel
+"""
+from typing import Any, Dict
+
+import jinja2
+
+from aitemplate.backend import registry
+from aitemplate.backend.backend_spec import CUDASpec
+from aitemplate.backend.common.elementwise_common import gen_offsets_str
+from aitemplate.backend.target import Target
+
+
+CONSTANT_TEMPLATE = jinja2.Template(
+    """
+#define WARP_SIZE 32
+#define MAX_THREADS 1024
+    """
+)
+
+KERNEL_TEMPLATE = jinja2.Template(
+    """
+__global__ void {{func_name}}(
+    {{data_t}}* output,
+    const {{data_t}}* vectors,
+    const {{data_t}}* matrices,
+    {{offsets}}
+    {{index_type}} b, {{index_type}} h,
+    {{index_type}} n, {{index_type}} d
+) {
+  const int b_h_begin = blockIdx.x * blockDim.y + threadIdx.y;
+  const int b_h_step = gridDim.x * blockDim.y;
+  for (int b_h = b_h_begin; b_h < b * h; b_h += b_h_step) {
+    const int b_idx = b_h / h;
+    const int h_idx = b_h % h;
+
+    const {{index_type}} row_start = offsets.data[0][b_idx];
+    const {{index_type}} row_end = offsets.data[0][b_idx + 1];
+    const {{index_type}} length = min(row_end - row_start, n);
+    if (length == 0) {
+      for (int d_idx = threadIdx.x; d_idx < d; d_idx += blockDim.x) {
+        output[b_h * d + d_idx] = 0;
+      }
+    } else {
+      for (int d_idx = threadIdx.x; d_idx < d; d_idx += blockDim.x) {
+        {{acc_t}} acc =
+            {{acc_t}}(vectors[b_h * n] * matrices[row_start * h * d + h_idx * d + d_idx]);
+        for (int l = 1; l < length; ++l) {
+          acc += {{acc_t}}(vectors[b_h * n + l] * matrices[(row_start + l) * h * d + h_idx * d + d_idx]);
+        }
+        output[b_h * d + d_idx] = {{data_t}}(acc);
+      }
+    }
+  }
+}
+    """
+)
+
+FUNC_TEMPLATE = jinja2.Template(
+    """
+{{head}}
+
+#include "jagged.h"
+
+namespace {
+
+{{constant}}
+
+{{kernel_function}}
+
+}  // namespace
+
+void invoke_{{func_name}}(void* output, const void* vectors, const void* matrices, {{index_type}} b, {{index_type}} h, {{index_type}} n, {{index_type}} d, {{offsets_decl}} {{prefix}}Stream_t stream) {
+    if (b == 0 || d == 0) {
+      return;
+    }
+    int block_dim_x = std::min(static_cast<int>(std::ceil(static_cast<double>(d) / WARP_SIZE) * WARP_SIZE), MAX_THREADS);
+    int block_dim_y = MAX_THREADS / block_dim_x;
+    int block_size = static_cast<int>(std::ceil(static_cast<double>(b * h) / block_dim_y));
+    {{func_name}}<<<block_size, dim3(block_dim_x, block_dim_y), 0, stream>>>(
+        reinterpret_cast<{{data_t}}*>(output),
+        reinterpret_cast<const {{data_t}}*>(vectors),
+        reinterpret_cast<const {{data_t}}*>(matrices),
+        {{offsets_call}}
+        b,
+        h,
+        n,
+        d
+    );
+}
+    """
+)
+
+FUNC_DECL_TEMPLATE = jinja2.Template(
+    """
+void invoke_{{func_name}}(void* output, const void* vectors, const void* matrices, {{index_type}} b, {{index_type}} h, {{index_type}} n, {{index_type}} d, {{offsets}} {{prefix}}Stream_t stream);
+    """
+)
+
+FUNC_CALL_TEMPLATE = jinja2.Template(
+    """
+{{indent}}{
+    {{indent}}invoke_{{func_name}}({{output}}, {{vectors}}, {{matrices}}, {{b}}, {{h}}, {{n}}, {{d}}, {{offsets}} {{stream}});
+{{indent}}}
+    """
+)
+
+
+def _gen_kernel_function(
+    func_attrs: Dict[str, Any],
+    index_type: str,
+    data_type: str,
+) -> str:
+    matrices = func_attrs["inputs"][1]
+
+    acc_t = "float"
+    if (
+        data_type in ["half", "bfloat16"]
+        and "use_fp16_acc" in Target.current()._kwargs
+        and Target.current()._kwargs["use_fp16_acc"]
+    ):
+        acc_t = data_type
+
+    kernel_func = KERNEL_TEMPLATE.render(
+        func_name=func_attrs["name"],
+        index_type=index_type,
+        data_t=data_type,
+        offsets=gen_offsets_str(
+            matrices._attrs["shape"][0],
+            has_type=True,
+            # the offsets are passed
+            # by value to the kernel
+            const_ref=False,
+            name="offsets",
+        ),
+        acc_t=acc_t,
+    )
+    return kernel_func
+
+
+@registry.reg("cuda.batched_dense_vec_jagged_2d_mul.gen_function")
+def jagged_to_dense_gen_function(func_attrs: Dict[str, Any]) -> str:
+    """Generates jagged_to_dense function definition."""
+
+    vectors = func_attrs["inputs"][0]
+    matrices = func_attrs["inputs"][1]
+    backend_spec = CUDASpec()
+
+    dtype = vectors.dtype()
+    data_type = backend_spec.dtype_to_backend_type(dtype)
+
+    kernel_function = _gen_kernel_function(
+        func_attrs,
+        backend_spec.index_type,
+        data_type,
+    )
+
+    constant = CONSTANT_TEMPLATE.render()
+
+    function = FUNC_TEMPLATE.render(
+        prefix=backend_spec.prefix,
+        index_type=backend_spec.index_type,
+        head=backend_spec.header_src_template.render(),
+        constant=constant,
+        kernel_function=kernel_function,
+        func_name=func_attrs["name"],
+        offsets_decl=gen_offsets_str(
+            matrices._attrs["shape"][0],
+            has_type=True,
+            # the offsets are passed
+            # by const reference to the function
+            const_ref=True,
+            name="offsets",
+        ),
+        offsets_call=gen_offsets_str(
+            matrices._attrs["shape"][0],
+            has_type=False,
+            const_ref=False,
+            name="offsets",
+        ),
+        data_t=data_type,
+    )
+    return function
+
+
+@registry.reg("cuda.batched_dense_vec_jagged_2d_mul.func_decl")
+def jagged_to_dense_gen_function_decl(func_attrs) -> str:
+    """Generate jagged_to_dense function declaration."""
+
+    matrices = func_attrs["inputs"][1]
+    func_name = func_attrs["name"]
+    backend_spec = CUDASpec()
+
+    return FUNC_DECL_TEMPLATE.render(
+        prefix=backend_spec.prefix,
+        index_type=backend_spec.index_type,
+        func_name=func_name,
+        offsets=gen_offsets_str(
+            matrices._attrs["shape"][0],
+            has_type=True,
+            const_ref=True,
+            name="offsets",
+        ),
+    )
+
+
+@registry.reg("cuda.batched_dense_vec_jagged_2d_mul.func_call")
+def jagged_to_dense_gen_function_call(
+    func_attrs,
+    indent: str,
+) -> str:
+    """Generate jagged_to_dense function call."""
+
+    vectors = func_attrs["inputs"][0]
+    vshape = vectors._attrs["shape"]
+    matrices = func_attrs["inputs"][1]
+    jshape = matrices._attrs["shape"]
+    output = func_attrs["outputs"][0]
+    backend_spec = CUDASpec()
+
+    return FUNC_CALL_TEMPLATE.render(
+        stream=backend_spec.stream,
+        func_name=func_attrs["name"],
+        matrices=matrices._attrs["name"],
+        vectors=vectors._attrs["name"],
+        b=vshape[0]._attrs["name"],
+        h=vshape[1]._attrs["name"],
+        n=vshape[2]._attrs["name"],
+        d=jshape[2]._attrs["name"],
+        output=output._attrs["name"],
+        offsets=gen_offsets_str(
+            matrices._attrs["shape"][0],
+            has_type=False,
+            const_ref=False,
+        ),
+        indent=indent,
+    )

--- a/python/aitemplate/compiler/ops/gemm_special/__init__.py
+++ b/python/aitemplate/compiler/ops/gemm_special/__init__.py
@@ -15,9 +15,17 @@
 """
 special gemm ops
 """
+from aitemplate.compiler.ops.gemm_special.batched_dense_vec_jagged_2d_mul import (
+    batched_dense_vec_jagged_2d_mul,
+)
 from aitemplate.compiler.ops.gemm_special.bmm_rcr_n1 import bmm_rcr_n1
 from aitemplate.compiler.ops.gemm_special.bmm_rrr_k1_tanh import bmm_rrr_k1_tanh
 from aitemplate.compiler.ops.gemm_special.gemm_rrr_small_nk import gemm_rrr_small_nk
 
 
-__all__ = ["bmm_rcr_n1", "bmm_rrr_k1_tanh", "gemm_rrr_small_nk"]
+__all__ = [
+    "batched_dense_vec_jagged_2d_mul",
+    "bmm_rcr_n1",
+    "bmm_rrr_k1_tanh",
+    "gemm_rrr_small_nk",
+]

--- a/python/aitemplate/compiler/ops/gemm_special/batched_dense_vec_jagged_2d_mul.py
+++ b/python/aitemplate/compiler/ops/gemm_special/batched_dense_vec_jagged_2d_mul.py
@@ -1,0 +1,108 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""
+Define batched_dense_vec_jagged_2d_mul op
+"""
+from typing import List
+
+from aitemplate.backend import registry
+
+from aitemplate.backend.target import Target
+
+from aitemplate.compiler.base import IntVar, Operator, Tensor
+
+
+class batched_dense_vec_jagged_2d_mul(Operator):
+    """
+    Returns a dense tensor containing batched matrix multiplication of batched vector and batched jagged tensor.
+    Args:
+        vectors (Tensor): batched vector tensor
+        matrices (Tensor): batched jagged tensor
+    Returns:
+        output (Tensor): a dense tensor containing the batched matrix multiplication result.
+    """
+
+    def __init__(
+        self,
+    ):
+        super().__init__()
+        self._attrs["op"] = "batched_dense_vec_jagged_2d_mul"
+
+    def _infer_shape(self, vectors: Tensor, matrices: Tensor) -> List[IntVar]:
+        jagged_int_var = matrices.shape()[0]
+        return [jagged_int_var.batch_dim(), matrices.shape()[1], matrices.shape()[2]]
+
+    def __call__(self, vectors: Tensor, matrices: Tensor) -> Tensor:
+        # Check matrices is jagged tensor
+        if not matrices.is_jagged():
+            matrices_name = matrices._attrs["name"]
+            raise RuntimeError(
+                f"Input tensor {matrices_name} is expected to be jagged, but actually dense."
+            )
+
+        # Check input tensor's dimension is 3
+        if len(vectors.shape()) != 3:
+            vectors_name = vectors._attrs["name"]
+            raise RuntimeError(f"Input tensor {vectors_name} dim should be 3.")
+
+        if len(matrices.shape()) != 3:
+            matrices_name = matrices._attrs["name"]
+            raise RuntimeError(f"Input tensor {matrices_name} dim should be 3.")
+
+        jagged_int_var = matrices.shape()[0]
+        # Check first dim B
+        if jagged_int_var.batch_dim() != vectors.shape()[0]:
+            raise RuntimeError(
+                f"Batch dim B of input tensors are expected to be the same, but actually first is {vectors.shape()[0]} and second is {jagged_int_var.batch_dim()}."
+            )
+
+        # Check second dim H
+        if vectors.shape()[1] != matrices.shape()[1]:
+            raise RuntimeError(
+                f"Second dim H of input tensors are expected to be the same, but actually first is {vectors.shape()[1]} and second is {matrices.shape()[1]}."
+            )
+
+        # Check tensor types
+        if vectors.dtype() != matrices.dtype():
+            raise RuntimeError(
+                f"Input tensors sare expected to have the same type, but actually first is {vectors.dtype()} and second is {matrices.dtype()}."
+            )
+
+        # Check Jagged dims
+        num_jagged_dims = len(jagged_int_var.jagged_dims())
+        if num_jagged_dims != 1:
+            raise RuntimeError(
+                f"Jagged dims for second jagged inputs should be 1, but actually is {num_jagged_dims}."
+            )
+        else:
+            jagged_max_values = jagged_int_var.jagged_dims()[0].max_value()
+            if jagged_max_values != vectors.shape()[2].value():
+                raise RuntimeError(
+                    f"max value is expected to be {vectors.shape()[2].value()} , but actually is {jagged_max_values}."
+                )
+
+        self._attrs["inputs"] = [vectors, matrices]
+        self._set_depth()
+        output_shape = self._infer_shape(vectors, matrices)
+        output = Tensor(output_shape, src_ops={self}, dtype=vectors.dtype())
+
+        self._attrs["outputs"] = [output]
+        return output
+
+    def gen_function(self) -> str:
+        target = Target.current()
+        func = registry.get(f"{target.name()}.{self._attrs['op']}.gen_function")
+        return func(self._attrs)

--- a/tests/unittest/ops/test_batched_dense_vec_jagged_2d_mul.py
+++ b/tests/unittest/ops/test_batched_dense_vec_jagged_2d_mul.py
@@ -1,0 +1,197 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Unittests for batched_dense_vec_jagged_2d_mul Operator.
+"""
+import unittest
+from typing import List
+
+import torch
+from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler.base import IntImm, IntVar, JaggedDim, Tensor
+from aitemplate.testing import detect_target
+from aitemplate.testing.jagged_utils import batched_dense_vec_jagged_2d_mul_ref
+from aitemplate.testing.test_utils import (
+    filter_test_cases_by_params,
+    get_random_torch_tensor,
+    get_torch_empty_tensor,
+    TestEnv,
+)
+from aitemplate.utils.torch_utils import string_to_torch_dtype
+from parameterized import parameterized
+
+
+_TOLERANCE_LIMITS = {
+    "float16": {"atol": 1e-1, "rtol": 1e-1},
+    "float32": {"atol": 3e-2, "rtol": 2e-2},
+    "bfloat16": {"atol": 2e-1, "rtol": 2e-1},
+}
+
+
+@unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+class BatchedDenseVecJagged2DMulTestCase(unittest.TestCase):
+    def _test_batched_dense_vec_jagged_2d_mul(
+        self,
+        B: int,
+        N: int,
+        H: int,
+        D: int,
+        offsets: List[int],
+        dtype: str = "float16",
+        offsets_dtype: str = "int32",
+        use_fp16_acc: bool = False,
+        test_suffix: str = "",
+    ):
+        # jagged shape is equal to (B, N, H, D)
+        batch_size = B
+        batch_dim = IntVar(values=[1, batch_size * 2], name="batch_size")
+        jagged_dims = [JaggedDim(min_value=0, max_value=N)]
+
+        total_length = offsets[-1]
+        total_length_dim = IntVar(values=[1, total_length * 2], name="total_length")
+        jagged_inner_shape = [H, D]
+        jagged_inner_dims = [IntImm(dim) for dim in jagged_inner_shape]
+        jagged_input_shape = [total_length] + jagged_inner_shape
+
+        offsets_dim = IntVar(values=[2, len(offsets) * 2])
+
+        # dense shape is (B, H, N)
+        dense_shape = [batch_size, H, N]
+        dense_dims = [batch_dim, IntImm(H), IntImm(N)]
+        SOURCE = Tensor(
+            shape=[
+                total_length_dim,
+                *jagged_inner_dims,
+            ],
+            name="source",
+            dtype=dtype,
+            is_input=True,
+        )
+        OFFSETS_LIST = [
+            Tensor(
+                shape=[
+                    offsets_dim,
+                ],
+                name="offsets",
+                dtype=offsets_dtype,
+                is_input=True,
+            )
+        ]
+        JAGGED = ops.make_jagged(
+            batch_dim=batch_dim,
+            jagged_dims=jagged_dims,
+        )(SOURCE, OFFSETS_LIST)
+
+        DENSE = Tensor(
+            shape=dense_dims,
+            name="dense",
+            dtype=dtype,
+            is_input=True,
+        )
+
+        RESULT = ops.batched_dense_vec_jagged_2d_mul()(DENSE, JAGGED)
+
+        RESULT._attrs["name"] = "result"
+        RESULT._attrs["is_output"] = True
+
+        assert not SOURCE.is_jagged()
+        assert not DENSE.is_jagged()
+        assert JAGGED.is_jagged()
+        assert not RESULT.is_jagged()
+
+        model = compile_model(
+            [RESULT],
+            detect_target(use_fp16_acc=use_fp16_acc),
+            "./tmp",
+            f"test_batched_dense_vec_jagged_2d_mul_{test_suffix}",
+        )
+
+        torch_offsets_dtype = string_to_torch_dtype(offsets_dtype)
+        offsets_pt = torch.tensor(offsets, dtype=torch_offsets_dtype).cuda()
+        source_pt = get_random_torch_tensor(jagged_input_shape, dtype)
+        dense_pt = get_random_torch_tensor(dense_shape, dtype)
+        result_pt = batched_dense_vec_jagged_2d_mul_ref(
+            vectors=dense_pt,
+            matrices=source_pt,
+            offsets=offsets_pt,
+        )
+        result = get_torch_empty_tensor([batch_size, H, D], dtype)
+
+        inputs = {"dense": dense_pt, "source": source_pt, "offsets": offsets_pt}
+        model.run_with_tensors(inputs, [result])
+
+        tolerance_limits = _TOLERANCE_LIMITS[dtype]
+        torch.testing.assert_close(result, result_pt, **tolerance_limits)
+
+    @parameterized.expand(
+        filter_test_cases_by_params(
+            {
+                TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
+                TestEnv.CUDA_SM80: [("bfloat16")],
+                # TestEnv.ROCM: [("float16")],
+            }
+        )
+    )
+    def test_batched_dense_vesc_jagged_2d_mul(self, ait_dtype):
+        # test with different combination of offsets_dtype, use_fp16_acc and shapes
+        self._test_batched_dense_vec_jagged_2d_mul(
+            4,
+            260,
+            10,
+            32,
+            [0, 1, 4, 6, 7],
+            dtype=ait_dtype,
+            offsets_dtype="int32",
+            use_fp16_acc=True,
+            test_suffix=f"{ait_dtype}_int32_True",
+        )
+        self._test_batched_dense_vec_jagged_2d_mul(
+            6,
+            130,
+            15,
+            39,
+            [0, 1, 4, 6, 7, 9, 10],
+            dtype=ait_dtype,
+            offsets_dtype="int32",
+            use_fp16_acc=False,
+            test_suffix=f"{ait_dtype}_int32_False",
+        )
+        self._test_batched_dense_vec_jagged_2d_mul(
+            8,
+            52,
+            21,
+            32,
+            [0, 1, 4, 6, 7, 8, 12, 20, 29],
+            dtype=ait_dtype,
+            offsets_dtype="int64",
+            use_fp16_acc=True,
+            test_suffix=f"{ait_dtype}_int64_True",
+        )
+        self._test_batched_dense_vec_jagged_2d_mul(
+            10,
+            10,
+            32,
+            8,
+            [0, 1, 4, 6, 7, 11, 15, 19, 23, 26, 28],
+            dtype=ait_dtype,
+            offsets_dtype="int64",
+            use_fp16_acc=False,
+            test_suffix=f"{ait_dtype}_int64_False",
+        )
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    unittest.main()


### PR DESCRIPTION
Summary: In this diff, batched_dense_vec_jagged_2d_mul front-end and back-end op is added. A unit test is included.

Differential Revision: D43921286

