### PR TITLE
added a pass to move view ops

### DIFF
--- a/python/aitemplate/compiler/transform/__init__.py
+++ b/python/aitemplate/compiler/transform/__init__.py
@@ -31,6 +31,7 @@ from aitemplate.compiler.transform.mark_param_tensor import (
     mark_special_views,
 )
 from aitemplate.compiler.transform.memory_planning import memory_planning
+from aitemplate.compiler.transform.move_view_ops import move_view_op_before_concat
 from aitemplate.compiler.transform.name_graph import name_graph
 from aitemplate.compiler.transform.optimize_graph import optimize_graph
 from aitemplate.compiler.transform.profile import profile

--- a/python/aitemplate/compiler/transform/move_view_ops.py
+++ b/python/aitemplate/compiler/transform/move_view_ops.py
@@ -1,0 +1,274 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+This pass move any view op between two concatenate ops to the front of the
+first concatenate op if possible.
+"""
+import copy
+from typing import Callable, List, Optional, Tuple
+
+from aitemplate.compiler.base import IntImm, IntVar, Operator, Tensor
+
+from aitemplate.compiler.tensor_accessor import TensorAccessor
+from aitemplate.compiler.transform import transform_utils
+from aitemplate.compiler.transform.toposort import toposort
+
+from aitemplate.utils import shape_utils
+
+
+# TODO: support other view ops such as squeeze and unsqueeze
+_SUPPORTED_VIEW_OPS = ["reshape", "flatten"]
+
+
+def _make_input_view_shape(
+    cat_input: Tensor,
+    original_view_shape: List[IntVar],
+    cat_dim: int,
+    input_idx: int,
+) -> Optional[List[IntVar]]:
+    """
+    Make a new view shape for cat_input_shape based on the original_view_shape,
+    if the cat dimension is the only dimension with a different value from
+    the original_view_shape.
+    """
+    cat_input_shape = cat_input.shape()
+    if cat_dim >= len(cat_input_shape) or cat_dim >= len(original_view_shape):
+        return None
+    # make sure each dimension at the same index in front of the cat_dim is the same for
+    # both cat_input_shape and original_view_shape
+    for curr_cat_dim, orig_dim in zip(
+        cat_input_shape[:cat_dim], original_view_shape[:cat_dim]
+    ):
+        if curr_cat_dim != orig_dim:
+            return None
+    input_stride_at_cat_dim = shape_utils.get_static_stride(cat_input_shape, cat_dim)
+    # make sure all dimensions are static after cat_dim
+    if input_stride_at_cat_dim is None:
+        return None
+    orig_view_stride_at_cat_dim = shape_utils.get_static_stride(
+        original_view_shape, cat_dim
+    )
+    # make sure all dimensions are static after cat_dim
+    if orig_view_stride_at_cat_dim is None:
+        return None
+    new_input_view_shape = copy.deepcopy(original_view_shape)
+    cat_stride = cat_input_shape[cat_dim].value() * input_stride_at_cat_dim
+    if cat_stride % orig_view_stride_at_cat_dim != 0:
+        return None
+    orig_dim_name = original_view_shape[cat_dim]._attrs["name"]
+    new_input_view_shape[cat_dim] = IntImm(
+        cat_stride // orig_view_stride_at_cat_dim,
+        name=f'{orig_dim_name}_{cat_input._attrs["name"]}_{input_idx}',
+    )
+    return new_input_view_shape
+
+
+def _call_view_op(
+    view_op: Callable, view_output_shape: List[IntVar], input_tensor: Tensor
+) -> Tensor:
+    """
+    call the view_op with suitable arguments and return the output tensor
+    """
+    view_op_type = view_op._attrs["op"]
+    if view_op_type == "reshape":
+        output = view_op(input_tensor, view_output_shape)
+    elif view_op_type == "flatten":
+        output = view_op(input_tensor)
+    else:
+        raise AssertionError(f"unsupported {view_op_type=}")
+    return output
+
+
+def _try_move_view_op(
+    first_cat: Operator, second_cat: Operator, view_op: Operator
+) -> bool:
+    """
+    Try to move the view_op to the front of the first_cat.
+    Return true if the transformation is successful, False otherwise.
+    """
+    cat_dim = first_cat._attrs["concat_dim"]
+    first_cat_output = first_cat._attrs["outputs"][0]
+    first_cat_output_shape = first_cat_output.shape()
+    # we might be able to support dynamic cat_dim, but let's be conservative
+    # for now
+    if not shape_utils.is_static_dimension(first_cat_output_shape, cat_dim):
+        return False
+    if second_cat._attrs["concat_dim"] != cat_dim:
+        return False
+    second_cat_output = second_cat._attrs["outputs"][0]
+    if not shape_utils.is_static_dimension(second_cat_output.shape(), cat_dim):
+        return False
+    # We are not always able to move the view op. For example, we cannot
+    # move the reshape to the front of cat_1 in the following code:
+    #    x1 = tensor([batch, 16])
+    #    x2 = tensor([batch, 8])
+    #    cat_1 = concatenate([x1, x2], cat_dim=1)
+    #    reshape_2 = reshape(cat_1, [batch, 4, 6])
+    #    x3 = tensor([batch, 2, 6])
+    #    cat_2 = concatenate([reshape_2, x3], cat_dim=1)
+    # Basically, we cannot reshape either x1 or x2 to a shape while
+    # keep cat_dim = 1, i.e. we cannot form a shape [batch, -1, 6] from
+    # either [batch, 16] or [batch, 8].
+    input_view_shapes = []
+    view_op_output = view_op._attrs["outputs"][0]
+    original_view_shape = view_op_output.shape()
+    for input_idx, first_cat_input in enumerate(first_cat._attrs["inputs"]):
+        input_view_shape = _make_input_view_shape(
+            first_cat_input, original_view_shape, cat_dim, input_idx
+        )
+        if input_view_shape is None:
+            return False
+        input_view_shapes.append(input_view_shape)
+    # Now we start modifying the graph.
+    # make a new output tensor for the first cat
+    new_first_cat_output = Tensor(original_view_shape, first_cat_output._attrs["name"])
+    transform_utils.replace_tensor(first_cat_output, new_first_cat_output)
+    first_cat._attrs["outputs"][0] = new_first_cat_output
+    new_first_cat_output._attrs["src_ops"].add(first_cat)
+
+    # remove the old view op
+    transform_utils.remove_view_op_from_sorted_graph(view_op)
+    # make a new view op for each first_cat's original input and place it between
+    # the original input and the first cat
+    new_first_cat_inputs = []
+    removable_first_cat_inputs = set()
+    # The same tensor may be used multiple times by the first cat.
+    # We don't want to make one view op for each use, because it would
+    # prevent us from propagating those view ops to an upper level.
+    first_cat_input_to_view_output = {}
+    for first_cat_input, input_view_shape in zip(
+        first_cat._attrs["inputs"], input_view_shapes
+    ):
+        new_view_output = first_cat_input_to_view_output.get(first_cat_input, None)
+        if new_view_output is None:
+            new_view_op = type(view_op)(**view_op._get_op_attributes())
+            new_view_output = _call_view_op(
+                new_view_op, input_view_shape, first_cat_input
+            )
+            first_cat_input_to_view_output[first_cat_input] = new_view_output
+            new_view_output._attrs["dst_ops"].add(first_cat)
+            first_cat_input._attrs["dst_ops"].remove(first_cat)
+        new_first_cat_inputs.append(new_view_output)
+        # This peephole optimization is necessary in case we pushing a view op
+        # in between two concat ops where we have another view op. We could write
+        # a standalone pass for fusing consecutive view ops and run the pass
+        # after each iteration of moving a view op here. But it seems to be
+        # quite inefficient because we have to scan the entire graph again.
+        # So, let's do it locally to save us some time. BTW, we may still implement
+        # a pass that fuses consecutive view ops, but we just don't need to apply
+        # such a pass here.
+        if (
+            first_cat_input._attrs["is_view_of"]
+            and not first_cat_input._attrs["is_output"]
+            and len(first_cat_input._attrs["dst_ops"]) == 1
+        ):
+            removable_first_cat_inputs.add(first_cat_input)
+    first_cat._attrs["inputs"] = new_first_cat_inputs
+    first_cat._attrs["original_inputs"] = list(new_first_cat_inputs)
+    first_cat._attrs["input_accessors"] = [
+        TensorAccessor(inp) for inp in new_first_cat_inputs
+    ]
+    for old_input_view in removable_first_cat_inputs:
+        new_view_op = old_input_view._attrs["dst_ops"][0]
+        assert (
+            len(new_view_op._attrs["inputs"]) == 1
+        ), f"expected {new_view_op=} to have a single input"
+        new_view_op._attrs["inputs"][0]._attrs["is_view_of"] = old_input_view._attrs[
+            "is_view_of"
+        ]
+        transform_utils.remove_view_op_from_sorted_graph(
+            old_input_view._attrs["src_ops"][0]
+        )
+    return True
+
+
+def _is_valid_cat_op(cat: Operator) -> bool:
+    """
+    Return true if the cat op is valid for moving the view op.
+    """
+    if cat._attrs["op"] != "concatenate":
+        return False
+    # skip if the cat has any fused strided op
+    if any(mask is False for mask in cat._attrs["input_masks"]):
+        return False
+    # If cat carries strided input_accessors or fused view ops, we skip it
+    if "input_accessors" in cat._attrs:
+        if any(
+            input_accessor.stride_dim is not None
+            or input_accessor.actual_shapes is not None
+            for input_accessor in cat._attrs["input_accessors"]
+        ):
+            return False
+    return True
+
+
+def _move_view_op_before_concat(
+    sorted_graph: List[Tensor],
+) -> Tuple[bool, List[Tensor]]:
+    """
+    Return a tuple of (bool, List[Tensor]), where True indicates the
+    graph has been successfully changed.
+    """
+    changed = False
+    for tensor in sorted_graph:
+        src_ops = tensor._attrs["src_ops"]
+        if len(src_ops) == 0:
+            continue
+        first_cat = list(src_ops)[0]
+        if not _is_valid_cat_op(first_cat):
+            continue
+        first_cat_outputs = first_cat._attrs["outputs"]
+        if len(first_cat_outputs) != 1:
+            continue
+        first_cat_output = first_cat_outputs[0]
+        # If the first cat is a graph output, we cannot fuse it
+        if first_cat_output._attrs["is_output"]:
+            continue
+        next_ops = first_cat_output._attrs["dst_ops"]
+        if len(next_ops) != 1:
+            continue
+        view_op = list(next_ops)[0]
+        # skip if the next op is not one of the supported view ops
+        if view_op._attrs["op"] not in _SUPPORTED_VIEW_OPS:
+            continue
+        view_op_output = view_op._attrs["outputs"][0]
+        if view_op_output._attrs["is_output"]:
+            continue
+        next_next_ops = view_op_output._attrs["dst_ops"]
+        if len(next_next_ops) != 1:
+            continue
+        second_cat = list(next_next_ops)[0]
+        if not _is_valid_cat_op(second_cat):
+            continue
+        if _try_move_view_op(first_cat, second_cat, view_op):
+            changed = True
+    return (changed, sorted_graph)
+
+
+def move_view_op_before_concat(
+    sorted_graph: List[Tensor], wordir: str = None
+) -> List[Tensor]:
+    """
+    This transformation turns "cat + view_op + cat" into "view_op + cat + cat".
+    The yielded pattern may be optimized further by the transform_memory_ops pass.
+    Note that this pass must be invoked before transform_strided_op_and_view_op
+    and transform_strided_ops.
+    """
+    changed = True
+    while changed:
+        changed, sorted_graph = _move_view_op_before_concat(sorted_graph)
+        if changed:
+            sorted_graph = toposort(sorted_graph)
+    return transform_utils.sanitize_sorted_graph(sorted_graph)

--- a/python/aitemplate/compiler/transform/optimize_graph.py
+++ b/python/aitemplate/compiler/transform/optimize_graph.py
@@ -35,6 +35,7 @@ from aitemplate.compiler.transform.fuse_parallel_gemms import fuse_parallel_gemm
 from aitemplate.compiler.transform.fuse_permute_bmm_and_gemm import (
     fuse_permute_bmm_and_gemm,
 )
+from aitemplate.compiler.transform.move_view_ops import move_view_op_before_concat
 from aitemplate.compiler.transform.split_large_concat_ops import split_large_concat_ops
 from aitemplate.compiler.transform.split_large_slice_scatter_ops import (
     split_large_slice_scatter_ops,
@@ -92,6 +93,8 @@ def optimize_graph(
         fuse_conv_elementwise,
         fuse_mm_elementwise,
         fuse_mm_reshape_permute,
+        # make sure we run move_view_op_before_concat before transform_memory_ops
+        move_view_op_before_concat,
         transform_memory_ops,
         fuse_ops,
         fuse_elementwise,

--- a/python/aitemplate/compiler/transform/transform_memory_ops.py
+++ b/python/aitemplate/compiler/transform/transform_memory_ops.py
@@ -121,7 +121,8 @@ def _try_merge_split_cat(first_op: Operator, cat: Operator) -> bool:
     cat._attrs["original_inputs"] = list(new_cat_original_inputs)
     cat._attrs["input_masks"] = [True] * len(new_cat_inputs)
     for tensor in first_op_inputs:
-        tensor._attrs["dst_ops"].remove(first_op)
+        # the same tensor may be used multiple times
+        tensor._attrs["dst_ops"].discard(first_op)
         tensor._attrs["dst_ops"].add(cat)
     for tensor in first_op_outputs:
         transform_utils.remove_tensor_from_sorted_graph(tensor)

--- a/python/aitemplate/compiler/transform/transform_utils.py
+++ b/python/aitemplate/compiler/transform/transform_utils.py
@@ -227,7 +227,8 @@ def remove_view_op_from_sorted_graph(op: Operator) -> None:
     input_tensor = op._attrs["inputs"][0]
     output_tensor = op._attrs["outputs"][0]
 
-    input_tensor._attrs["dst_ops"] = output_tensor._attrs["dst_ops"]
+    input_tensor._attrs["dst_ops"].remove(op)
+    input_tensor._attrs["dst_ops"].update(output_tensor._attrs["dst_ops"])
     for dst_op in output_tensor._attrs["dst_ops"]:
         dst_op.replace_input_tensor(output_tensor, input_tensor)
     if output_tensor._attrs["is_output"]:

--- a/python/aitemplate/utils/shape_utils.py
+++ b/python/aitemplate/utils/shape_utils.py
@@ -16,7 +16,7 @@
 Util functions to handle shapes.
 """
 
-from typing import List
+from typing import List, Optional
 
 
 def gen_int_var(values: List[int], name: str = None):
@@ -185,3 +185,18 @@ def is_same_shape(shapes1, shapes2) -> bool:
         if dim1 != dim2:
             return False
     return True
+
+
+def get_static_stride(shape, dim) -> Optional[int]:
+    """
+    This is a helper function that returns the static stride for dim.
+    It returns None if it cannot generate a static stride.
+    """
+    from aitemplate.compiler.base import IntImm
+
+    stride = 1
+    for d in shape[dim + 1 :]:
+        if not isinstance(d, IntImm):
+            return None
+        stride *= d.value()
+    return stride

--- a/tests/unittest/compiler/test_move_view_ops.py
+++ b/tests/unittest/compiler/test_move_view_ops.py
@@ -1,0 +1,1379 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import unittest
+
+import torch
+
+from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler.ops.common.epilogue import FuncEnum
+from aitemplate.frontend import IntImm, Tensor
+from aitemplate.testing import detect_target
+from aitemplate.testing.test_utils import (
+    get_random_torch_tensor,
+    get_torch_empty_tensor,
+)
+from aitemplate.utils import graph_utils, shape_utils
+
+
+class MoveViewOpsTestCase(unittest.TestCase):
+    BATCH_SIZE = 1024
+
+    def __init__(self, *args, **kwargs):
+        super(MoveViewOpsTestCase, self).__init__(*args, **kwargs)
+        self.test_count = 0
+
+    def _test_non_movable_reshape_cat(self, M0, M1, N, test_name, dtype="float16"):
+        # make a graph like below:
+        # concat_0 = concatenate(x0, x1, dim=1)
+        # reshape_1 = reshape(concat_0)
+        # y = concatenate(reshape_1, x2, dim=2)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0 * N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1 * N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        M2 = M0 + M1
+        X2 = Tensor(
+            shape=[batch_dim, M2, IntImm(N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        cat_dim_1 = 1
+        concat_0 = ops.concatenate()([X0, X1], dim=cat_dim_1)
+        reshape_to_shape_1 = [-1, M2, N]
+        reshape_1 = ops.reshape()(concat_0, reshape_to_shape_1)
+        cat_dim_2 = 2
+        Y = ops.concatenate()([reshape_1, X2], dim=cat_dim_2)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        self.assertEqual(len(sorted_graph), 5)
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 2)
+        self.assertEqual(sorted_ops[0]._attrs["op"], "concatenate")
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0 * N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1 * N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2, N], dtype)
+            concat_0_pt = torch.cat([x0_pt, x1_pt], dim=cat_dim_1)
+            reshape_1_pt = torch.reshape(concat_0_pt, reshape_to_shape_1)
+            y_pt = torch.cat([reshape_1_pt, x2_pt], dim=cat_dim_2)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x1": x1_pt, "x2": x2_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.01, rtol=0.01)
+
+    def test_non_movable_reshape_cat(self):
+        self._test_non_movable_reshape_cat(
+            M0=4,
+            M1=2,
+            N=4,
+            test_name="test_non_movable_reshape_cat",
+            dtype="float16",
+        )
+
+    def _test_move_reshape_cat_basic(
+        self, M0, M1, M2, N, test_name, dtype="float16", non_movable=False
+    ):
+        # make a graph like below:
+        # concat_0 = concatenate(x0, x1)
+        # reshape_1 = reshape(concat_0)
+        # y = concatenate(reshape_1, x2)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0 * N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1 * N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        if non_movable is True:
+            assert (M0 + M1) % 3 == 0, "(M0 + M1) * N must be divisible by 3"
+            X2_M = (M0 + M1) * N // 3
+            X2_N = 3
+            reshape_to_shape_1 = [-1, X2_M, X2_N]
+        else:
+            reshape_to_shape_1 = [-1, M0 + M1, N]
+            X2_M = M2
+            X2_N = N
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(X2_M), IntImm(X2_N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        cat_dim = 1
+        concat_0 = ops.concatenate()([X0, X1], dim=cat_dim)
+        reshape_1 = ops.reshape()(concat_0, reshape_to_shape_1)
+        Y = ops.concatenate()([reshape_1, X2], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        if non_movable is True:
+            expected_num_tensors = 5
+            # reshape can be fused into the second cat
+            expected_num_ops = 2
+        else:
+            expected_num_tensors = 4
+            expected_num_ops = 1
+        self.assertEqual(len(sorted_graph), expected_num_tensors)
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), expected_num_ops)
+        self.assertEqual(sorted_ops[0]._attrs["op"], "concatenate")
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0 * N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1 * N], dtype)
+            x2_pt = get_random_torch_tensor([batch, X2_M, X2_N], dtype)
+            concat_0_pt = torch.cat([x0_pt, x1_pt], dim=cat_dim)
+            reshape_1_pt = torch.reshape(concat_0_pt, reshape_to_shape_1)
+            y_pt = torch.cat([reshape_1_pt, x2_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x1": x1_pt, "x2": x2_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.01, rtol=0.01)
+
+    def test_move_reshape_cat_basic(self):
+        self._test_move_reshape_cat_basic(
+            M0=4,
+            M1=2,
+            M2=6,
+            N=4,
+            test_name="test_move_reshape_cat_basic_non_movable",
+            dtype="float16",
+            non_movable=True,
+        )
+        self._test_move_reshape_cat_basic(
+            M0=1,
+            M1=5,
+            M2=7,
+            N=3,
+            test_name="test_move_reshape_cat_basic",
+            dtype="float16",
+        )
+        self._test_move_reshape_cat_basic(
+            M0=2,
+            M1=2,
+            M2=6,
+            N=8,
+            test_name="test_move_reshape_cat_basic",
+            dtype="float16",
+        )
+
+    def _test_move_reshape_cat_basic_2(self, M0, M1, M2, N, test_name, dtype="float16"):
+        # make a graph like below:
+        # reshape_0 = reshape(x0)
+        # reshape_1 = reshape(x1)
+        # concat_2 = concatenate(reshape_0, x3, reshape_1)
+        # reshape_3 = reshape(concat_2)
+        # y = concatenate(x2, reshape_3, x2)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        assert M0 % 2 == 0, f"{M0=} must be divisible by 2"
+        assert N % 2 == 0, f"{N=} must be divisible by 2"
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0 // 2), IntImm(N * 2)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1), IntImm(N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2), IntImm(N // 2)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        X3 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N)],
+            dtype=dtype,
+            name="x3",
+            is_input=True,
+        )
+        cat_dim = 1
+        reshape_0 = ops.reshape()(X0, [-1, M0, N])
+        reshape_1 = ops.reshape()(X1, [-1, M1, N])
+        concat_2 = ops.concatenate()([reshape_0, X3, reshape_1], dim=cat_dim)
+        reshape_to_shape_3 = [-1, (M0 + M0 + M1) * 2, N // 2]
+        reshape_3 = ops.reshape()(concat_2, reshape_to_shape_3)
+        Y = ops.concatenate()([X2, reshape_3, X2], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        self.assertEqual(len(sorted_graph), 5)
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 1)
+        self.assertEqual(sorted_ops[0]._attrs["op"], "concatenate")
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0 // 2, N * 2], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1, N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2, N // 2], dtype)
+            x3_pt = get_random_torch_tensor([batch, M0, N], dtype)
+            reshape_0_pt = torch.reshape(x0_pt, [-1, M0, N])
+            reshape_1_pt = torch.reshape(x1_pt, [-1, M1, N])
+            concat_2_pt = torch.cat([reshape_0_pt, x3_pt, reshape_1_pt], dim=cat_dim)
+            reshape_3_pt = torch.reshape(concat_2_pt, reshape_to_shape_3)
+            y_pt = torch.cat([x2_pt, reshape_3_pt, x2_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x1": x1_pt, "x2": x2_pt, "x3": x3_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.01, rtol=0.01)
+
+    def test_move_reshape_cat_basic_2(self):
+        self._test_move_reshape_cat_basic_2(
+            M0=2,
+            M1=2,
+            M2=6,
+            N=8,
+            test_name="test_move_reshape_cat_basic_2",
+            dtype="float16",
+        )
+
+    def _test_move_reshape_cat_basic_3(self, M0, M2, N, test_name, dtype="float16"):
+        # make a graph like below:
+        # concat_0 = concatenate(x0, x0)
+        # reshape_1 = reshape(concat_0)
+        # y = concatenate(reshape_1, x2)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0 * N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2), IntImm(N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        cat_dim = 1
+        concat_0 = ops.concatenate()([X0, X0], dim=cat_dim)
+        reshape_to_shape_1 = [-1, M0 + M0, N]
+        reshape_1 = ops.reshape()(concat_0, reshape_to_shape_1)
+        Y = ops.concatenate()([reshape_1, X2], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        self.assertEqual(len(sorted_graph), 3)
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 1)
+        self.assertEqual(sorted_ops[0]._attrs["op"], "concatenate")
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0 * N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2, N], dtype)
+            concat_0_pt = torch.cat([x0_pt, x0_pt], dim=cat_dim)
+            reshape_1_pt = torch.reshape(concat_0_pt, reshape_to_shape_1)
+            y_pt = torch.cat([reshape_1_pt, x2_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x2": x2_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.01, rtol=0.01)
+
+    def test_move_reshape_cat_basic_3(self):
+        self._test_move_reshape_cat_basic_3(
+            M0=1,
+            M2=7,
+            N=3,
+            test_name="test_move_reshape_cat_basic_3",
+            dtype="float16",
+        )
+
+    def _test_move_reshape_cat_1(self, M0, M1, M2, N, test_name, dtype="float16"):
+        # make a graph like below:
+        # concat_0 = concatenate(x0, x1)
+        # reshape_2 = reshape(concat_0)
+        # concat_4 = concatenate(x2, reshape_2)
+        # flatten_5 = flatten(concat_4)
+        # concat_6 = concatenate(x0, flatten_5)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0 * N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1 * N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2), IntImm(N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        cat_dim = 1
+        concat_0 = ops.concatenate()([X0, X1], dim=cat_dim)
+        reshape_2 = ops.reshape()(concat_0, [-1, M0 + M1, N])
+        concat_4 = ops.concatenate()([X2, reshape_2], dim=cat_dim)
+        flatten_5 = ops.flatten(start_dim=1, end_dim=-1)(concat_4)
+        Y = ops.concatenate()([X0, flatten_5], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 1)
+        self.assertEqual(sorted_ops[0]._attrs["op"], "concatenate")
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0 * N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1 * N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2, N], dtype)
+            concat_0_pt = torch.cat([x0_pt, x1_pt], dim=cat_dim)
+            reshape_2_pt = torch.reshape(concat_0_pt, [-1, M0 + M1, N])
+            concat_4_pt = torch.cat([x2_pt, reshape_2_pt], dim=cat_dim)
+            flatten_5_pt = torch.flatten(concat_4_pt, 1, -1)
+            y_pt = torch.cat([x0_pt, flatten_5_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x1": x1_pt, "x2": x2_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.05, rtol=0.05)
+
+    def test_move_reshape_cat_1(self):
+        self._test_move_reshape_cat_1(
+            M0=2,
+            M1=2,
+            M2=6,
+            N=8,
+            test_name="test_move_reshape_cat_1",
+            dtype="float16",
+        )
+
+    def _test_move_reshape_cat_2(self, M0, M1, M2, M3, N, test_name, dtype="float16"):
+        # make a graph like below:
+        # concat_0 = concatenate(x0, x1)
+        # concat_1 = concatenate(x0, x1)
+        # reshape_2 = reshape(concat_0)
+        # reshape_3 = reshape(concat_1)
+        # concat_4 = concatenate(x2, reshape_2, reshape_3, x3, reshape_2)
+        # flatten_5 = flatten(concat_4)
+        # concat_6 = concatenate(x0, flatten_5, x1, flatten_5)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0 * N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1 * N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2), IntImm(N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        X3 = Tensor(
+            shape=[batch_dim, IntImm(M3), IntImm(N)],
+            dtype=dtype,
+            name="x3",
+            is_input=True,
+        )
+        cat_dim = 1
+        concat_0 = ops.concatenate()([X0, X1], dim=cat_dim)
+        concat_1 = ops.concatenate()([X0, X1], dim=cat_dim)
+        reshape_2 = ops.reshape()(concat_0, [-1, M0 + M1, N])
+        reshape_3 = ops.reshape()(concat_1, [-1, M0 + M1, N])
+        concat_4 = ops.concatenate()(
+            [X2, reshape_2, reshape_3, X3, reshape_2], dim=cat_dim
+        )
+        flatten_5 = ops.flatten(start_dim=1, end_dim=-1)(concat_4)
+        Y = ops.concatenate()([X0, flatten_5, X1, flatten_5], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 1)
+        self.assertEqual(sorted_ops[0]._attrs["op"], "concatenate")
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0 * N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1 * N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2, N], dtype)
+            x3_pt = get_random_torch_tensor([batch, M3, N], dtype)
+            concat_0_pt = torch.cat([x0_pt, x1_pt], dim=cat_dim)
+            concat_1_pt = torch.cat([x0_pt, x1_pt], dim=cat_dim)
+            reshape_2_pt = torch.reshape(concat_0_pt, [-1, M0 + M1, N])
+            reshape_3_pt = torch.reshape(concat_1_pt, [-1, M0 + M1, N])
+            concat_4_pt = torch.cat(
+                [x2_pt, reshape_2_pt, reshape_3_pt, x3_pt, reshape_2_pt], dim=cat_dim
+            )
+            flatten_5_pt = torch.flatten(concat_4_pt, 1, -1)
+            y_pt = torch.cat([x0_pt, flatten_5_pt, x1_pt, flatten_5_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x1": x1_pt, "x2": x2_pt, "x3": x3_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.05, rtol=0.05)
+
+    def test_move_reshape_cat_2(self):
+        self._test_move_reshape_cat_2(
+            M0=2,
+            M1=2,
+            M2=6,
+            M3=4,
+            N=8,
+            test_name="test_move_reshape_cat_2",
+            dtype="float16",
+        )
+
+    def _test_move_strided_reshape_cat(
+        self, M0, M1, M2, M3, N, test_name, dtype="float16"
+    ):
+        # make a graph like below:
+        # add_0 = add(x0, x1)
+        # concat_1 = concatenate(add_0, x2)
+        # reshape_2 = reshape(concat_1)
+        # y = concatenate(reshape_2, x3)
+        assert M0 == M1, f"expected {M0=} to be equal to {M1=}"
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0 * N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1 * N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2 * N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        X3 = Tensor(
+            shape=[batch_dim, IntImm(M3), IntImm(N)],
+            dtype=dtype,
+            name="x3",
+            is_input=True,
+        )
+        cat_dim = 1
+        add_0 = ops.elementwise(FuncEnum.ADD)(X0, X1)
+        concat_1 = ops.concatenate()([add_0, X2], dim=cat_dim)
+        reshape_2 = ops.reshape()(concat_1, [-1, M0 + M2, N])
+        Y = ops.concatenate()([reshape_2, X3], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 2)
+        concat_cnt = 0
+        for sorted_op in sorted_ops:
+            if sorted_op._attrs["op"] == "concatenate":
+                concat_cnt += 1
+        self.assertEqual(concat_cnt, 1)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0 * N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1 * N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2 * N], dtype)
+            x3_pt = get_random_torch_tensor([batch, M3, N], dtype)
+            add_0_pt = x0_pt + x1_pt
+            concat_1_pt = torch.cat([add_0_pt, x2_pt], dim=cat_dim)
+            reshape_2_pt = torch.reshape(concat_1_pt, [-1, M0 + M2, N])
+            y_pt = torch.cat([reshape_2_pt, x3_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x1": x1_pt, "x2": x2_pt, "x3": x3_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.05, rtol=0.05)
+
+    def test_move_strided_reshape_cat(self):
+        self._test_move_strided_reshape_cat(
+            M0=4,
+            M1=4,
+            M2=6,
+            M3=3,
+            N=8,
+            test_name="test_move_strided_reshape_cat",
+            dtype="float16",
+        )
+        self._test_move_strided_reshape_cat(
+            M0=4,
+            M1=4,
+            M2=5,
+            M3=10,
+            N=7,
+            test_name="test_move_strided_reshape_cat",
+            dtype="float16",
+        )
+
+    def _test_move_strided_reshape_cat_2(
+        self, M0, M1, M2, M3, N, test_name, dtype="float16"
+    ):
+        # make a graph like below:
+        # add_0 = add(x0, x0)
+        # reshape_1 = reshape(add_0)
+        # add_2 = add(x1, x1)
+        # concat_3 = concatenate(x2, reshape_1, x2, add_2)
+        # reshape_4 = reshape(concat_3)
+        # y = concatenate(x3, reshape_4, x3)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1 * N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2 * N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        X3 = Tensor(
+            shape=[batch_dim, IntImm(M3), IntImm(N)],
+            dtype=dtype,
+            name="x3",
+            is_input=True,
+        )
+
+        cat_dim = 1
+        add_0 = ops.elementwise(FuncEnum.ADD)(X0, X0)
+        reshape_1 = ops.reshape()(add_0, [-1, M0 * N])
+        add_2 = ops.elementwise(FuncEnum.ADD)(X1, X1)
+        concat_3 = ops.concatenate()([X2, reshape_1, X2, add_2], dim=cat_dim)
+        reshape_to_shape_4 = (
+            sum([t.shape()[cat_dim].value() for t in [X2, reshape_1, X2, add_2]]) // N
+        )
+        reshape_4 = ops.reshape()(concat_3, [-1, reshape_to_shape_4, N])
+        Y = ops.concatenate()([X3, reshape_4, X3], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        module = compile_model(Y, target, "./tmp", test_name)
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 3)
+        concat_cnt = 0
+        for sorted_op in sorted_ops:
+            if sorted_op._attrs["op"] == "concatenate":
+                concat_cnt += 1
+        self.assertEqual(concat_cnt, 1)
+        output_tensors = {op._attrs["outputs"][0] for op in sorted_ops}
+        self.assertEqual(len(output_tensors), 1)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0, N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1 * N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2 * N], dtype)
+            x3_pt = get_random_torch_tensor([batch, M3, N], dtype)
+            add_0_pt = x0_pt + x0_pt
+            reshape_1_pt = torch.reshape(add_0_pt, [batch, M0 * N])
+            add_2_pt = x1_pt + x1_pt
+            concat_3_pt = torch.cat([x2_pt, reshape_1_pt, x2_pt, add_2_pt], dim=cat_dim)
+            reshape_4_pt = torch.reshape(concat_3_pt, [-1, reshape_to_shape_4, N])
+            y_pt = torch.cat([x3_pt, reshape_4_pt, x3_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x1": x1_pt, "x2": x2_pt, "x3": x3_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.05, rtol=0.05)
+
+    def test_move_strided_reshape_cat_2(self):
+        self._test_move_strided_reshape_cat_2(
+            M0=4,
+            M1=6,
+            M2=9,
+            M3=16,
+            N=8,
+            test_name="test_move_strided_reshape_cat_2",
+            dtype="float16",
+        )
+
+    def _test_move_strided_reshape_cat_3(
+        self, M0, M1, M2, M3, N, test_name, dtype="float16"
+    ):
+        # make a graph like below:
+        # slice_0 = slice(x4)
+        # slice_1 = slice(x4)
+        # slice_2 = slice(x4)
+        # add_0 = add(x0, x0)
+        # reshape_1 = reshape(add_0)
+        # add_2 = add(x1, x1)
+        # flatten_3 = flatten(add_2)
+        # concat_4 = concatenate(x2, slice_0, slice_1, reshape_1, slice_2, flatten_3) # 2d
+        # add_5 = add(x3, x3)
+        # reshape_6 = reshape(add_5)
+        # reshape_7 = reshape(concat_4)
+        # concat_8 = concatenate(x0, reshape_7, reshape_6) # 3d
+        # add_9 = add(x0, x0)
+        # flatten_10 = flatten(concat_8) # 2d
+        # reshape_11 = reshape(add_9) # 2d
+        # y = concatenate(x1, reshape_11, flatten_10, x2) # 2d
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1 * N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2 * N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        X3 = Tensor(
+            shape=[batch_dim, IntImm(M3), IntImm(N)],
+            dtype=dtype,
+            name="x3",
+            is_input=True,
+        )
+        M4 = 10 * M0
+        X4 = Tensor(
+            shape=[batch_dim, IntImm(M4 * N)],
+            dtype=dtype,
+            name="x4",
+            is_input=True,
+        )
+
+        slice_start_indices_0 = [None, 0]
+        slice_end_indices_0 = [None, N]
+        slice_start_indices_1 = [None, 3 * N]
+        slice_end_indices_1 = [None, 4 * N]
+        slice_start_indices_2 = [None, 4 * N]
+        slice_end_indices_2 = [None, 8 * N]
+        slice_0 = ops.dynamic_slice()(X4, slice_start_indices_0, slice_end_indices_0)
+        slice_1 = ops.dynamic_slice()(X4, slice_start_indices_1, slice_end_indices_1)
+        slice_2 = ops.dynamic_slice()(X4, slice_start_indices_2, slice_end_indices_2)
+        cat_dim = 1
+        add_0 = ops.elementwise(FuncEnum.ADD)(X0, X0)
+        reshape_1 = ops.reshape()(add_0, [-1, M0 * N])
+        add_2 = ops.elementwise(FuncEnum.ADD)(X1, X1)
+        flatten_3 = ops.flatten(start_dim=1, end_dim=-1)(add_2)
+        concat_4 = ops.concatenate()(
+            [X2, slice_0, slice_1, reshape_1, slice_2, flatten_3], dim=cat_dim
+        )
+        add_5 = ops.elementwise(FuncEnum.ADD)(X3, X3)
+        reshape_6 = ops.reshape()(add_5, [-1, M3, N])
+        reshape_to_shape_7 = (
+            sum(
+                [
+                    t.shape()[cat_dim].value()
+                    for t in [X2, slice_0, slice_1, reshape_1, slice_2, flatten_3]
+                ]
+            )
+            // N
+        )
+        reshape_7 = ops.reshape()(concat_4, [-1, reshape_to_shape_7, N])
+        concat_8 = ops.concatenate()([X0, reshape_7, reshape_6], dim=cat_dim)
+        add_9 = ops.elementwise(FuncEnum.ADD)(X0, X0)
+        flatten_10 = ops.flatten(start_dim=1, end_dim=-1)(concat_8)
+        reshape_11 = ops.reshape()(add_9, [-1, M0 * N])
+        Y = ops.concatenate()([X1, reshape_11, flatten_10, X2], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        module = compile_model(Y, target, "./tmp", test_name)
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 5)
+        concat_cnt = 0
+        for sorted_op in sorted_ops:
+            if sorted_op._attrs["op"] == "concatenate":
+                concat_cnt += 1
+        self.assertEqual(concat_cnt, 1)
+        output_tensors = {op._attrs["outputs"][0] for op in sorted_ops}
+        self.assertEqual(len(output_tensors), 1)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0, N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1 * N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2 * N], dtype)
+            x3_pt = get_random_torch_tensor([batch, M3, N], dtype)
+            x4_pt = get_random_torch_tensor([batch, M4 * N], dtype)
+
+            slice_indices_0 = [
+                slice(i, j) for i, j in zip(slice_start_indices_0, slice_end_indices_0)
+            ]
+            slice_indices_1 = [
+                slice(i, j) for i, j in zip(slice_start_indices_1, slice_end_indices_1)
+            ]
+            slice_indices_2 = [
+                slice(i, j) for i, j in zip(slice_start_indices_2, slice_end_indices_2)
+            ]
+            slice_0_pt = x4_pt[slice_indices_0]
+            slice_1_pt = x4_pt[slice_indices_1]
+            slice_2_pt = x4_pt[slice_indices_2]
+
+            add_0_pt = x0_pt + x0_pt
+            reshape_1_pt = torch.reshape(add_0_pt, [batch, M0 * N])
+            add_2_pt = x1_pt + x1_pt
+            flatten_3_pt = torch.flatten(add_2_pt, 1, -1)
+            concat_4_pt = torch.cat(
+                [x2_pt, slice_0_pt, slice_1_pt, reshape_1_pt, slice_2_pt, flatten_3_pt],
+                dim=cat_dim,
+            )
+            add_5_pt = x3_pt + x3_pt
+            reshape_6_pt = torch.reshape(add_5_pt, [-1, M3, N])
+            reshape_7_pt = torch.reshape(concat_4_pt, [-1, reshape_to_shape_7, N])
+            concat_8_pt = torch.cat([x0_pt, reshape_7_pt, reshape_6_pt], dim=cat_dim)
+            add_9_pt = x0_pt + x0_pt
+            flatten_10_pt = torch.flatten(concat_8_pt, 1, -1)
+            reshape_11_pt = torch.reshape(add_9_pt, [-1, M0 * N])
+            y_pt = torch.cat([x1_pt, reshape_11_pt, flatten_10_pt, x2_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x1": x1_pt, "x2": x2_pt, "x3": x3_pt, "x4": x4_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.05, rtol=0.05)
+
+    def test_move_strided_reshape_cat_3(self):
+        self._test_move_strided_reshape_cat_3(
+            M0=4,
+            M1=6,
+            M2=9,
+            M3=16,
+            N=8,
+            test_name="test_move_strided_reshape_cat_3",
+            dtype="float16",
+        )
+
+    def _test_move_strided_reshape_cat_4(self, M0, M2, N, test_name, dtype="float16"):
+        # make a graph like below:
+        # slice_0 = slice(x4)
+        # concat_4 = concatenate(x2, slice_0) # 2d
+        # reshape_7 = reshape(concat_4)
+        # y = concatenate(x0, reshape_7) # 3d
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2 * N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        M4 = 10 * M0
+        X4 = Tensor(
+            shape=[batch_dim, IntImm(M4 * N)],
+            dtype=dtype,
+            name="x4",
+            is_input=True,
+        )
+
+        slice_start_indices_0 = [None, 0]
+        slice_end_indices_0 = [None, N]
+        slice_0 = ops.dynamic_slice()(X4, slice_start_indices_0, slice_end_indices_0)
+        cat_dim = 1
+        concat_4 = ops.concatenate()([X2, slice_0], dim=cat_dim)
+        reshape_to_shape_7 = (
+            sum([t.shape()[cat_dim].value() for t in [X2, slice_0]]) // N
+        )
+        reshape_7 = ops.reshape()(concat_4, [-1, reshape_to_shape_7, N])
+        Y = ops.concatenate()([X0, reshape_7], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        module = compile_model(Y, target, "./tmp", test_name)
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 1)
+        concat_cnt = 0
+        for sorted_op in sorted_ops:
+            if sorted_op._attrs["op"] == "concatenate":
+                concat_cnt += 1
+        self.assertEqual(concat_cnt, 1)
+        output_tensors = {op._attrs["outputs"][0] for op in sorted_ops}
+        self.assertEqual(len(output_tensors), 1)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0, N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2 * N], dtype)
+            x4_pt = get_random_torch_tensor([batch, M4 * N], dtype)
+
+            slice_indices_0 = [
+                slice(i, j) for i, j in zip(slice_start_indices_0, slice_end_indices_0)
+            ]
+            slice_0_pt = x4_pt[slice_indices_0]
+
+            concat_4_pt = torch.cat([x2_pt, slice_0_pt], dim=cat_dim)
+            reshape_7_pt = torch.reshape(concat_4_pt, [-1, reshape_to_shape_7, N])
+            y_pt = torch.cat([x0_pt, reshape_7_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x2": x2_pt, "x4": x4_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.05, rtol=0.05)
+
+    def test_move_strided_reshape_cat_4(self):
+        self._test_move_strided_reshape_cat_4(
+            M0=4,
+            M2=9,
+            N=8,
+            test_name="test_move_strided_reshape_cat_4",
+            dtype="float16",
+        )
+
+    def _test_move_strided_reshape_cat_5(self, M0, M2, N, test_name, dtype="float16"):
+        # make a graph like below:
+        # slice_0 = slice(x4)
+        # concat_4 = concatenate(x2, slice_0) # 2d
+        # reshape_7 = reshape(concat_4)
+        # concat_8 = concatenate(x0, reshape_7) # 3d
+        # flatten_10 = reshape(concat_8) # 2d
+        # y = concatenate(flatten_10, x2) # 2d
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2 * N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        M4 = 10 * M0
+        X4 = Tensor(
+            shape=[batch_dim, IntImm(M4 * N)],
+            dtype=dtype,
+            name="x4",
+            is_input=True,
+        )
+
+        slice_start_indices_0 = [None, 0]
+        slice_end_indices_0 = [None, N]
+        slice_0 = ops.dynamic_slice()(X4, slice_start_indices_0, slice_end_indices_0)
+        cat_dim = 1
+        concat_4 = ops.concatenate()([X2, slice_0], dim=cat_dim)
+        reshape_to_shape_7 = (
+            sum([t.shape()[cat_dim].value() for t in [X2, slice_0]]) // N
+        )
+        reshape_7 = ops.reshape()(concat_4, [-1, reshape_to_shape_7, N])
+        concat_8 = ops.concatenate()([X0, reshape_7], dim=cat_dim)
+        flatten_10 = ops.flatten(start_dim=1, end_dim=-1)(concat_8)
+        Y = ops.concatenate()([flatten_10, X2], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        module = compile_model(Y, target, "./tmp", test_name)
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 1)
+        concat_cnt = 0
+        for sorted_op in sorted_ops:
+            if sorted_op._attrs["op"] == "concatenate":
+                concat_cnt += 1
+        self.assertEqual(concat_cnt, 1)
+        output_tensors = {op._attrs["outputs"][0] for op in sorted_ops}
+        self.assertEqual(len(output_tensors), 1)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0, N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2 * N], dtype)
+            x4_pt = get_random_torch_tensor([batch, M4 * N], dtype)
+
+            slice_indices_0 = [
+                slice(i, j) for i, j in zip(slice_start_indices_0, slice_end_indices_0)
+            ]
+            slice_0_pt = x4_pt[slice_indices_0]
+
+            concat_4_pt = torch.cat([x2_pt, slice_0_pt], dim=cat_dim)
+            reshape_7_pt = torch.reshape(concat_4_pt, [-1, reshape_to_shape_7, N])
+            concat_8_pt = torch.cat([x0_pt, reshape_7_pt], dim=cat_dim)
+            flatten_10_pt = torch.flatten(concat_8_pt, 1, -1)
+            y_pt = torch.cat([flatten_10_pt, x2_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x2": x2_pt, "x4": x4_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.05, rtol=0.05)
+
+    def test_move_strided_reshape_cat_5(self):
+        self._test_move_strided_reshape_cat_5(
+            M0=4,
+            M2=9,
+            N=8,
+            test_name="test_move_strided_reshape_cat_5",
+            dtype="float16",
+        )
+
+    def _test_move_strided_reshape_cat_6(self, M0, M2, N, test_name, dtype="float16"):
+        # make a graph like below:
+        # add_0 = add(x4, x4)
+        # concat_4 = concatenate(x2, add_0) # 2d
+        # reshape_7 = reshape(concat_4)
+        # concat_8 = concatenate(x0, reshape_7) # 3d
+        # flatten_10 = reshape(concat_8) # 2d
+        # y = concatenate(flatten_10, x2) # 2d
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2 * N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        M4 = 10 * M0
+        X4 = Tensor(
+            shape=[batch_dim, IntImm(M4 * N)],
+            dtype=dtype,
+            name="x4",
+            is_input=True,
+        )
+
+        add_0 = ops.elementwise(FuncEnum.ADD)(X4, X4)
+        cat_dim = 1
+        concat_4 = ops.concatenate()([X2, add_0], dim=cat_dim)
+        reshape_to_shape_7 = sum([t.shape()[cat_dim].value() for t in [X2, add_0]]) // N
+        reshape_7 = ops.reshape()(concat_4, [-1, reshape_to_shape_7, N])
+        concat_8 = ops.concatenate()([X0, reshape_7], dim=cat_dim)
+        flatten_10 = ops.flatten(start_dim=1, end_dim=-1)(concat_8)
+        Y = ops.concatenate()([flatten_10, X2], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        module = compile_model(Y, target, "./tmp", test_name)
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 2)
+        concat_cnt = 0
+        for sorted_op in sorted_ops:
+            if sorted_op._attrs["op"] == "concatenate":
+                concat_cnt += 1
+        self.assertEqual(concat_cnt, 1)
+        output_tensors = {op._attrs["outputs"][0] for op in sorted_ops}
+        self.assertEqual(len(output_tensors), 1)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0, N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2 * N], dtype)
+            x4_pt = get_random_torch_tensor([batch, M4 * N], dtype)
+
+            add_0_pt = x4_pt + x4_pt
+            concat_4_pt = torch.cat([x2_pt, add_0_pt], dim=cat_dim)
+            reshape_7_pt = torch.reshape(concat_4_pt, [-1, reshape_to_shape_7, N])
+            concat_8_pt = torch.cat([x0_pt, reshape_7_pt], dim=cat_dim)
+            flatten_10_pt = torch.flatten(concat_8_pt, 1, -1)
+            y_pt = torch.cat([flatten_10_pt, x2_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x2": x2_pt, "x4": x4_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.05, rtol=0.05)
+
+    def test_move_strided_reshape_cat_6(self):
+        self._test_move_strided_reshape_cat_6(
+            M0=4,
+            M2=9,
+            N=8,
+            test_name="test_move_strided_reshape_cat_6",
+            dtype="float16",
+        )
+
+    def _test_move_strided_reshape_cat_7(
+        self, M0, M1, M2, M3, N, test_name, dtype="float16"
+    ):
+        # make a graph like below:
+        # add_0 = add(x0, x1)
+        # concat_1 = concatenate(add_0, x2)
+        # reshape_2 = reshape(concat_1)
+        # add_3 = add(x4, reshape_2)
+        # concat_4 = concatenate(x3, reshape_2, x3)
+        # reduce_5 = reduce_sum(add_3)
+        # reduce_6 = reduce_sum(concat_5)
+        # y = add(reduce_5, reduce_6)
+        assert M0 == M1, f"expected {M0=} to be equal to {M1=}"
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0 * N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1 * N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2 * N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        X3 = Tensor(
+            shape=[batch_dim, IntImm(M3), IntImm(N)],
+            dtype=dtype,
+            name="x3",
+            is_input=True,
+        )
+        M4 = M0 + M2
+        X4 = Tensor(
+            shape=[batch_dim, IntImm(M0 + M2), IntImm(N)],
+            dtype=dtype,
+            name="x4",
+            is_input=True,
+        )
+        cat_dim = 1
+        add_0 = ops.elementwise(FuncEnum.ADD)(X0, X1)
+        concat_1 = ops.concatenate()([add_0, X2], dim=cat_dim)
+        reshape_2 = ops.reshape()(concat_1, [-1, M0 + M2, N])
+        add_3 = ops.elementwise(FuncEnum.ADD)(X4, reshape_2)
+        concat_4 = ops.concatenate()([X3, reshape_2, X3], dim=cat_dim)
+        reduce_dim = cat_dim
+        reduce_5 = ops.reduce_sum(reduce_dim)(add_3)
+        reduce_6 = ops.reduce_sum(reduce_dim)(concat_4)
+        Y = ops.elementwise(FuncEnum.ADD)(reduce_5, reduce_6)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 7)
+        concat_cnt = 0
+        for sorted_op in sorted_ops:
+            if sorted_op._attrs["op"] == "concatenate":
+                concat_cnt += 1
+        self.assertEqual(concat_cnt, 2)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0 * N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1 * N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2 * N], dtype)
+            x3_pt = get_random_torch_tensor([batch, M3, N], dtype)
+            x4_pt = get_random_torch_tensor([batch, M4, N], dtype)
+            add_0_pt = x0_pt + x1_pt
+            concat_1_pt = torch.cat([add_0_pt, x2_pt], dim=cat_dim)
+            reshape_2_pt = torch.reshape(concat_1_pt, [-1, M0 + M2, N])
+            add_3_pt = x4_pt + reshape_2_pt
+            concat_4_pt = torch.cat([x3_pt, reshape_2_pt, x3_pt], dim=cat_dim)
+            reduce_5_pt = torch.sum(add_3_pt, reduce_dim)
+            reduce_6_pt = torch.sum(concat_4_pt, reduce_dim)
+            y_pt = reduce_5_pt + reduce_6_pt
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {"x0": x0_pt, "x1": x1_pt, "x2": x2_pt, "x3": x3_pt, "x4": x4_pt}
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.05, rtol=0.05)
+
+    def test_move_strided_reshape_cat_7(self):
+        self._test_move_strided_reshape_cat_7(
+            M0=4,
+            M1=4,
+            M2=6,
+            M3=3,
+            N=8,
+            test_name="test_move_strided_reshape_cat_7",
+            dtype="float16",
+        )
+        self._test_move_strided_reshape_cat_7(
+            M0=4,
+            M1=4,
+            M2=5,
+            M3=3,
+            N=7,
+            test_name="test_move_strided_reshape_cat_7",
+            dtype="float16",
+        )
+
+    def _test_move_strided_reshape_cat_8(
+        self, M0, M1, M2, M3, N, test_name, dtype="float16"
+    ):
+        # make a graph like below:
+        # add_0 = add(x0, x1)  # 2d
+        # concat_1 = concatenate(add_0, x2) # 2d
+        # reshape_2 = reshape(concat_1) # 3d
+        # bmm_crr_add_3 = bmm_crr_add(reshape_2, x4, x5) # 3d
+        # concat_4 = concatenate(x3, reshape_2, x3) # 3d
+        # reshape_5 = reshape(concat_4) # 2d
+        # add_6 = add(reshape_5, x6) # 2d
+        # concat_7 = concatenate(x0, reshape_5, x0)
+        # reshape_8 = reshape(bmm_crr_add_3) # 2d
+        # reduce_9 = reduce_sum(reshape_8)
+        # reduce_10 = reduce_sum(add_6)
+        # reduce_11 = reduce_sum(concat_7)
+        # add_12 = add(reduce_9, reduce_10)
+        # y = add(add_12, reduce_11)
+        assert M0 == M1, f"expected {M0=} to be equal to {M1=}"
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0 * N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1 * N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2 * N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        X3 = Tensor(
+            shape=[batch_dim, IntImm(M3), IntImm(N)],
+            dtype=dtype,
+            name="x3",
+            is_input=True,
+        )
+        M4 = M0 + M2
+        X4 = Tensor(
+            shape=[IntImm(M4), IntImm(N)],
+            dtype=dtype,
+            name="x4",
+            is_input=True,
+        )
+        X5 = Tensor(
+            shape=[IntImm(N)],
+            dtype=dtype,
+            name="x5",
+            is_input=True,
+        )
+        cat_dim = 1
+        add_0 = ops.elementwise(FuncEnum.ADD)(X0, X1)
+        concat_1 = ops.concatenate()([add_0, X2], dim=cat_dim)
+        bmm_K = M0 + M2
+        reshape_2 = ops.reshape()(concat_1, [-1, bmm_K, N])
+        # bmm_crr_add_3[batch, N, N] = bmm_crr_add(
+        #     reshape_2[batch, bmm_K, N], X4[bmm_K, N], X5[N]
+        # )
+        bmm_crr_add_3 = ops.bmm_crr_add()(reshape_2, X4, X5)
+        concat_4 = ops.concatenate()([X3, reshape_2, X3], dim=cat_dim)  # 3d
+        reshape_to_shape_5 = (
+            sum([t.shape()[cat_dim].value() for t in [X3, reshape_2, X3]]) * N
+        )
+        reshape_5 = ops.reshape()(concat_4, [-1, reshape_to_shape_5])  # 2d
+        X6 = Tensor(
+            shape=[batch_dim, IntImm(reshape_to_shape_5)],
+            dtype=dtype,
+            name="x6",
+            is_input=True,
+        )
+        add_6 = ops.elementwise(FuncEnum.ADD)(reshape_5, X6)
+        concat_7 = ops.concatenate()([X0, reshape_5, X0], dim=cat_dim)  # 2d
+        reshape_8 = ops.reshape()(bmm_crr_add_3, [-1, N * N])  # 2d
+        reduce_dim = cat_dim
+        reduce_9 = ops.reduce_sum(reduce_dim)(reshape_8)
+        reduce_10 = ops.reduce_sum(reduce_dim)(add_6)
+        reduce_11 = ops.reduce_sum(reduce_dim)(concat_7)
+        add_12 = ops.elementwise(FuncEnum.ADD)(reduce_9, reduce_10)
+        Y = ops.elementwise(FuncEnum.ADD)(add_12, reduce_11)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        # import pdb; pdb.set_trace()
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 10)
+        concat_cnt = 0
+        for sorted_op in sorted_ops:
+            if sorted_op._attrs["op"] == "concatenate":
+                concat_cnt += 1
+        self.assertEqual(concat_cnt, 3)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0 * N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1 * N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2 * N], dtype)
+            x3_pt = get_random_torch_tensor([batch, M3, N], dtype)
+            x4_pt = get_random_torch_tensor([M4, N], dtype)
+            x5_pt = get_random_torch_tensor([N], dtype)
+            x6_pt = get_random_torch_tensor([batch, reshape_to_shape_5], dtype)
+            add_0_pt = x0_pt + x1_pt
+            concat_1_pt = torch.cat([add_0_pt, x2_pt], dim=cat_dim)
+            reshape_2_pt = torch.reshape(concat_1_pt, [-1, bmm_K, N])
+            reshape_2_trans_pt = torch.transpose(reshape_2_pt, -2, -1)
+            bmm_crr_add_3_pt = torch.matmul(reshape_2_trans_pt, x4_pt) + x5_pt
+            concat_4_pt = torch.cat([x3_pt, reshape_2_pt, x3_pt], dim=cat_dim)
+            reshape_5_pt = torch.reshape(concat_4_pt, [-1, reshape_to_shape_5])
+            add_6_pt = reshape_5_pt + x6_pt
+            concat_7_pt = torch.cat([x0_pt, reshape_5_pt, x0_pt], dim=cat_dim)
+            reshape_8_pt = torch.reshape(bmm_crr_add_3_pt, [-1, N * N])
+            reduce_9_pt = torch.sum(reshape_8_pt, reduce_dim)
+            reduce_10_pt = torch.sum(add_6_pt, reduce_dim)
+            reduce_11_pt = torch.sum(concat_7_pt, reduce_dim)
+            add_12_pt = reduce_9_pt + reduce_10_pt
+            y_pt = add_12_pt + reduce_11_pt
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {
+                "x0": x0_pt,
+                "x1": x1_pt,
+                "x2": x2_pt,
+                "x3": x3_pt,
+                "x4": x4_pt,
+                "x5": x5_pt,
+                "x6": x6_pt,
+            }
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y_pt, y, atol=0.1, rtol=0.1)
+
+    def test_move_strided_reshape_cat_8(self):
+        self._test_move_strided_reshape_cat_8(
+            M0=4,
+            M1=4,
+            M2=6,
+            M3=4,
+            N=4,
+            test_name="test_move_strided_reshape_cat_8",
+            dtype="float16",
+        )
+        # self._test_move_strided_reshape_cat_8(
+        #    M0=4,
+        #    M1=4,
+        #    M2=6,
+        #    M3=3,
+        #    N=4,
+        #    test_name="test_move_strided_reshape_cat_8",
+        #    dtype="float16",
+        # )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/compiler/test_move_view_ops.py
+++ b/tests/unittest/compiler/test_move_view_ops.py
@@ -1306,7 +1306,6 @@ class MoveViewOpsTestCase(unittest.TestCase):
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
         module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
-        # import pdb; pdb.set_trace()
         self.test_count += 1
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
@@ -1364,15 +1363,15 @@ class MoveViewOpsTestCase(unittest.TestCase):
             test_name="test_move_strided_reshape_cat_8",
             dtype="float16",
         )
-        # self._test_move_strided_reshape_cat_8(
-        #    M0=4,
-        #    M1=4,
-        #    M2=6,
-        #    M3=3,
-        #    N=4,
-        #    test_name="test_move_strided_reshape_cat_8",
-        #    dtype="float16",
-        # )
+        self._test_move_strided_reshape_cat_8(
+            M0=4,
+            M1=4,
+            M2=6,
+            M3=3,
+            N=4,
+            test_name="test_move_strided_reshape_cat_8",
+            dtype="float16",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unittest/compiler/test_slice_reshape_scatter.py
+++ b/tests/unittest/compiler/test_slice_reshape_scatter.py
@@ -45,6 +45,9 @@ class SliceScatterReshapeCatTestCase(unittest.TestCase):
         reshape_to,
         input_x_shape,
         dim,
+        # when it's true, it means that the reshape can be moved to the front
+        # of the first concat op so that we can fuse all ops into a single concat
+        reshape_movable=False,
         add_tanh=False,
         dtype="float16",
     ):
@@ -100,17 +103,22 @@ class SliceScatterReshapeCatTestCase(unittest.TestCase):
         module = compile_model(
             Y, target, "./tmp", "slice_scatter_reshape_cat", dll_name=dll_name
         )
-        Y_src_ops = Y._attrs["src_ops"]
-        np.testing.assert_equal(len(Y_src_ops), 2)
-        np.testing.assert_equal(concat_op_2 in Y_src_ops, True)
-        np.testing.assert_equal(concat_op_2._attrs["input_masks"], [True, False, True])
-        Y_src_ops_list = list(Y_src_ops)
-        slice_reshape_scatter_op = (
-            Y_src_ops_list[1] if concat_op_2 == Y_src_ops_list[0] else Y_src_ops_list[0]
-        )
-        np.testing.assert_equal(
-            slice_reshape_scatter_op._attrs["op"], "slice_reshape_scatter"
-        )
+        Y_src_ops = list(Y._attrs["src_ops"])
+        if reshape_movable:
+            np.testing.assert_equal(len(Y_src_ops), 1)
+            np.testing.assert_equal(Y_src_ops[0]._attrs["op"], "concatenate")
+        else:
+            np.testing.assert_equal(len(Y_src_ops), 2)
+            np.testing.assert_equal(concat_op_2 in Y_src_ops, True)
+            np.testing.assert_equal(
+                concat_op_2._attrs["input_masks"], [True, False, True]
+            )
+            slice_reshape_scatter_op = (
+                Y_src_ops[1] if concat_op_2 == Y_src_ops[0] else Y_src_ops[0]
+            )
+            np.testing.assert_equal(
+                slice_reshape_scatter_op._attrs["op"], "slice_reshape_scatter"
+            )
 
         input_name_to_index = module.get_input_name_to_index_map()
         inputs = [0 for i in range(len(Xs_pt) + 1)]
@@ -130,6 +138,7 @@ class SliceScatterReshapeCatTestCase(unittest.TestCase):
             reshape_to=[1, 2, 2],
             input_x_shape=[1, 1, 2],
             dim=1,
+            reshape_movable=True,
         )
         self._run_one_test(
             input_shapes=[[10, 20], [15, 44]],
@@ -207,13 +216,9 @@ class SliceScatterReshapeCatTestCase(unittest.TestCase):
         dll_name = "test.so"
         test_name = "slice_scatter_reshape_cat_float16_2"
         module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
-        Y_src_ops = Y._attrs["src_ops"]
-        self.assertEqual(len(Y_src_ops), 3)
-        slice_reshape_scatter_cnt = 0
-        for op in Y_src_ops:
-            if op._attrs["op"] == "slice_reshape_scatter":
-                slice_reshape_scatter_cnt += 1
-        self.assertEqual(slice_reshape_scatter_cnt, 2)
+        Y_src_ops = list(Y._attrs["src_ops"])
+        self.assertEqual(len(Y_src_ops), 1)
+        self.assertEqual(Y_src_ops[0]._attrs["op"], "concatenate")
 
         slice_indices = [slice(i, j) for i, j in zip(start_indices, end_indices)]
 

--- a/tests/unittest/compiler/test_split_large_slice_scatter.py
+++ b/tests/unittest/compiler/test_split_large_slice_scatter.py
@@ -68,15 +68,9 @@ class SliceScatterLargeInputsTestCase(unittest.TestCase):
         test_name = "slice_scatter_large_inputs"
         module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         self.test_count += 1
-        Y_src_ops = Y._attrs["src_ops"]
-        # We have a single concat op. All the rest are slice_reshape_scatter ops
-        concat_cnt = 0
-        for op in Y_src_ops:
-            if op._attrs["op"] == "concatenate":
-                concat_cnt += 1
-                continue
-            self.assertEqual(op._attrs["op"], "slice_reshape_scatter")
-        self.assertEqual(concat_cnt, 1)
+        Y_src_ops = list(Y._attrs["src_ops"])
+        self.assertEqual(len(Y_src_ops), 5)
+        self.assertTrue(all(op._attrs["op"] == "concatenate" for op in Y_src_ops))
 
         input0_pt = get_random_torch_tensor(input0_shape, dtype)
         input1_pt = get_random_torch_tensor(input1_shape, dtype)

--- a/tests/unittest/compiler/test_strided_reshape_cat.py
+++ b/tests/unittest/compiler/test_strided_reshape_cat.py
@@ -114,8 +114,16 @@ class StridedReshapeCatTestCase(unittest.TestCase):
                 concat_op._attrs["input_masks"], [False, False, True, False]
             )
         else:
-            np.testing.assert_equal(concat_op_1._attrs["input_masks"], [False, False])
-            np.testing.assert_equal(concat_op_2._attrs["input_masks"], [True, False])
+            Y_src_ops = list(Y_src_ops)
+            np.testing.assert_equal(len(Y_src_ops), 2)
+            concat_op = (
+                Y_src_ops[0]
+                if Y_src_ops[0]._attrs["op"] == "concatenate"
+                else Y_src_ops[1]
+            )
+            np.testing.assert_equal(
+                concat_op._attrs["input_masks"], [False, False, True, False]
+            )
 
         expected_inputs_group_gemm_op = [X1, W1, X2, W2, X3, W3]
         np.testing.assert_equal(


### PR DESCRIPTION
Added a pass move_view_op_before_concat that turns "cat + view_op + cat" into "view_op + cat + cat" whenever possible. The yielded pattern may be optimized further by the transform_memory_ops pass, which assumes no view ops between two fusible concat ops. Note that this pass must be invoked before transform_strided_op_and_view_op and transform_strided_ops.

For view ops, we only enable reshape and flatten at the moment. We will extend it to others such as squeeze and unsqueeze.