### PR TITLE
Add logics in elementwise to handle the case that a jagged tensor is treated as a dense tensor in AIT

### DIFF
--- a/python/aitemplate/backend/common/elementwise_common.py
+++ b/python/aitemplate/backend/common/elementwise_common.py
@@ -713,7 +713,16 @@ def _get_mixed_jagged_dense_config(
         # dense inputs' shapes) will be treated as a single dense dim
         return False, None, False
 
+    # If all dense inputs' first dim is equal to jagged_int_var's total_length(),
+    # treat all these dense inputs as jagged inputs as well.
     jagged_int_var = output_shape[0]
+    all_dense_jagged = True
+    for dense_input_shape in dense_input_shapes:
+        if dense_input_shape[0] != jagged_int_var.total_length():
+            all_dense_jagged = False
+    if all_dense_jagged:
+        return False, None, False
+
     jagged_max_dense_prefix_shape = jagged_int_var.get_max_dense_shape()
     jagged_suffix_shape = output_shape[1:]
     output_volume = jagged_max_dense_prefix_shape + jagged_suffix_shape
@@ -821,7 +830,10 @@ def _gen_input_broadcast_calculator_str(
 
     start_idx = 0
     for i, (input_dim, output_dim) in enumerate(zip(input_shape, output_shape)):
-        if input_dim != output_dim:
+        if input_dim != output_dim and not (
+            isinstance(output_dim, JaggedIntVar)
+            and input_dim == output_dim.total_length()
+        ):
             assert input_dim == IntImm(
                 1
             ), "Unexpected shapes! Input: {}, output: {}".format(

--- a/python/aitemplate/compiler/ops/common/elementwise.py
+++ b/python/aitemplate/compiler/ops/common/elementwise.py
@@ -112,9 +112,11 @@ def _broadcast_dense_and_jagged_shape(
                 "higher than the rank of the jagged inputs (when treating "
                 "the jagged dims as separate dims)."
             )
-
-        broadcastable, _ = shape_utils.get_broadcast_max_shape(
+        broadcastable_jagged_dense, _ = shape_utils.get_broadcast_max_shape(
             jagged_max_dense_prefix_shape, dense_prefix_shape
+        )
+        broadcastable_jagged_jagged, _ = shape_utils.get_broadcast_max_shape(
+            [jagged_first_dim.total_length()], dense_prefix_shape
         )
         if not broadcastable:
             raise ValueError(

--- a/python/aitemplate/utils/shape_utils.py
+++ b/python/aitemplate/utils/shape_utils.py
@@ -51,7 +51,7 @@ def get_broadcast_max_shape(shape1, shape2):
     Note that two shapes are not required to have the same number of dimensions.
     For example, shape [5, 2, 3] and shape [3] are also broadcastable.
     """
-    from aitemplate.compiler.base import IntImm
+    from aitemplate.compiler.base import IntImm, JaggedIntVar
 
     min_len = min(len(shape1), len(shape2))
     if len(shape1) > len(shape2):
@@ -64,6 +64,12 @@ def get_broadcast_max_shape(shape1, shape2):
         dim2 = shape2[idx]
         if dim1 == dim2:
             res_shape[idx] = dim1
+            continue
+        if isinstance(dim1, JaggedIntVar) and dim1.total_length() == dim2:
+            res_shape[idx] = dim1
+            continue
+        if isinstance(dim2, JaggedIntVar) and dim2.total_length() == dim1:
+            res_shape[idx] = dim2
             continue
         if dim1 == IntImm(1):
             res_shape[idx] = dim2


### PR DESCRIPTION
Summary:
ATT, it looks that it's possible that a jagged tensor is identified as a dense
tensor in fx2ait lowering if this jagged tensor is never used in any fbgemm
jagged operators. e.g. Adding two jagged tensors together do not require any
special fbgemm jagged operators. This diff handles this case for elementwise.

We need to think systematically on how to solve this issue for other operators
as well. i.e. When jagged_int_var.total_length() == dense_int_var, sometimes we
want them to be treated equally (e.g. when calculating the broadcasted dim),
but sometimes we want to always pick up the jagged_int_var (e.g. when inferring
output shapes).

Differential Revision: D44191261

