### PR TITLE
Handle implicit + explicit jagged Tensor inputs in elementwise

### DIFF
--- a/python/aitemplate/backend/common/elementwise_common.py
+++ b/python/aitemplate/backend/common/elementwise_common.py
@@ -722,16 +722,7 @@ def _get_mixed_jagged_dense_config(
         # dense inputs' shapes) will be treated as a single dense dim
         return False, None, False
 
-    # If all dense inputs' first dim is equal to jagged_int_var's total_length(),
-    # treat all these dense inputs as jagged inputs as well.
     jagged_int_var = output_shape[0]
-    all_dense_jagged = True
-    for dense_input_shape in dense_input_shapes:
-        if dense_input_shape[0] != jagged_int_var.total_length():
-            all_dense_jagged = False
-    if all_dense_jagged:
-        return False, None, False
-
     jagged_max_dense_prefix_shape = jagged_int_var.get_max_dense_shape()
     jagged_suffix_shape = output_shape[1:]
     output_volume = jagged_max_dense_prefix_shape + jagged_suffix_shape
@@ -839,10 +830,7 @@ def _gen_input_broadcast_calculator_str(
 
     start_idx = 0
     for i, (input_dim, output_dim) in enumerate(zip(input_shape, output_shape)):
-        if input_dim != output_dim and not (
-            isinstance(output_dim, JaggedIntVar)
-            and input_dim == output_dim.total_length()
-        ):
+        if input_dim != output_dim:
             assert input_dim == IntImm(
                 1
             ), "Unexpected shapes! Input: {}, output: {}".format(

--- a/python/aitemplate/compiler/ops/common/view_ops.py
+++ b/python/aitemplate/compiler/ops/common/view_ops.py
@@ -661,6 +661,10 @@ class make_jagged(_view):
         return [jagged_int_var] + source._attrs["shape"][1:]
 
     def __call__(self, source: Tensor, offsets_list: List[Tensor]) -> Tensor:
+        if source.is_jagged():
+            # already a jagged Tensor
+            return source
+
         jagged_dims = self._attrs["jagged_dims"]
         if len(offsets_list) != len(jagged_dims):
             raise ValueError(

--- a/python/aitemplate/utils/shape_utils.py
+++ b/python/aitemplate/utils/shape_utils.py
@@ -51,7 +51,7 @@ def get_broadcast_max_shape(shape1, shape2):
     Note that two shapes are not required to have the same number of dimensions.
     For example, shape [5, 2, 3] and shape [3] are also broadcastable.
     """
-    from aitemplate.compiler.base import IntImm, JaggedIntVar
+    from aitemplate.compiler.base import IntImm
 
     min_len = min(len(shape1), len(shape2))
     if len(shape1) > len(shape2):
@@ -64,12 +64,6 @@ def get_broadcast_max_shape(shape1, shape2):
         dim2 = shape2[idx]
         if dim1 == dim2:
             res_shape[idx] = dim1
-            continue
-        if isinstance(dim1, JaggedIntVar) and dim1.total_length() == dim2:
-            res_shape[idx] = dim1
-            continue
-        if isinstance(dim2, JaggedIntVar) and dim2.total_length() == dim1:
-            res_shape[idx] = dim2
             continue
         if dim1 == IntImm(1):
             res_shape[idx] = dim2

--- a/tests/unittest/ops/test_jagged_elementwise.py
+++ b/tests/unittest/ops/test_jagged_elementwise.py
@@ -256,6 +256,7 @@ class JaggedElementwiseTestCase(unittest.TestCase):
         jagged_max_prefix_shape: List[int],
         jagged1_inner_shape: List[int],
         jagged2_inner_shape: List[int],
+        implicit_jagged_input: bool,
         offsets_list: List[List[int]],
         dtype: str = "float16",
         offsets_dtype: str = "int32",
@@ -314,10 +315,14 @@ class JaggedElementwiseTestCase(unittest.TestCase):
             for i, offsets_dim in enumerate(offsets_dims)
         ]
 
-        JAGGED1 = ops.make_jagged(
-            batch_dim=batch_dim,
-            jagged_dims=jagged_dims,
-        )(SOURCE1, OFFSETS_LIST)
+        if implicit_jagged_input:
+            JAGGED1 = SOURCE1
+        else:
+            JAGGED1 = ops.make_jagged(
+                batch_dim=batch_dim,
+                jagged_dims=jagged_dims,
+            )(SOURCE1, OFFSETS_LIST)
+
         JAGGED2 = ops.make_jagged(
             batch_dim=batch_dim,
             jagged_dims=jagged_dims,
@@ -328,7 +333,13 @@ class JaggedElementwiseTestCase(unittest.TestCase):
         RESULT._attrs["name"] = "result"
         RESULT._attrs["is_output"] = True
 
-        assert not SOURCE1.is_jagged()
+        if implicit_jagged_input:
+            # SOURCE1 is "converted" into a jagged Tensor
+            # in the ops.elementwise by replacing its first
+            # dim with the JaggedIntVar from JAGGED 2
+            assert SOURCE1.is_jagged()
+        else:
+            assert not SOURCE1.is_jagged()
         assert not SOURCE2.is_jagged()
         assert JAGGED1.is_jagged()
         assert JAGGED2.is_jagged()
@@ -358,10 +369,11 @@ class JaggedElementwiseTestCase(unittest.TestCase):
 
     @parameterized.expand(
         [
-            param(1, "int32", [4, 3], [5], [5]),
-            param(2, "int32", [4, 3], [5], [1]),
-            param(3, "int64", [4, 3], [1], [5]),
-            param(4, "int64", [4, 3], [5, 1, 7], [1, 6, 1]),
+            param(1, "int32", [4, 3], [5], [5], False),
+            param(2, "int32", [4, 3], [5], [1], False),
+            param(3, "int64", [4, 3], [1], [5], True),
+            param(4, "int64", [4, 3], [5, 1, 7], [1, 6, 1], False),
+            param(5, "int64", [4, 3], [5, 6, 7], [1, 6, 7], True),
         ]
     )
     def test_jagged_jagged_elementise_add_single_offsets_fp16(
@@ -371,11 +383,13 @@ class JaggedElementwiseTestCase(unittest.TestCase):
         jagged_max_prefix_shape,
         jagged1_inner_shape,
         jagged2_inner_shape,
+        implicit_jagged_input,
     ):
         self._test_jagged_jagged_elementwise_add(
             jagged_max_prefix_shape=jagged_max_prefix_shape,
             jagged1_inner_shape=jagged1_inner_shape,
             jagged2_inner_shape=jagged2_inner_shape,
+            implicit_jagged_input=implicit_jagged_input,
             offsets_list=[[0, 1, 4, 6, 7]],
             dtype="float16",
             offsets_dtype=offsets_dtype,
@@ -384,10 +398,10 @@ class JaggedElementwiseTestCase(unittest.TestCase):
 
     @parameterized.expand(
         [
-            param(1, "int32", [3, 4, 5, 200], [10], [10]),
-            param(2, "int32", [3, 4, 5, 200], [1, 2], [2, 1]),
-            param(3, "int64", [3, 4, 5, 150], [6, 7, 8], [6, 7, 8]),
-            param(4, "int64", [3, 4, 5, 150], [6, 1, 8], [1, 7, 1]),
+            param(1, "int32", [3, 4, 5, 200], [10], [10], False),
+            param(2, "int32", [3, 4, 5, 200], [1, 2], [2, 1], True),
+            param(3, "int64", [3, 4, 5, 150], [6, 7, 8], [6, 7, 8], False),
+            param(4, "int64", [3, 4, 5, 150], [6, 1, 8], [1, 7, 1], True),
         ]
     )
     def test_jagged_jagged_elementise_add_multiple_offsets_fp16(
@@ -397,11 +411,13 @@ class JaggedElementwiseTestCase(unittest.TestCase):
         jagged_max_prefix_shape,
         jagged1_inner_shape,
         jagged2_inner_shape,
+        implicit_jagged_input,
     ):
         self._test_jagged_jagged_elementwise_add(
             jagged_max_prefix_shape=jagged_max_prefix_shape,
             jagged1_inner_shape=jagged1_inner_shape,
             jagged2_inner_shape=jagged2_inner_shape,
+            implicit_jagged_input=implicit_jagged_input,
             offsets_list=[
                 [0, 1, 3, 5],
                 [0, 2, 4, 7, 9, 10],


### PR DESCRIPTION
Summary: When `elementwise` has both explicit (with `JaggedIntVar` as the first dim) and implicit (with `total_length: IntVar` as the first dim) jagged Tensor inputs, current broadcasting doesn't work, as it can't broadcast `total_length: IntVar` against the `JaggedIntVar`. In this diff, we're making the implicit jagged Tensor inputs explicit before the broadcasting takes place, by replacing the `total_length: IntVar` in their shape by the corresponding `JaggedIntVar` in the jagged input's shape.

Differential Revision: D44199071

