### PR TITLE
Use List[T] instead of list[T] in type info

### DIFF
--- a/python/aitemplate/backend/builder.py
+++ b/python/aitemplate/backend/builder.py
@@ -25,10 +25,9 @@ import os
 import re
 import shlex
 import subprocess
-import typing
 from hashlib import sha1
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional, Tuple, Union
 
 import jinja2
 
@@ -224,12 +223,12 @@ class Runner(BaseRunner):
     Runner is inherited from BaseRunner.
     """
 
-    def __init__(self, devs: list[int], timeout: int = 10):
+    def __init__(self, devs: List[int], timeout: int = 10):
         """Initialize a parallel runner for building
 
         Parameters
         ----------
-        devs : list[int]
+        devs : List[int]
             CPU ids for compiling
         timeout : int, optional
             Compiling timeout, by default 10 (seconds)
@@ -241,7 +240,7 @@ class Runner(BaseRunner):
         self._ftask_proc = process_task
         self._fret_proc = process_return
 
-    def push(self, idx: typing.Union[int, str], cmd: str, target: Target) -> None:
+    def push(self, idx: Union[int, str], cmd: str, target: Target) -> None:
         """Push a building task into runner
 
         Parameters
@@ -255,7 +254,7 @@ class Runner(BaseRunner):
         """
         self._queue.append(Task(idx, cmd, target, shell=True))
 
-    def pull(self) -> list[None]:
+    def pull(self) -> List:
         """Pull building results.
         Check whether all building tasks are successful.
 
@@ -296,7 +295,7 @@ class Builder(object):
 
     def build_objs(
         self,
-        files: list[typing.Tuple[str, str]],
+        files: List[Tuple[str, str]],
         cc_cmd: str,
         binary_cc_cmd: Optional[str] = None,
     ):
@@ -304,7 +303,7 @@ class Builder(object):
 
         Parameters
         ----------
-        files : list[Tuple[str, str]]
+        files : List[Tuple[str, str]]
             list of tuples of source code path and object file path
         cc_cmd : str
             command line template for building objects
@@ -345,14 +344,14 @@ class Builder(object):
         self._runner.join()
         self._runner.pull()
 
-    def build_so(self, target: Target, objs: list[str]):
+    def build_so(self, target: Target, objs: List[str]):
         """Generate a task to build all objects into a dynamic library
 
         Parameters
         ----------
         target : Target
             Device target of dynamic library
-        objs : list[str]
+        objs : List[str]
             List of all object file paths for building the dynamic library.
         """
         _LOGGER.info("Building " + target)

--- a/python/aitemplate/backend/codegen.py
+++ b/python/aitemplate/backend/codegen.py
@@ -60,12 +60,12 @@ CONSTANT_FOLDER_MODEL_NAME = "ConstantFolder"
 MODEL_NAME = "Model"
 
 
-def gen_profiler(sorted_graph: list[Tensor], workdir: str, dynamic_profiling_strategy):
+def gen_profiler(sorted_graph: List[Tensor], workdir: str, dynamic_profiling_strategy):
     """Generate operator profiler source code files for the given graph
 
     Parameters
     ----------
-    sorted_graph : list[Tensor]
+    sorted_graph : List[Tensor]
         The network after running toposort transformation
     workdir : str
         Target directory for generated C++ source code files
@@ -83,13 +83,13 @@ def gen_profiler(sorted_graph: list[Tensor], workdir: str, dynamic_profiling_str
 
 
 def gen_function_src(
-    sorted_graph: list[Tensor], workdir: str, model_name: str = ""
-) -> list[Tuple[str, str]]:
+    sorted_graph: List[Tensor], workdir: str, model_name: str = ""
+) -> List[Tuple[str, str]]:
     """Generate functions source code files for the given graph
 
     Parameters
     ----------
-    sorted_graph : list[Tensor]
+    sorted_graph : List[Tensor]
         The network after running toposort transformation
     workdir : str
         Target directory for generated C++ source code files
@@ -98,7 +98,7 @@ def gen_function_src(
 
     Returns
     -------
-    list[Tuple[str, str]]
+    List[Tuple[str, str]]
         List of tuple (source file path, object file path)
     """
     target = Target.current()
@@ -321,7 +321,7 @@ class ModelContainerGenerator:
         graph: List[Tensor],
         output_tensors: List[Tensor],
         model_name: str = MODEL_NAME,
-        additional_unbound_constants: Optional[list[Tensor]] = None,
+        additional_unbound_constants: Optional[List[Tensor]] = None,
         debug_settings: Optional[AITDebugSettings] = None,
     ):
         self.target = Target.current()
@@ -986,7 +986,7 @@ _DEBUG_SETTINGS = AITDebugSettings()
 
 
 def gen_library_src(  # noqa: C901
-    sorted_graph: list[Tensor],
+    sorted_graph: List[Tensor],
     max_blob_size: int,
     max_constant_blob_size: int,
     workspace: Workspace,
@@ -994,13 +994,13 @@ def gen_library_src(  # noqa: C901
     output_tensors: List[Tensor],
     model_name: str = "",
     debug_settings: AITDebugSettings = _DEBUG_SETTINGS,
-    additional_unbound_constants: Optional[list[Tensor]] = None,
-) -> list[Tuple[str, str]]:
+    additional_unbound_constants: Optional[List[Tensor]] = None,
+) -> List[Tuple[str, str]]:
     """Generate model driver source code files for the given graph
 
     Parameters
     ----------
-    sorted_graph : list[Tensor]
+    sorted_graph : List[Tensor]
         The network after running toposort transformation
     max_blob_size : int
         Total memory for input/output tensor and intermediate results,
@@ -1016,7 +1016,7 @@ def gen_library_src(  # noqa: C901
 
     Returns
     -------
-    list[Tuple[str, str]]
+    List[Tuple[str, str]]
         List of tuple (source file path, object file path)
     """
 

--- a/python/aitemplate/backend/task_runner.py
+++ b/python/aitemplate/backend/task_runner.py
@@ -23,6 +23,8 @@ import subprocess
 import time
 import typing
 from collections import OrderedDict
+from typing import List
+
 
 # pylint: disable=R1732,R1710,R1721
 class Task(object):
@@ -193,12 +195,12 @@ class DeviceFarm(object):
     Devices are logical devices, can be CPUs or GPUs.
     """
 
-    def __init__(self, devs: list[int]) -> None:
+    def __init__(self, devs: List[int]) -> None:
         """Initialize a Device Farm given a list of device ids.
 
         Parameters
         ----------
-        devs : list[int]
+        devs : List[int]
             List of device ids in int
         """
         if isinstance(devs, int):
@@ -243,11 +245,11 @@ class DeviceFarm(object):
 class BaseRunner(object):
     """Genetic subprocess task runner for different purposes"""
 
-    def __init__(self, devs: list[int], tag: str, timeout: int = 10) -> None:
+    def __init__(self, devs: List[int], tag: str, timeout: int = 10) -> None:
         """
         Parameters
         ----------
-        devs : list[int]
+        devs : List[int]
             List of device ids for tasks.
         tag : str
             Runner's name tag
@@ -287,9 +289,7 @@ class BaseRunner(object):
         self._finished_tasks = set()
         self._queue = []
 
-    def pull(
-        self, ftask_proc: typing.Callable, fret_proc: typing.Callable
-    ) -> list[object]:
+    def pull(self, ftask_proc: typing.Callable, fret_proc: typing.Callable) -> List:
         """Pull results from all tasks executed on the runner.
 
         Parameters
@@ -301,7 +301,7 @@ class BaseRunner(object):
 
         Returns
         -------
-        list
+        List
             Aggregated returns from all tasks
         """
         ret = []

--- a/python/aitemplate/compiler/base.py
+++ b/python/aitemplate/compiler/base.py
@@ -94,7 +94,7 @@ class IntVar(Node):
 
         Parameters
         ----------
-        values : list[int]
+        values : List[int]
             A list of possible values of this dynamic dimension.
             len(values) must be >= 2.
 

--- a/tests/lint/check_meta_header.py
+++ b/tests/lint/check_meta_header.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 import sys
+from typing import List
 
 import click
 
@@ -36,7 +37,7 @@ PY_HEADER = process_header(HEADER, "#")
 CPP_HEADER = process_header(HEADER, "//")
 
 
-def dfs(root_path: str) -> list[str]:
+def dfs(root_path: str) -> List[str]:
     """DFS source code tree to find python files missing header
 
     Parameters
@@ -46,7 +47,7 @@ def dfs(root_path: str) -> list[str]:
 
     Returns
     -------
-    list[str]
+    List[str]
         file list missing header
     """
     ret = []
@@ -66,12 +67,12 @@ def dfs(root_path: str) -> list[str]:
     return ret
 
 
-def fix_header(file_list: list[str]) -> None:
+def fix_header(file_list: List[str]) -> None:
     """Adding Meta header to to source files
 
     Parameters
     ----------
-    file_list : list[str]
+    file_list : List[str]
         file list missing header
     """
     for path in file_list:


### PR DESCRIPTION
Use `List[T]` instead of `list[T]` in type info

Until Python 3.9 [added support for type hinting using standard collections](https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections), you had to use `typing.Tuple` and `typing.List` if you wanted to document what type the contents of the containers needed to be:

Up until Python 3.8, `tuple` and `list` did not support being [used as generic types](https://docs.python.org/3/library/typing.html#generics).

More [info](https://stackoverflow.com/questions/39458193/using-list-tuple-etc-from-typing-vs-directly-referring-type-as-list-tuple-etc) on it