### PR TITLE
AIT build cache

### DIFF
--- a/python/aitemplate/backend/build_cache.py
+++ b/python/aitemplate/backend/build_cache.py
@@ -1,0 +1,44 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""
+The build_cache functionality is split into
+this file and build_cache_base.py
+
+This file is part of the AITemplate OSS distribution.
+For Meta-internal use, there can be an alternative
+to this file which allows to instantiate build caches
+with Meta-internal backing infrastructure.
+"""
+
+from aitemplate.backend.build_cache_base import (
+    BuildCache,
+    FileBasedBuildCache,
+    NoBuildCache,
+)
+from aitemplate.utils import environ as aitemplate_env
+
+__all__ = ["BUILD_CACHE", "BuildCache"]
+
+
+def create_build_cache() -> BuildCache:
+    build_cache_dir = aitemplate_env.ait_build_cache_dir()
+    if build_cache_dir is None or build_cache_dir == "":
+        return NoBuildCache()
+    else:
+        return FileBasedBuildCache(build_cache_dir)
+
+
+BUILD_CACHE: BuildCache = create_build_cache()

--- a/python/aitemplate/backend/build_cache_base.py
+++ b/python/aitemplate/backend/build_cache_base.py
@@ -1,0 +1,458 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import hashlib
+import logging
+import os
+import secrets
+import shutil
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+from aitemplate.utils.io import file_age, touch
+
+_LOGGER = logging.getLogger(__name__)
+
+# File extensions to be considered source files
+source_extensions = {
+    "cpp",
+    "h",
+    "cu",
+    "cuh",
+    "c",
+    "hpp",
+    "hxx",
+    "py",
+    "cxx",
+    "cc",
+    "version",
+    "binhash",
+    "hash",
+}
+
+source_filenames = {
+    # needs to be lowercase, because everything is lowercased before comparison
+    # Filenames in here are considered source files, even if their extension would
+    # suggest they are cache artifacts
+    "makefile"
+}
+
+# File extensions of files to be considered cache artifacts ( unless they are considered source files )
+cache_extensions = {"obj", "so", "dll", "exe", ""}
+
+
+def filename_norm_split(filename: str) -> Tuple[str, str]:
+    """
+    Splits filename into basename and extension
+    and lowercases results to enable simple lookup
+    in a case-insensitive manner.
+
+    Args:
+        filename (str): Filename/Path to split
+
+    Returns:
+        Tuple[str,str]: file basename, file extension
+    """
+    file_basename = os.path.basename(filename).lower()
+    file_parts = file_basename.split(".")
+    if len(file_parts) > 1:
+        file_ext = file_parts[-1]
+    else:
+        file_ext = ""
+    return file_basename, file_ext
+
+
+def is_source(filename: str) -> bool:
+    """
+    Simple filter function, returns true if the passed filename is considered
+    to be a source file (used to build the cache key) for the purpose of caching
+
+    Args:
+        filename (str): File path as a string
+
+    Returns:
+        bool: Whether the filename is a source file
+    """
+    file_basename, file_ext = filename_norm_split(filename)
+    return (file_basename in source_filenames) or (file_ext in source_extensions)
+
+
+def is_cache_artifact(filename: str) -> bool:
+    """
+    Simple filter function, returns true if the passed filename is considered
+    to be a cacheable artifact (not used to build cache key, but stored in cache)
+    for the purpose of caching
+
+    Args:
+        filename (str): File path as a string
+
+    Returns:
+        bool: Whether the filename is a cache artifact
+    """
+    file_basename, file_ext = filename_norm_split(filename)
+    return not is_source(filename) and file_ext in cache_extensions
+
+
+def is_bin_file(filename: str) -> bool:
+    """
+    Simple filter function, returns true if the passed filename is considered
+    to be a bin file which needs to be considered for the purpose of creating
+    a cache-key, but may be deleted after an initial build.
+
+    bin files are hashed, and their hashes are kept in a small separete file
+    for future use when building the cache key. So the hash is not lost, even if the binary
+    file is deleted.
+
+    Args:
+        filename (str): File path as a string
+
+    Returns:
+        bool: Whether the filename is a binary file in the above sense
+    """
+    return filename.lower().endswith(".bin")
+
+
+def create_dir_hash(
+    cmds: List[str],
+    build_dir: str,
+    filter_func: Callable[[str], bool] = is_source,
+    debug=False,
+) -> str:
+    """Create a hash of the (source file) contents of a build directory, used for
+    creating a cache key of an entire directory along with the build commands.
+
+    Args:
+        cmds (List[str]): Build commands to be incorporated in hash key computation
+        build_dir (str): Path to build directory ( not part of hash )
+        filter_func (Callable[[str], bool], optional): Filter function which determines whether a given file is considered a source file or not. Defaults to is_source(path).
+        debug (bool, optional): Whether to write a 'cache_key.log' file into the build directory, so that cache misses can be debugged more easily. Defaults to False.
+
+    Returns:
+        str: SHA256 Hash of the build directory contents in the form of a hexdigest string.
+    """
+
+    try:
+        hash_log = None
+        if debug:
+            hash_log = open(  # noqa: P201 - this is actually closed properly in the finally close below
+                os.path.join(build_dir, "cache_key.log"), mode="w", encoding="utf8"
+            )
+            hash_log.write(f"Building dir hash of {build_dir}\n")
+        basepath = Path(build_dir)
+        files = [p.relative_to(basepath) for p in basepath.rglob("*") if not p.is_dir()]
+        hash_object = hashlib.sha256()
+        for cmd in cmds:
+            _cmd = cmd.replace(
+                build_dir, "${BUILD_DIR}"
+            )  # Make sure we can cache regardless of the build directory location.
+            hash_object.update(_cmd.encode("utf-8"))
+        for fpath in sorted(files):
+            if not filter_func(str(fpath)):
+                continue
+            hash_object.update(str(fpath).encode("utf-8"))
+            fullpath = str(basepath / fpath)
+            with open(fullpath, "rb") as f:
+                # read file in chunks of 32kb
+                # in order to support large files ( constants.obj )
+                while True:
+                    chunk = f.read(1024 * 32)
+                    if not chunk:
+                        break
+                    hash_object.update(chunk)
+                if debug:
+                    hash_log.write(f"\t{str(fpath)} -> {hash_object.hexdigest()}\n")
+        if debug:
+            hash_log.write(
+                f"Final hash of {build_dir} is {hash_object.hexdigest().lower()}\n"
+            )
+        return hash_object.hexdigest().lower()
+    finally:
+        if hash_log:
+            hash_log.close()
+
+
+def write_binhash_file(
+    build_dir,
+    binhash_filename="constants.hash",
+    filter_func: Callable[[str], bool] = is_bin_file,
+):
+    """Hash all binary input files, so we don't have to keep them ( Usecase: constants.obj / constants.bin )
+
+    Args:
+        build_dir (str): Path to build directory
+        binhash_filename (str, optional): File to be written within build_dir, defaults to "constants.hash".
+        filter_func (Callable[[str], bool], optional): Filter function to determine which files to hash. Defaults to is_bin_file.
+    """
+    binhash = create_dir_hash([binhash_filename], build_dir, filter_func=filter_func)
+    with open(os.path.join(build_dir, binhash_filename), "w", encoding="utf-8") as f:
+        f.write(binhash)
+
+
+class BuildCache(ABC):
+    """
+    Abstract base class for build cache implementations
+    """
+
+    @abstractmethod
+    def retrieve_build_cache(
+        self,
+        cmds: List[str],
+        build_dir: str,
+        from_sources_filter_func: Callable[[str], bool] = is_source,
+    ) -> Tuple[bool, Optional[str]]:
+        """
+        Retrieves the build cache artifacts for the given build directory,
+        so that ideally no compilation needs to take place.
+
+        Args:
+            cmds (_type_): Build commands, these will be part of the hash used to calculate a lookup key
+            build_dir (str): Build directory. The source files, Makefile and some other files will be hashed and used to
+                             determine the build cache key.
+            from_sources_filter_func (Callable[[str], bool], optional): Filter function, which may be used to determine which files are being considered source files. Defaults to is_source.
+
+        Returns:
+            Tuple[bool, Optional[str]]: A tuple indicating whether the build cache was successfully retrieved, and a cache key (which should be passed on to store_build_cache on rebuild )
+        """
+        ...
+
+    @abstractmethod
+    def store_build_cache(
+        self,
+        cmds: List[str],
+        build_dir: str,
+        cache_key: str,
+        filter_func: Callable[[str], bool] = is_cache_artifact,
+    ) -> bool:
+        """
+        Store the build cache artifacts
+
+        Args:
+            cmds ( List[str]): Build commands, these will be part of the hash used to calculate a lookup key
+            build_dir (str): Path to build directory to retrieve build artifacts from
+            cache_key (str): Cache key, as returned from retrieve_build_cache
+            filter_func (Callable[[str], bool], optional): Filter function, which may be used to determine which files are being considered cacheable artifact files. Defaults to is_cache_artifact.
+
+        Returns:
+            bool: Whether the artifacts were successfully stored
+        """
+        ...
+
+    def maybe_cleanup(
+        self, lru_retention_hours: int = 72, cleanup_max_age_seconds: int = 3600
+    ):
+        """
+        Maybe clean up the build cache if its been longer than `cleanup_max_age_seconds` that it has been cleaned up
+
+        Args:
+            lru_retention_hours (int, optional): How many hours should unused elements be retained in the cache? Defaults to 72.
+            cleanup_max_age_seconds (int, optional): Cleanup interval in seconds. Defaults to 3600.
+        """
+        pass
+
+    def cleanup(self, retention_hours: int = 72):
+        """Do a cache cleanup.
+
+        Args:
+            retention_hours (int, optional): How many hours should unused elements be retained in the cache? Defaults to 72.
+        """
+        pass
+
+
+class NoBuildCache(BuildCache):
+    def __init__(self):
+        """
+        Dummy build cache implementation which does nothing.
+
+        For method docstrings, see parent class.
+        """
+        _LOGGER.info("Build cache disabled")
+
+    def retrieve_build_cache(
+        self,
+        cmds: List[str],
+        build_dir: str,
+        from_sources_filter_func: Callable[[str], bool] = is_source,
+    ) -> Tuple[bool, Optional[str]]:
+        return False, None
+
+    def store_build_cache(
+        self,
+        cmds: List[str],
+        build_dir: str,
+        cache_key: str,
+        filter_func: Callable[[str], bool] = is_cache_artifact,
+    ) -> bool:
+        pass
+
+
+class FileBasedBuildCache(BuildCache):
+    def __init__(
+        self,
+        cache_dir,
+        lru_retention_hours=72,
+        cleanup_max_age_seconds=3600,
+        debug=True,
+    ):
+        """Filesystem based build cache.
+
+        For method docstrings, see parent class.
+
+        Args:
+            cache_dir (str): Path to store cache data below. Should be an empty, temporary directory with enough space to hold the cache contents. Will be written to and deleted in!
+            lru_retention_hours (int, optional): Retention time for *unused* cache entries. Defaults to 72.
+            cleanup_max_age_seconds (int, optional): Minimum time between cache cleanups in seconds. After this time, a new cleanup gets triggered on next cache retrieval. Defaults to 3600.
+            debug (bool, optional): Whether to enable debugging cache key creation ( see debug parameter of create_dir_hash). Defaults to True. May be left at True, as it is usually helpful and  does not hurt performance.
+        """
+        self.cache_dir = cache_dir
+        self.lru_retention_hours = lru_retention_hours
+        self.cleanup_max_age_seconds = cleanup_max_age_seconds
+        self.debug = debug
+        _LOGGER.info(
+            f"Using file-based build cache, cache directory = {self.cache_dir}"
+        )
+
+    def retrieve_build_cache(
+        self,
+        cmds: List[str],
+        build_dir: str,
+        from_sources_filter_func: Callable[[str], bool] = is_source,
+    ) -> Tuple[bool, Optional[str]]:
+        """See docstring of implemented method interface in parent class"""
+
+        self.maybe_cleanup(self.lru_retention_hours, self.cleanup_max_age_seconds)
+        cache_dir = self.cache_dir
+        dir_hash = create_dir_hash(
+            cmds, build_dir, filter_func=from_sources_filter_func, debug=self.debug
+        )
+        key_cache_dir = os.path.join(cache_dir, dir_hash)
+        if os.path.exists(key_cache_dir):
+            _LOGGER.info(f"CACHE: Using cached build results for {build_dir}")
+            target_basepath = Path(build_dir)
+            src_basepath = Path(key_cache_dir)
+            copy_files = [
+                p.relative_to(src_basepath)
+                for p in src_basepath.rglob("*")
+                if not p.is_dir()
+            ]
+            for filepath in copy_files:
+                target_path = target_basepath / filepath
+                target_parent = target_path.parent
+                src_path = src_basepath / filepath
+                if target_parent != target_basepath:
+                    os.makedirs(str(target_parent), exist_ok=True)
+                shutil.copy(
+                    str(src_path),
+                    str(target_path),
+                    follow_symlinks=True,
+                )  # Using shutil.copy intentionally instead of copy2, so the file modification time is updated, and file owner
+                # is not copied. When you retrieve the file from cache, it is yours.
+                _LOGGER.debug(f"CACHE: retrieved {filepath}")
+            # make sure the last modified timestamp is updated, so we can
+            # evict cache directories which are too old using a separate script
+            os.utime(key_cache_dir)
+            return True, dir_hash
+        _LOGGER.info(f"CACHE: No results found for {build_dir}")
+        return False, dir_hash
+
+    def store_build_cache(
+        self,
+        cmds: List[str],
+        build_dir: str,
+        cache_key: str,
+        filter_func: Callable[[str], bool] = is_cache_artifact,
+    ) -> bool:
+        """See docstring of implemented method interface in parent class"""
+        cache_dir = self.cache_dir
+        key_cache_dir = os.path.join(cache_dir, cache_key)
+
+        # We create a temporary directory first, so we can do an
+        # atomic update later to prevent race conditions
+        # in a distributed / parallel build setting
+        random_str = secrets.token_hex(16)
+
+        # the temp_cache_dir will be renamed to key_cache_dir
+        # atomically later. It needs to be on same file system
+        # for atomic rename, so we put it into the same folder.
+        temp_cache_dir = key_cache_dir + f".{random_str}.tmp"
+        try:
+            os.makedirs(temp_cache_dir, exist_ok=False)
+        except OSError:
+            _LOGGER.warn(
+                f"CACHE: Failed to create tempdir {temp_cache_dir}. Cannot write cache entries."
+            )
+            return False
+        basepath = Path(build_dir)
+        target_basepath = Path(temp_cache_dir)
+        copy_files = [
+            p.relative_to(basepath) for p in basepath.rglob("*") if not p.is_dir()
+        ]
+        for filepath in copy_files:
+            src_path = basepath / filepath
+            if not filter_func(str(filepath)):
+                continue
+
+            target_path = target_basepath / filepath
+            target_parent = target_path.parent
+            if target_parent != target_basepath:
+                os.makedirs(str(target_parent), exist_ok=True)
+            shutil.copy2(
+                str(src_path),
+                str(target_path),
+                follow_symlinks=True,
+            )  # Use copy2, so the file metadata (incl. last modified time) is preserved
+            _LOGGER.info(f"CACHE: storing {filepath} into {key_cache_dir}: ")
+        try:
+            os.rename(
+                temp_cache_dir, key_cache_dir
+            )  # Atomic update to prevent race condition
+            return True
+        except OSError:
+            _LOGGER.info(
+                f"CACHE: update race conflict - {key_cache_dir} already exists. (Note: No error! This can be expected to happen occasionally.))"
+            )
+            shutil.rmtree(temp_cache_dir, ignore_errors=True)
+            return False
+
+    def maybe_cleanup(
+        self, lru_retention_hours: int = 72, cleanup_max_age_seconds: int = 3600
+    ):
+        """See docstring of implemented method interface in parent class"""
+        last_cleaned_seconds = file_age(os.path.join(self.cache_dir, ".last_cleaned"))
+        if last_cleaned_seconds > cleanup_max_age_seconds:
+            self.cleanup(lru_retention_hours)
+
+    def cleanup(self, lru_retention_hours: int = 72):
+        """See docstring of implemented method interface in parent class"""
+        _LOGGER.info(
+            f"CACHE: Cleaning up build cache below {self.cache_dir}. Folders last used more than {lru_retention_hours} hours ago will be deleted."
+        )
+        touch(os.path.join(self.cache_dir, ".last_cleaned"))
+        if os.path.isdir(self.cache_dir):
+            now = datetime.now()
+            age_limit = timedelta(hours=lru_retention_hours)
+
+            for dirpath in os.scandir(self.cache_dir):
+                if os.path.isdir(dirpath):
+                    # Get the modification time of the directory and convert it to a datetime object
+                    mtime = os.path.getmtime(dirpath)
+                    modification_time = datetime.fromtimestamp(mtime)
+
+                    # Check if the directory is older than N hours
+                    if now - modification_time > age_limit:
+                        _LOGGER.info(f"CACHE: Deleting {dirpath}")
+                        shutil.rmtree(dirpath)

--- a/python/aitemplate/backend/cuda/target_def.py
+++ b/python/aitemplate/backend/cuda/target_def.py
@@ -15,11 +15,13 @@
 """
 CUDA target specialization
 """
+import hashlib
 import json
 import logging
 import os
 import pipes
 import re
+import secrets
 import shutil
 import sys
 import tempfile
@@ -39,7 +41,9 @@ from aitemplate.backend.target import (
 )
 
 from aitemplate.utils import environ
+from aitemplate.utils.io import copytree_with_hash
 from aitemplate.utils.misc import is_debug
+
 
 # pylint: disable=C0415,W0707,W0611,W0702,W1401
 
@@ -200,22 +204,53 @@ class FBCUDA(CUDA):
         static_files_path = parutil.get_dir_path("aitemplate/AITemplate/static")
         self._include_path = None
         if not FBCUDA.cutlass_path_:
-            self._include_path = tempfile.mkdtemp()
-
+            # Copy all of the includes over into an include directory
+            random_key = secrets.token_hex(16)
+            # the random_key part of this path will later be renamed to the content hash
+            self._include_path = os.path.join(
+                tempfile.gettempdir(), "aitemplate_tmp", random_key, "includes"
+            )
+            includes_content_hash = hashlib.sha256()
             FBCUDA.cutlass_path_ = self._include_path + "/cutlass"
             self.cub_path_ = self._include_path + "/cub"
-            shutil.copytree(cutlass_src_path, FBCUDA.cutlass_path_)
-            shutil.copytree(cub_src_path, self.cub_path_)
-
+            # copy recursively, and update a content hash in one go
+            copytree_with_hash(
+                cutlass_src_path, FBCUDA.cutlass_path_, hash=includes_content_hash
+            )
+            copytree_with_hash(cub_src_path, self.cub_path_, hash=includes_content_hash)
             attention_src_path = parutil.get_dir_path(
                 "aitemplate/AITemplate/python/aitemplate/backend/cuda/attention/src"
             )
             attention_include_path = self._include_path + "/att_include"
-            shutil.copytree(attention_src_path, attention_include_path)
-            ait_static_include_path = self._include_path + "/static"
-            shutil.copytree(
-                static_files_path + "/include/kernels", ait_static_include_path
+            copytree_with_hash(
+                attention_src_path, attention_include_path, hash=includes_content_hash
             )
+            ait_static_include_path = self._include_path + "/static"
+            copytree_with_hash(
+                static_files_path + "/include/kernels",
+                ait_static_include_path,
+                hash=includes_content_hash,
+            )
+            # Now we have a content hash over all include contents
+            include_hash_digest = includes_content_hash.hexdigest()
+            # Prepare to rename atomically
+            old_path = os.path.join(tempfile.gettempdir(), "aitemplate_tmp", random_key)
+            new_path = os.path.join(
+                tempfile.gettempdir(), "aitemplate_tmp", include_hash_digest
+            )
+            # if it already exists, we don't want to overwrite it
+            # we can just delete our copy.
+            try:
+                os.rename(old_path, new_path)
+            except OSError:
+                # target directory with identical contents already exists
+                shutil.rmtree(old_path)  # No need to keep out copy
+
+            # set the include paths to the final variant
+            self._include_path = os.path.join(new_path, "includes")
+            self.cub_path_ = self._include_path + "/cub"
+            FBCUDA.cutlass_path_ = self._include_path + "/cutlass"
+
         self.cutlass_path_ = FBCUDA.cutlass_path_
 
         cutlass_lib_path = parutil.get_dir_path(

--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -35,6 +35,7 @@ from aitemplate.compiler.model import (
     Model,
     TorchTensor,
 )
+from aitemplate.compiler.transform.name_graph import reset_name_counters
 from aitemplate.compiler.transform.profile import elapsed_dt_sec
 from aitemplate.utils import graph_utils
 from aitemplate.utils.debug_settings import AITDebugSettings
@@ -212,6 +213,7 @@ def compile_model(
     if int(recompile) == 1:
         os.makedirs(test_dir, exist_ok=True)
         with target:
+            reset_name_counters()
             graph = compiler.transform.toposort(tensor)
             graph_utils.dump_graph_debug_str_to_file(graph, test_dir, "toposort")
 

--- a/python/aitemplate/compiler/transform/name_graph.py
+++ b/python/aitemplate/compiler/transform/name_graph.py
@@ -31,6 +31,17 @@ MEMO = set()
 user_provided_dim = set()
 
 
+def reset_name_counters():
+    global func_cnt
+    global tensor_cnt
+    global func_name_to_tensor_cnt
+    global MEMO
+    func_cnt = 0
+    tensor_cnt = 0
+    func_name_to_tensor_cnt = {}
+    MEMO = set()
+
+
 def valid_c_name(name):
     return re.sub(r"\W|^(?=\d)", "_", name)
 
@@ -52,6 +63,8 @@ def name_graph(sorted_graph: List[Tensor]) -> None:
     ----------
     sorted_graph : List[Tensor]
         Input graph to be named
+    reset_counters : bool
+        If True, reset counters which are used to name tensors and functions. (Default: False)
     """
     global func_cnt
     global tensor_cnt

--- a/python/aitemplate/utils/environ.py
+++ b/python/aitemplate/utils/environ.py
@@ -17,6 +17,7 @@ A common place for holding AIT-related env control variables
 """
 import logging
 import os
+from typing import Optional
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,3 +67,17 @@ def shorten_tensor_names_for_plots() -> bool:
     making the graph representation significantly simpler.
     """
     return os.getenv("AIT_PLOT_SHORTEN_TENSOR_NAMES", "0") == "1"
+
+
+def ait_build_cache_dir() -> Optional[str]:
+    """
+    When set to a non-empty string, cache the build artifacts
+    below this directory for significantly faster builds.
+
+    See aitemplate.backend.build_cache
+
+    Returns:
+        Optional[str]: Value of AIT_BUILD_CACHE_DIR environment variable,
+        or None if not set.
+    """
+    return os.environ.get("AIT_BUILD_CACHE_DIR", None)

--- a/python/aitemplate/utils/io.py
+++ b/python/aitemplate/utils/io.py
@@ -1,0 +1,209 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Util functions to handle file or network io
+"""
+import hashlib
+import os
+import tarfile
+import time
+from io import BytesIO
+from pathlib import Path
+from typing import Optional, Union
+
+
+def touch(file_path):
+    """
+    Emulates the Linux 'touch' command by creating an empty file if it doesn't exist, or updating the modified timestamp if it does.
+
+    :param file_path: str: The path to the file to be created or updated.
+    :return: None
+    """
+    if not os.path.exists(file_path):
+        p = Path(file_path)
+        # ensure parent directory exists
+        os.makedirs(str(p.parent), exist_ok=True)
+        open(file_path, "w").close()
+
+    # Update the modified timestamp
+    os.utime(file_path)
+
+
+def file_age(file_path):
+    """
+    Returns the age of a file in seconds since its last modified timestamp.
+
+    :param file_path: str: The path to the file.
+    :return: float: The age of the file in seconds.
+    """
+    if not os.path.isfile(file_path):
+        return 3600 * 24 * 1000.0
+
+    # Get the current time and the file's last modification time
+    current_time = time.time()
+    file_mtime = os.path.getmtime(file_path)
+
+    # Calculate the file age in seconds
+    file_age_seconds = current_time - file_mtime
+
+    return file_age_seconds
+
+
+# Utility functions to be used by (not yet existing) distributed cache implementations
+# to minimize the amount of network roundtrips and network bandwidth needed
+
+
+def create_archive(directory_path: str, filter_func=None) -> bytes:
+    """Create tar.gz archive in-memory and return the archive contents as
+    a bytes object.
+
+    Args:
+        directory_path (str): Directory to create archive of.
+        filter_func (_type_, optional): A function which, being passed a filename,
+                                        returns whether to include it or not.
+                                        Defaults to None (include all).
+
+    Returns:
+        bytes: Archive contents as a bytes object.
+    """
+    # Archive files in a directory.
+
+    # Create an in-memory bytes buffer
+    buffer = BytesIO()
+
+    # Determine the appropriate compression mode
+    compression_mode = None
+    compression_mode = "w:gz"
+
+    # Create a new archive file
+    with tarfile.open(fileobj=buffer, mode=compression_mode) as archive:
+        # Walk through the directory tree and add each file to the archive
+        for root, _, files in os.walk(directory_path):
+            for _file in files:
+                # Check if the file should be included based on the filter function
+                if filter_func is not None:
+                    file_basename = os.path.basename(_file)
+                    file_root, file_extension = os.path.splitext(_file)
+                    if not filter_func(file_basename, file_extension):
+                        continue
+
+                # Calculate the relative path of the file
+                relative_path = os.path.relpath(
+                    os.path.join(root, _file), directory_path
+                )
+
+                # Add the file to the archive with the relative path
+                archive.add(os.path.join(root, _file), arcname=relative_path)
+
+    # Get the bytes from the buffer
+    buffer.seek(0)
+    compressed_bytes = buffer.read()
+
+    return compressed_bytes
+
+
+def extract_archive(
+    archive_bytes: bytes, target_directory: str, overwrite: bool = False
+):
+    """Extract a tar.gz archive (written for example via create_archive) from a bytes buffer
+    into a target directory.
+
+    Args:
+        archive_bytes (bytes): Byte contents of the tar.gz archive to be extracted.
+        target_directory (str): Target directory to extract to.
+        overwrite (bool, optional): Whether to overwrite files or not.
+                                    If False, files will be silently skipped
+                                    if they already exist. Defaults to False.
+    """
+    # Create an in-memory bytes buffer
+    buffer = BytesIO(archive_bytes)
+
+    archive = tarfile.open(fileobj=buffer, mode="r:gz")
+
+    # Extract the archive contents into the target directory
+    for member in archive.getmembers():
+        # Calculate the full path of the extracted file or directory
+        target_path = os.path.join(target_directory, member.name)
+
+        # Check if the file or directory already exists
+        if os.path.exists(target_path):
+            if not overwrite:
+                continue
+            else:
+                os.remove(target_path)
+
+        # Extract the file or directory from the archive
+        archive.extract(member, target_directory)
+
+    # Close the archive object
+    archive.close()
+
+
+def copytree_with_hash(
+    src_path: Union[Path, str],
+    dst_path: Union[Path, str],
+    buffer_size=1024 * 1024,
+    hash: Optional[hashlib.sha256] = None,
+    max_depth: int = 20,
+) -> Optional[str]:
+    """Copy a directory and its contents recursively, while at the same time calculating a hash over each file and filename.
+
+    :param src_path: Path: The path to the source directory.
+    :param dst_path: Path: The path to the destination directory.
+    :param buffer_size: int: The buffer size to read and write data in.
+    :param hash: Optional[hashlib.sha256]: The hash to use for calculating the hash. ( Default: None)
+    :max_depth: int : The maximum recursion depth. Default: 20
+    :return: None, if a hash instance was passed. Otherwise, the hash of the copied data and path names.
+    """
+
+    if hash is None:
+        hash_obj = hashlib.sha256()
+    else:
+        hash_obj = hash
+    if isinstance(src_path, str):
+        src_path = Path(src_path)
+    if isinstance(dst_path, str):
+        dst_path = Path(dst_path)
+    if dst_path.exists():
+        dst_path = dst_path.resolve()
+        if not dst_path.is_dir():
+            raise OSError("Target path exists and is not a directory.")
+        dst_path = dst_path / src_path.name
+    hash_obj.update(dst_path.name.encode("utf-8"))
+    if src_path.is_file():
+        # Copy the file to the destination
+        with open(dst_path, "wb") as dst_file:
+            with open(src_path, "rb") as src_file:
+                while True:
+                    data = src_file.read(buffer_size)
+                    if not data:
+                        break
+                    hash_obj.update(data)
+                    dst_file.write(data)
+    elif src_path.is_symlink():
+        new_src_path = src_path.resolve()
+        copytree_with_hash(new_src_path, dst_path, buffer_size, hash_obj, max_depth - 1)
+    elif src_path.is_dir():
+        # Recursively copy the directory contents
+        os.makedirs(dst_path, exist_ok=True)
+        for sub_path in src_path.iterdir():
+            sub_dst_path = dst_path / sub_path.name
+            copytree_with_hash(
+                sub_path, sub_dst_path, buffer_size, hash_obj, max_depth - 1
+            )
+    else:
+        raise OSError(f"Source path {src_path} is neither file, directory nor symlink.")
+    if hash is None:
+        return hash_obj.hexdigest()

--- a/tests/unittest/backend/test_build_cache.py
+++ b/tests/unittest/backend/test_build_cache.py
@@ -1,0 +1,240 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import logging
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+from aitemplate.backend.build_cache_base import (
+    create_dir_hash,
+    FileBasedBuildCache,
+    is_source,
+)
+from aitemplate.backend.cuda.target_def import FBCUDA
+
+from aitemplate.compiler import compile_model, ops
+from aitemplate.frontend import IntImm, Tensor
+from aitemplate.testing import detect_target
+from aitemplate.testing.test_utils import filter_test_cases_by_test_env
+from aitemplate.utils.debug_settings import AITDebugSettings
+from aitemplate.utils.io import file_age
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BuildCacheTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        torch.manual_seed(0)
+
+    def _create_model_graph(self):
+        dtype = "float32"
+        X1 = Tensor(
+            shape=[IntImm(1), IntImm(10)],
+            dtype=dtype,
+            name="X1",
+            is_input=True,
+        )
+        Y = ops.expand()(X1, shape=(10, 10))
+        Y._attrs["name"] = "output_0"
+        Y._attrs["is_output"] = True
+        return Y
+
+    def test_file_build_cache(self):
+
+        with tempfile.TemporaryDirectory() as parent_dir:
+            cache_dir = os.path.join(parent_dir, "build_cache")
+            shutil.rmtree(cache_dir, ignore_errors=True)
+            cache = FileBasedBuildCache(
+                cache_dir,
+                lru_retention_hours=0,
+                cleanup_max_age_seconds=1000,
+                debug=True,
+            )
+            cache.maybe_cleanup()
+            assert os.path.exists(cache_dir + "/.last_cleaned")
+            assert (
+                file_age(cache_dir + "/.last_cleaned") < 10.0
+            ), "Last clean time should  than 10 seconds"
+
+            build_dir_1 = os.path.join(parent_dir, "build_1")
+            build_dir_2 = os.path.join(parent_dir, "build_2")
+
+            os.makedirs(build_dir_1, exist_ok=False)
+            os.makedirs(build_dir_2, exist_ok=False)
+            for build_dir in [build_dir_1, build_dir_2]:
+                bp = Path(build_dir)
+                (bp / "Makefile").write_text("test.exe: test.cu")
+                (bp / "test.cu").write_text("printf('Hello, World!');")
+            assert create_dir_hash(
+                [f"make {build_dir_1}"], build_dir_1
+            ) == create_dir_hash([f"make {build_dir_2}"], build_dir_2)
+            found_entry1, cache_key1 = cache.retrieve_build_cache(
+                [f"make {build_dir_1}"], build_dir_1
+            )
+            found_entry2, cache_key2 = cache.retrieve_build_cache(
+                [f"make {build_dir_2}"], build_dir_2
+            )
+            assert not found_entry1
+            assert not found_entry2
+            assert cache_key1 == cache_key2
+            assert cache_key1 == create_dir_hash([f"make {build_dir_1}"], build_dir_1)
+            (Path(build_dir_2) / "test.obj").write_bytes("ELF1234".encode("ascii"))
+            cache.store_build_cache([f"make {build_dir_2}"], build_dir_2, cache_key2)
+            assert os.path.exists(os.path.join(cache_dir, cache_key2))
+            found_entry1, cache_key1 = cache.retrieve_build_cache(
+                [f"make {build_dir_1}"], build_dir_1
+            )
+            assert os.path.exists(os.path.join(build_dir_1, "test.obj"))
+            assert (
+                Path(os.path.join(build_dir_1, "test.obj")).read_bytes()
+                == Path(os.path.join(build_dir_2, "test.obj")).read_bytes()
+            )
+
+    def test_deterministic_codegen(self, dtype="float32"):
+        # Tests, whether repeated invocation of compilation results in identical generated source files
+        test_name = "test_deterministic_codegen"
+        basepath = "./tmp"
+
+        # Clean previous test results. These are usually kept for debugging purposes
+        # but we need a clean slate here.
+        if os.path.exists(basepath):
+            existing_dirs = [
+                d
+                for d in os.listdir(basepath)
+                if d.startswith(test_name) and os.path.isdir(os.path.join(basepath, d))
+            ]
+            for d in existing_dirs:
+                oldpath = os.path.join(basepath, d)
+                if os.path.exists(oldpath) and test_name in oldpath:
+                    shutil.rmtree(oldpath)
+        else:
+            os.mkdir(basepath)
+
+        Y = self._create_model_graph()
+        target = detect_target()
+        debug_settings = AITDebugSettings(gen_standalone=False)
+        dll_name = "test.so"
+        build_dir = os.path.join("./tmp", test_name)
+        compile_model(
+            Y,
+            target,
+            "./tmp",
+            test_name + "_1",
+            dll_name=dll_name,
+            debug_settings=debug_settings,
+        )
+        hash1 = create_dir_hash(["test_name"], build_dir + "_1", is_source, debug=True)
+        Y = self._create_model_graph()
+        target = detect_target()
+        # Variant 2: Clean build
+        compile_model(
+            Y,
+            target,
+            "./tmp",
+            test_name + "_2",
+            dll_name=dll_name,
+            debug_settings=debug_settings,
+        )
+        hash2 = create_dir_hash(["test_name"], build_dir + "_2", is_source, debug=True)
+        assert (
+            hash1 == hash2
+        ), "Code generation was not deterministic. Cache key mismatch between first and second code generation pass. Hint: Debug this with the help of the debug option of function create_dir_hash(...)"
+        # Variant 3: Build over existing build dir
+        Y = self._create_model_graph()
+        target = detect_target()
+        compile_model(
+            Y,
+            target,
+            "./tmp",
+            test_name + "_2",
+            dll_name=dll_name,
+            debug_settings=debug_settings,
+        )
+        hash3 = create_dir_hash(["test_name"], build_dir + "_2", is_source, debug=True)
+        assert (
+            hash2 == hash3
+        ), "Code generation was not deterministic. Cache key mismatch between second and third code generation pass. Hint: Debug this with the help of the debug option of function create_dir_hash(...)"
+
+        # Variant 4: Let's provoke to copy the includes again, maybe to a new path?
+        Y = self._create_model_graph()
+        FBCUDA.cutlass_path_ = None
+        compile_model(
+            Y,
+            target,
+            "./tmp",
+            test_name + "_4",
+            dll_name=dll_name,
+            debug_settings=debug_settings,
+        )
+        hash4 = create_dir_hash(["test_name"], build_dir + "_4", is_source, debug=True)
+
+        assert (
+            hash3 == hash4
+        ), "Code generation was not deterministic. Cache key mismatch between third and fourth code generation pass. Hint: Debug this with the help of the debug option of function create_dir_hash(...)"
+
+        with open(
+            os.path.join(build_dir + "_4", "Makefile"), "a", encoding="utf-8"
+        ) as f:
+            f.write("\n")
+
+        hash5 = create_dir_hash(["test_name"], build_dir + "_4", is_source, debug=True)
+        assert (
+            hash4 != hash5
+        ), "Directory hash was not sensitive to a change in the Makefile, the hashes should be different. Hint: Debug this with the help of the debug option of function create_dir_hash"
+        with open(
+            os.path.join(build_dir + "_4", "anything.cu"), "w", encoding="utf-8"
+        ) as f:
+            f.write("// Nothing, really\n")
+
+        hash6 = create_dir_hash(["test_name"], build_dir + "_4", is_source, debug=True)
+        assert (
+            hash6 != hash5
+        ), "Directory hash was not sensitive to a change in a source file, the hashes should be different. Hint: Debug this with the help of the debug option of function create_dir_hash"
+
+        os.rename(
+            os.path.join(build_dir + "_4", "anything.cu"),
+            os.path.join(build_dir + "_4", "anything_.cu"),
+        )
+        hash7 = create_dir_hash(["test_name"], build_dir + "_4", is_source, debug=True)
+        assert (
+            hash7 != hash6
+        ), "Directory hash was not sensitive to a change of name of a source file, the hashes should be different. Hint: Debug this with the help of the debug option of function create_dir_hash"
+
+        Y = self._create_model_graph()
+        target = detect_target()
+        debug_settings = AITDebugSettings(gen_standalone=True)
+        compile_model(
+            Y,
+            target,
+            "./tmp",
+            test_name + "_8",
+            dll_name=dll_name,
+            debug_settings=debug_settings,
+        )
+        hash8 = create_dir_hash(["test_name"], build_dir + "_8", is_source, debug=True)
+
+        assert (
+            hash8 != hash1
+        ), "Directory hash was not sensitive to a change of Makefile (standalone codegen) and possibly source code, the hashes should be different. Hint: Debug this with the help of the debug option of function create_dir_hash"
+
+
+filter_test_cases_by_test_env(BuildCacheTestCase)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
The compilation stage of AIT's generated source files takes a considerable amount of time. It would be nice if we could speed up the build using a build cache, for example using ccache. This would be especially beneficial for speeding up
Unit tests, possibly with a huge cost benefit to Meta,
considering how much time is spent in AIT unit tests on GPU build servers ( see https://www.internalfb.com/sevmanager/view/322359 ) - also, we as developers might wait unneccessarily long for unit tests to complete, so developer productivity could be improved.

Unfortunately, ccache does not work with AIT build scripts for nvcc as it destroys the options that need to be passed down to the host compiler ( I tried that).

But luckily, AIT's codegen has a nice property that we can exploit: The generated sources are rather compact, and all in a single directory. So instead of caching build results for a single file, we could attempt to hash *all* of the sources of a build directory, and if nothing changed, to retrieve the build results for that directory instead of invoking make.

This would likely speed up CI builds considerably.

This diff has a small POC to test this hypothesis.

I was able to, for example, bring down the execution time of this small set of unit tests down from approx. 60 to 15 seconds  after having warmed the build cache:

  buck2 run @//mode/dev-nosan AITemplate:test_gemm --local-only -- -r 3d_2d_rcr

or this set, from approx. 530 seconds, down to approx. 100 seconds.

  buck2 run @//mode/dev-nosan AITemplate:test_expand --local-only

It works rather simple: Define an environment variable
like this:

  export AIT_BUILD_CACHE_DIR=/tmp/ait_build_cache

and that's it. If it is not defined, it is disabled.

Note:

This is a PoC - to actually productionalize it to speed up CI builds, we would need a distributed cache, so that builders share the cached artifacts. This could be done with a network file system or using something like memcached. If we use a network file system, we should at least ensure that cache updates are atomic ( e.g. write to a temp directory and then rename it to the final cache dir)

Differential Revision: D44229622

