### PR TITLE
Add ait full op converters

### DIFF
--- a/fx2ait/fx2ait/acc_tracer/acc_ops.py
+++ b/fx2ait/fx2ait/acc_tracer/acc_ops.py
@@ -2967,22 +2967,6 @@ def tensor_split(*, input, indices_or_sections, dim=0):
 
 
 @register_acc_op_mapping(
-    op_and_target=("call_method", "new_ones"),
-    arg_replacement_tuples=[
-        ("input", "input"),
-        ("size", "size"),
-        ("dtype", "dtype", this_arg_is_optional),
-        ("device", "device", this_arg_is_optional),
-        ("requires_grad", "requires_grad", this_arg_is_optional),
-    ],
-)
-@register_acc_op
-def new_ones(*, input, size, dtype=None, device=None, requires_grad=False):
-    assert requires_grad is False, f"requires_grad != False, it is {requires_grad}"
-    return input.new_ones(size, dtype=dtype, device=device)
-
-
-@register_acc_op_mapping(
     op_and_target=("call_method", "new_empty"),
     arg_replacement_tuples=[
         ("input", "input"),
@@ -3278,6 +3262,74 @@ def group_norm(*, input, num_groups, weight=None, bias=None, eps=1e-05):
 @register_acc_op
 def long(*, input):
     return input.long()
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_method", "new_full"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("size", "size"),
+        ("fill_value", "fill_value"),
+        ("dtype", "dtype", this_arg_is_optional),
+        ("device", "device", this_arg_is_optional),
+        ("requires_grad", "requires_grad", this_arg_is_optional),
+    ],
+)
+@register_acc_op
+def new_full(*, input, size, fill_value, dtype=None, device=None, requires_grad=False):
+    return input.new_full(size, fill_value=fill_value, dtype=dtype, device=device)
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.full_like))
+@register_acc_op
+def full_like(*, input, fill_value, dtype=None, device=None):
+    return torch.full_like(
+        input=input, fill_value=fill_value, dtype=dtype, device=device
+    )
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_method", "new_ones"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("size", "size"),
+        ("dtype", "dtype", this_arg_is_optional),
+        ("device", "device", this_arg_is_optional),
+        ("requires_grad", "requires_grad", this_arg_is_optional),
+    ],
+)
+@register_acc_op
+def new_ones(*, input, size, dtype=None, device=None, requires_grad=False):
+    assert requires_grad is False, f"requires_grad != False, it is {requires_grad}"
+    return input.new_ones(size, dtype=dtype, device=device)
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.ones_like))
+@register_acc_op
+def ones_like(*, input, dtype=None, device=None):
+    return torch.ones_like(input=input, dtype=dtype, device=device)
+
+
+@register_acc_op_mapping(
+    op_and_target=("call_method", "new_zeros"),
+    arg_replacement_tuples=[
+        ("input", "input"),
+        ("size", "size"),
+        ("dtype", "dtype", this_arg_is_optional),
+        ("device", "device", this_arg_is_optional),
+        ("requires_grad", "requires_grad", this_arg_is_optional),
+    ],
+)
+@register_acc_op
+def new_zeros(*, input, size, dtype=None, device=None, requires_grad=False):
+    assert requires_grad is False, f"requires_grad != False, it is {requires_grad}"
+    return input.new_zeros(size, dtype=dtype, device=device)
+
+
+@register_acc_op_mapping(op_and_target=("call_function", torch.zeros_like))
+@register_acc_op
+def zeros_like(*, input, dtype=None, device=None):
+    return torch.zeros_like(input=input, dtype=dtype, device=device)
 
 
 ###############################################################################

--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -34,6 +34,7 @@ from aitemplate.compiler.public import (
     elementwise,
     expand,
     flatten,
+    full,
     FuncEnum,
     gemm_rcr,
     gemm_rrr,
@@ -1663,3 +1664,59 @@ def acc_ops_neg(
         raise ValueError(f"Unexpected input dtype {dt}")
 
     return create_binary_op(FuncEnum.MUL, args, new_kwargs, name)
+
+
+@ait_converter(acc_ops.new_full)
+def acc_ops_new_full(
+    target: Target, args: Tuple[Argument, ...], kwargs: Dict[str, Argument], name: str
+) -> ConverterOutput:
+    size = kwargs["size"]
+    fill_value = kwargs["fill_value"]
+    return full()(size, fill_value=fill_value, dtype="float16")
+
+
+@ait_converter(acc_ops.full_like)
+def acc_ops_full_like(
+    target: Target, args: Tuple[Argument, ...], kwargs: Dict[str, Argument], name: str
+) -> ConverterOutput:
+    input_val = kwargs["input"]
+    if not isinstance(input_val, AITTensor):
+        raise RuntimeError(f"Non-tensor inputs for {name}: {input_val}")
+    fill_value = kwargs["fill_value"]
+    return full()(input_val.shape(), fill_value=fill_value, dtype="float16")
+
+
+@ait_converter(acc_ops.new_ones)
+def acc_ops_new_ones(
+    target: Target, args: Tuple[Argument, ...], kwargs: Dict[str, Argument], name: str
+) -> ConverterOutput:
+    size = kwargs["size"]
+    return full()(size, 1, dtype="float16")
+
+
+@ait_converter(acc_ops.ones_like)
+def acc_ops_ones_like(
+    target: Target, args: Tuple[Argument, ...], kwargs: Dict[str, Argument], name: str
+) -> ConverterOutput:
+    input_val = kwargs["input"]
+    if not isinstance(input_val, AITTensor):
+        raise RuntimeError(f"Non-tensor inputs for {name}: {input_val}")
+    return full()(input_val.shape(), 1, dtype="float16")
+
+
+@ait_converter(acc_ops.new_zeros)
+def acc_ops_new_zeros(
+    target: Target, args: Tuple[Argument, ...], kwargs: Dict[str, Argument], name: str
+) -> ConverterOutput:
+    size = kwargs["size"]
+    return full()(size, 0, dtype="float16")
+
+
+@ait_converter(acc_ops.zeros_like)
+def acc_ops_zeros_like(
+    target: Target, args: Tuple[Argument, ...], kwargs: Dict[str, Argument], name: str
+) -> ConverterOutput:
+    input_val = kwargs["input"]
+    if not isinstance(input_val, AITTensor):
+        raise RuntimeError(f"Non-tensor inputs for {name}: {input_val}")
+    return full()(input_val.shape(), 0, dtype="float16")

--- a/fx2ait/fx2ait/test/converters/test_ait_full.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_full.py
@@ -1,0 +1,79 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import torch
+from fx2ait.acc_tracer import acc_ops
+from fx2ait.tools.common_fx2ait import AITTestCase
+
+
+class TestFullConverter(AITTestCase):
+    def test_new_full(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                full = x.new_full((2, 6), 2.2)
+                return torch.cat([full, x], dim=1)
+
+        model = TestModule().cuda().half()
+        input = [torch.randn([2, 3]).cuda().half()]
+        self.run_test(model, input, expected_ops={acc_ops.new_full})
+
+    def test_full_like(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                full = torch.full_like(x, 2.2)
+                return torch.cat([full, x], dim=1)
+
+        model = TestModule().cuda().half()
+        input = [torch.randn([2, 3]).cuda().half()]
+        self.run_test(model, input, expected_ops={acc_ops.full_like})
+
+    def test_new_ones(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                full = x.new_ones((2, 6))
+                return torch.cat([full, x], dim=1)
+
+        model = TestModule().cuda().half()
+        input = [torch.randn([2, 3]).cuda().half()]
+        self.run_test(model, input, expected_ops={acc_ops.cat, acc_ops.new_ones})
+
+    def test_ones_like(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                ones = torch.ones_like(x)
+                return torch.cat([ones, x], dim=1)
+
+        model = TestModule().cuda().half()
+        input = [torch.randn([2, 3]).cuda().half()]
+        self.run_test(model, input, expected_ops={acc_ops.cat, acc_ops.ones_like})
+
+    def test_new_zeros(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                zeros = x.new_zeros((2, 6))
+                return torch.cat([zeros, x], dim=1)
+
+        model = TestModule().cuda().half()
+        input = [torch.randn([2, 3]).cuda().half()]
+        self.run_test(model, input, expected_ops={acc_ops.cat, acc_ops.new_zeros})
+
+    def test_zeros_like(self):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                zeros = torch.zeros_like(x)
+                return torch.cat([zeros, x], dim=1)
+
+        model = TestModule().cuda().half()
+        input = [torch.randn([2, 3]).cuda().half()]
+        self.run_test(model, input, expected_ops={acc_ops.zeros_like})

--- a/python/aitemplate/compiler/public/__init__.py
+++ b/python/aitemplate/compiler/public/__init__.py
@@ -79,6 +79,7 @@ from aitemplate.compiler.ops.tensor.chunk import chunk
 from aitemplate.compiler.ops.tensor.concatenate import concatenate
 from aitemplate.compiler.ops.tensor.dynamic_slice import dynamic_slice
 from aitemplate.compiler.ops.tensor.expand import expand
+from aitemplate.compiler.ops.tensor.full import full
 from aitemplate.compiler.ops.tensor.permute import permute
 from aitemplate.compiler.ops.tensor.split import split
 


### PR DESCRIPTION
Summary:
ATT
* ops like torch.ones/torch.zeros will be const_fold by lowering pass, thus not adding converter for them

Differential Revision: D44274432

