### PR TITLE
Add dynamic JaggedDim bounds support

### DIFF
--- a/python/aitemplate/backend/common/elementwise_common.py
+++ b/python/aitemplate/backend/common/elementwise_common.py
@@ -672,10 +672,19 @@ def get_dynamic_dims(*shapes: List[List[IntVar]]) -> List[IntVar]:
             if not isinstance(dim, IntImm):
                 res[dim._attrs["name"]] = dim
                 if isinstance(dim, JaggedIntVar):
-                    # the batch_dim within the JaggedIntVar may not be present directly
-                    # in other input / output shapes, so we're adding it here separately
+                    # the batch_dim and the JaggedDim bounds within the JaggedIntVar
+                    # may not be present directly in other input / output shapes,
+                    # so we're adding it here separately
                     batch_dim = dim.batch_dim()
                     res[batch_dim._attrs["name"]] = batch_dim
+                    for jagged_dim in dim.jagged_dims():
+                        min_value = jagged_dim.min_value()
+                        if not isinstance(min_value, IntImm):
+                            res[min_value._attrs["name"]] = min_value
+                        max_value = jagged_dim.max_value()
+                        if not isinstance(max_value, IntImm):
+                            res[max_value._attrs["name"]] = max_value
+
     return list(res.values())
 
 

--- a/python/aitemplate/compiler/base.py
+++ b/python/aitemplate/compiler/base.py
@@ -220,21 +220,26 @@ class JaggedDim(Node):
 
     def __init__(
         self,
-        min_value: int,
-        max_value: int,
+        min_value: IntVar,
+        max_value: IntVar,
     ):
         """Initializes a JaggedDim.
 
         Parameters
         ----------
-        min_value : int
+        min_value : IntVar
             Minimum possible value of the jagged dimension.
-        max_value : int
+        max_value : IntVar
             Maximum possible value of the jagged dimension.
         """
-        if min_value < 0:
+        if isinstance(min_value, int):
+            min_value = IntImm(min_value)
+        if isinstance(max_value, int):
+            max_value = IntImm(max_value)
+
+        if min_value.lower_bound() < 0:
             raise ValueError(f"{min_value=}, but must be non-negative.")
-        if min_value > max_value:
+        if min_value.lower_bound() > max_value.upper_bound():
             raise ValueError(f"{min_value=} can't be larger than {max_value=}.")
 
         super().__init__()
@@ -256,11 +261,11 @@ class JaggedDim(Node):
             attrs["offsets"] = {"name": self._attrs["offsets"]._attrs["name"]}
         return str(attrs)
 
-    def min_value(self) -> int:
+    def min_value(self) -> IntVar:
         """The minimum possible value of the JaggedDim."""
         return self._attrs["values"][0]
 
-    def max_value(self) -> int:
+    def max_value(self) -> IntVar:
         """The maximum possible value of the JaggedDim."""
         return self._attrs["values"][1]
 
@@ -427,7 +432,7 @@ class JaggedIntVar(IntVar):
         """
         result = [self.batch_dim()]
         for dim in self.jagged_dims():
-            result.append(IntImm(dim.max_value()))
+            result.append(dim.max_value())
         return result
 
 

--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -125,6 +125,13 @@ def _mark_isolated_int_vars(sorted_graph: List[Tensor]):
                     int_vars[batch_dim._attrs["name"]] = batch_dim
                     total_length = dim.total_length()
                     int_vars[total_length._attrs["name"]] = total_length
+                    for jagged_dim in dim.jagged_dims():
+                        min_value = jagged_dim.min_value()
+                        if not isinstance(min_value, IntImm):
+                            int_vars[min_value._attrs["name"]] = min_value
+                        max_value = jagged_dim.max_value()
+                        if not isinstance(max_value, IntImm):
+                            int_vars[max_value._attrs["name"]] = max_value
                 if tensor._attrs["is_input"]:
                     int_var_names_in_input_shapes.add(name)
 

--- a/python/aitemplate/compiler/ops/gemm_special/batched_dense_vec_jagged_2d_mul.py
+++ b/python/aitemplate/compiler/ops/gemm_special/batched_dense_vec_jagged_2d_mul.py
@@ -27,12 +27,17 @@ from aitemplate.compiler.base import IntVar, Operator, Tensor
 
 class batched_dense_vec_jagged_2d_mul(Operator):
     """
-    Returns a dense tensor containing batched matrix multiplication of batched vector and batched jagged tensor.
+    Compute a dense tensor containing batched matrix
+    multiplication of a batched dense vector and
+    a batched jagged matrix.
+
     Args:
-        vectors (Tensor): batched vector tensor
-        matrices (Tensor): batched jagged tensor
+        vectors (Tensor): batched dense vector of shape [B, H, N].
+        matrices (Tensor): batched jagged matrix of shape [sum_B(N_B), H, D].
+
     Returns:
-        output (Tensor): a dense tensor containing the batched matrix multiplication result.
+        output (Tensor): dense tensor containing the batched vector /
+        jagged matrix multiplication result of shape [B, H, D].
     """
 
     def __init__(
@@ -46,52 +51,54 @@ class batched_dense_vec_jagged_2d_mul(Operator):
         return [jagged_int_var.batch_dim(), matrices.shape()[1], matrices.shape()[2]]
 
     def __call__(self, vectors: Tensor, matrices: Tensor) -> Tensor:
-        # Check matrices is jagged tensor
         if not matrices.is_jagged():
-            matrices_name = matrices._attrs["name"]
-            raise RuntimeError(
-                f"Input tensor {matrices_name} is expected to be jagged, but actually dense."
+            raise TypeError(
+                f"matrices must be a jagged Tensor, but got a dense Tensor {matrices}."
+            )
+        if vectors.is_jagged():
+            raise TypeError(
+                f"vectors must be a jagged Tensor, but got a jagged Tensor {vectors}."
             )
 
-        # Check input tensor's dimension is 3
         if len(vectors.shape()) != 3:
-            vectors_name = vectors._attrs["name"]
-            raise RuntimeError(f"Input tensor {vectors_name} dim should be 3.")
+            raise ValueError(f"vectors must be rank-3, but got {vectors}.")
 
         if len(matrices.shape()) != 3:
-            matrices_name = matrices._attrs["name"]
-            raise RuntimeError(f"Input tensor {matrices_name} dim should be 3.")
+            raise ValueError(f"matrices must be rank-3, but got {matrices}.")
 
         jagged_int_var = matrices.shape()[0]
-        # Check first dim B
         if jagged_int_var.batch_dim() != vectors.shape()[0]:
             raise RuntimeError(
-                f"Batch dim B of input tensors are expected to be the same, but actually first is {vectors.shape()[0]} and second is {jagged_int_var.batch_dim()}."
+                "The batch dim B of the jagged matrices tensor and "
+                "dense vectors tensor must be the same, but got "
+                f"{jagged_int_var.batch_dim()=} != {vectors.shape()[0]=}."
             )
 
-        # Check second dim H
         if vectors.shape()[1] != matrices.shape()[1]:
             raise RuntimeError(
-                f"Second dim H of input tensors are expected to be the same, but actually first is {vectors.shape()[1]} and second is {matrices.shape()[1]}."
+                f"The second dim H of the jagged matrices tensor and "
+                "dense vectors tensor must be the same, but got "
+                f"{matrices.shape()[1]=} != {vectors.shape()[1]}."
             )
 
-        # Check tensor types
         if vectors.dtype() != matrices.dtype():
             raise RuntimeError(
-                f"Input tensors sare expected to have the same type, but actually first is {vectors.dtype()} and second is {matrices.dtype()}."
+                "vectors and matrices must have the same type, but got "
+                f"{vectors.dtype()=} != {matrices.dtype()=}."
             )
 
-        # Check Jagged dims
-        num_jagged_dims = len(jagged_int_var.jagged_dims())
-        if num_jagged_dims != 1:
+        if len(jagged_int_var.jagged_dims()) != 1:
             raise RuntimeError(
-                f"Jagged dims for second jagged inputs should be 1, but actually is {num_jagged_dims}."
+                "Jagged matrices tensor must have a "
+                f"single JaggedDim, but got {matrices}."
             )
         else:
-            jagged_max_values = jagged_int_var.jagged_dims()[0].max_value()
-            if jagged_max_values != vectors.shape()[2].value():
+            max_value = jagged_int_var.jagged_dims()[0].max_value()
+            if max_value != vectors.shape()[2]:
                 raise RuntimeError(
-                    f"max value is expected to be {vectors.shape()[2].value()} , but actually is {jagged_max_values}."
+                    "Upper bound (max_value) of the jagged dim in matrices "
+                    "must be equal to the last dim N in vectors, but got "
+                    f"{max_value=} != {vectors.shape()[2].value()=}."
                 )
 
         self._attrs["inputs"] = [vectors, matrices]

--- a/python/aitemplate/compiler/ops/tensor/padded_dense_to_jagged.py
+++ b/python/aitemplate/compiler/ops/tensor/padded_dense_to_jagged.py
@@ -20,7 +20,7 @@ from typing import List
 
 from aitemplate.backend import registry
 from aitemplate.backend.target import Target
-from aitemplate.compiler.base import IntImm, IntVar, JaggedDim, Operator, Tensor
+from aitemplate.compiler.base import IntVar, JaggedDim, Operator, Tensor
 from aitemplate.compiler.ops import make_jagged
 
 
@@ -86,13 +86,6 @@ class padded_dense_to_jagged(Operator):
             raise TypeError(
                 f"x.shape()[0] must be IntVar, but got {type(x_shape[0]).__name__}."
             )
-        for i, dim in enumerate(x_shape[1 : 1 + len(offsets_list)], start=1):
-            if not isinstance(dim, IntImm):
-                raise TypeError(
-                    "All sequence dimensions in the x.shape() (corresponding to the "
-                    "jagged dimensions of the output jagged Tensor) must be IntImm, "
-                    f"but got type(x_shape()[{i}]) == {type(dim).__name__}."
-                )
 
         self._attrs["inputs"] = [x, *offsets_list]
         self._set_depth()
@@ -114,7 +107,7 @@ class padded_dense_to_jagged(Operator):
         jagged_output = make_jagged(
             batch_dim=x_shape[0],
             jagged_dims=[
-                JaggedDim(min_value=0, max_value=dim.value())
+                JaggedDim(min_value=0, max_value=dim)
                 for dim in x_shape[1 : 1 + len(offsets_list)]
             ],
         )(

--- a/python/aitemplate/testing/jagged_utils.py
+++ b/python/aitemplate/testing/jagged_utils.py
@@ -373,3 +373,31 @@ def batched_dense_vec_jagged_2d_mul_ref(
     ).squeeze(
         dim=2
     )  # [B, H, D]
+
+
+def add_jagged_dense_ref(
+    jagged: torch.Tensor,
+    offsets_list: List[torch.Tensor],
+    dense: torch.Tensor,
+    jagged_max_shape: List[int] = None,
+) -> torch.Tensor:
+    """The reference function for jagged / dense elementwise add."""
+    if jagged_max_shape is None:
+        jagged_max_shape = dense.shape
+
+    assert len(jagged.shape) + len(offsets_list) >= len(dense.shape)
+    assert len(jagged_max_shape) == len(jagged.shape) + len(offsets_list)
+
+    return dense_to_jagged(
+        dense=(
+            dense
+            + jagged_to_dense(
+                jagged=jagged,
+                offsets_list=offsets_list,
+                dense_shape=jagged_max_shape,
+                padding_value=0.0,
+            )
+        ),
+        offsets_list=offsets_list,
+        padding_value=-1.0,
+    )


### PR DESCRIPTION
Summary:
Previously, `JaggedDim`---a jagged dimension encoded in the first `total_length` / `sum_B(N_B)` dimension of a jagged Tensor---could only have static (`int`) `min_value` and `max_value`. This is problematic when the bounds (in particular, the upper bound: `max_value`) of a jagged dimension in a jagged Tensor shape, as well as the corresponding `max_seq_len` dimension in a dense Tensor shape, are dynamic (`IntVar`). The latter can happen, as the maximum sequence length can, in principle, be dynamic within a single compiled AIT model.

This diff promotes the `min_value` / `max_value` of `JaggedDim` to either `IntImm` for static cases (backward-compatible with previously supported `int` use cases) or `IntVar` for dynamic cases.

Differential Revision: D44198794

