### PR TITLE
Remove inheritance from object

### DIFF
--- a/examples/01_resnet-50/weight_utils.py
+++ b/examples/01_resnet-50/weight_utils.py
@@ -30,7 +30,7 @@ from aitemplate.testing import detect_target
 CONV_WEIGHT_PATTERN = re.compile(r"conv\d+\.weight")
 
 
-class timm_export(object):
+class timm_export:
     def __init__(self, model_name, pretrained=True):
         self.model_name = model_name
         if model_name != "resnet50":

--- a/python/aitemplate/backend/builder.py
+++ b/python/aitemplate/backend/builder.py
@@ -268,7 +268,7 @@ class Runner(BaseRunner):
         return ret
 
 
-class Builder(object):
+class Builder:
     """Builder is a module to compile generated source code
     files into binary objects.
     """

--- a/python/aitemplate/backend/cuda/utils.py
+++ b/python/aitemplate/backend/cuda/utils.py
@@ -27,7 +27,7 @@ from aitemplate.utils.mk_cutlass_lib.mk_cutlass_lib import mk_cutlass_lib
 _LOGGER = logging.getLogger(__name__)
 
 
-class Args(object):
+class Args:
     def __init__(self, arch):
         self.operations = "all"
         self.build_dir = ""

--- a/python/aitemplate/backend/profiler_cache.py
+++ b/python/aitemplate/backend/profiler_cache.py
@@ -464,7 +464,7 @@ def ait_cache_version() -> int:
     return __AIT_CACHE_VERSION__
 
 
-class ProfileCacheDB(object):
+class ProfileCacheDB:
     r"""Local SQLite profile cache database."""
 
     def __init__(

--- a/python/aitemplate/backend/rocm/utils.py
+++ b/python/aitemplate/backend/rocm/utils.py
@@ -28,7 +28,7 @@ from aitemplate.backend import registry
 # pylint: disable=C0103,C0415,W0707
 
 
-class Args(object):
+class Args:
     def __init__(self, arch):
         self.operations = "all"
         self.build_dir = ""

--- a/python/aitemplate/backend/target.py
+++ b/python/aitemplate/backend/target.py
@@ -49,7 +49,7 @@ class TargetType(IntEnum):
     rocm = 2
 
 
-class Target(object):
+class Target:
     def __init__(self, static_files_path: str):
         """
         Parameters

--- a/python/aitemplate/backend/task_runner.py
+++ b/python/aitemplate/backend/task_runner.py
@@ -25,7 +25,7 @@ import typing
 from collections import OrderedDict
 
 # pylint: disable=R1732,R1710,R1721
-class Task(object):
+class Task:
     """Task is an object containing a bash command,
     process for the command, and output of the process.
     """
@@ -187,7 +187,7 @@ class Task(object):
                 self._proc.stderr.close()
 
 
-class DeviceFarm(object):
+class DeviceFarm:
     """Device Farm is a stateful object to
     schedule and assigns a task to the available devices.
     Devices are logical devices, can be CPUs or GPUs.
@@ -240,7 +240,7 @@ class DeviceFarm(object):
             self._dev_stats[dev] = False
 
 
-class BaseRunner(object):
+class BaseRunner:
     """Genetic subprocess task runner for different purposes"""
 
     def __init__(self, devs: list[int], tag: str, timeout: int = 10) -> None:

--- a/python/aitemplate/compiler/model.py
+++ b/python/aitemplate/compiler/model.py
@@ -154,7 +154,7 @@ def _reshape_tensor(tensor: TorchTensor, shape: List[int]) -> TorchTensor:
     return new_tensor.reshape(shape)
 
 
-class Model(object):
+class Model:
     class _DLLWrapper:
         def __init__(
             self,

--- a/python/aitemplate/compiler/tensor_accessor.py
+++ b/python/aitemplate/compiler/tensor_accessor.py
@@ -30,7 +30,7 @@ from aitemplate.compiler.base import IntImm, IntVar, Tensor
 _LOGGER = logging.getLogger(__name__)
 
 
-class TensorAccessor(object):
+class TensorAccessor:
     """
     A tensor accessor which manages how to access a Tensor.
     Must always be used together with a Tensor.

--- a/python/aitemplate/compiler/transform/fuse_ops.py
+++ b/python/aitemplate/compiler/transform/fuse_ops.py
@@ -36,7 +36,7 @@ from aitemplate.compiler.transform.toposort import toposort
 _LOGGER = logging.getLogger(__name__)
 
 
-class SimpleDisjointSet(object):
+class SimpleDisjointSet:
     def __init__(self):
         self.node_to_list_mapping: Dict[Any, List[Any]] = {}
 

--- a/python/aitemplate/frontend/nn/parameter.py
+++ b/python/aitemplate/frontend/nn/parameter.py
@@ -18,7 +18,7 @@ Parameter definition.
 from aitemplate.compiler.base import Tensor
 
 
-class Parameter(object):
+class Parameter:
     def __init__(self, shape, dtype, name=None, value=None):
         self._tensor = Tensor(shape=shape, dtype=dtype, name=name)
         self._value = value

--- a/python/aitemplate/frontend/parameter.py
+++ b/python/aitemplate/frontend/parameter.py
@@ -18,7 +18,7 @@ Parameter definition.
 from aitemplate.compiler.base import Tensor
 
 
-class Parameter(object):
+class Parameter:
     def __init__(self, shape, dtype, name=None, value=None):
         self._tensor = Tensor(shape=shape, dtype=dtype, name=name)
         self._value = value

--- a/python/aitemplate/utils/visualization/pydot.py
+++ b/python/aitemplate/utils/visualization/pydot.py
@@ -601,7 +601,7 @@ def graph_from_incidence_matrix(matrix, node_prefix="", directed=False):
     return graph
 
 
-class Common(object):
+class Common:
     """Common information to several classes.
 
     Should not be directly used, several classes are derived from


### PR DESCRIPTION
Inheritance from `object` was needed in Python2.
However, in Python3 classes are implicitly inherit from `object`.

More [info](https://stackoverflow.com/questions/4015417/why-do-python-classes-inherit-object) on it

