### PR TITLE
enabled to merge concat ops with multiple dst_ops

### DIFF
--- a/python/aitemplate/compiler/transform/__init__.py
+++ b/python/aitemplate/compiler/transform/__init__.py
@@ -42,6 +42,7 @@ from aitemplate.compiler.transform.split_large_concat_ops import split_large_con
 from aitemplate.compiler.transform.split_large_split_ops import split_large_split_ops
 from aitemplate.compiler.transform.toposort import toposort
 from aitemplate.compiler.transform.transform_memory_ops import transform_memory_ops
+from aitemplate.compiler.transform.transform_merge_slice_ops import merge_slice_ops
 from aitemplate.compiler.transform.transform_odd_alignment import (
     transform_odd_alignment,
 )

--- a/python/aitemplate/compiler/transform/move_view_ops.py
+++ b/python/aitemplate/compiler/transform/move_view_ops.py
@@ -171,7 +171,11 @@ def _try_move_view_op(
         new_view_output_shapes.append(input_view_shape)
     # Now we start modifying the graph.
     # make a new output tensor for the first cat
-    new_first_cat_output = Tensor(original_view_shape, first_cat_output._attrs["name"])
+    new_first_cat_output = Tensor(
+        original_view_shape,
+        first_cat_output._attrs["name"],
+        dtype=first_cat_output.dtype(),
+    )
     transform_utils.replace_tensor(first_cat_output, new_first_cat_output)
     first_cat._attrs["outputs"][0] = new_first_cat_output
     new_first_cat_output._attrs["src_ops"].add(first_cat)
@@ -179,8 +183,8 @@ def _try_move_view_op(
     for dst_op in new_first_cat_output._attrs["dst_ops"]:
         dst_op_type = dst_op._attrs["op"]
         if dst_op_type in _SUPPORTED_VIEW_OPS:
-            # it's safe to remove the old view ops, because they have the same
-            # output shape
+            # we've ensured all view ops have the same output shape before entering
+            # this function, so it's safe to remove the old view ops
             transform_utils.remove_view_op_from_sorted_graph(dst_op)
         else:
             # we need to place a view op as we've changed the concat's output shape

--- a/python/aitemplate/compiler/transform/optimize_graph.py
+++ b/python/aitemplate/compiler/transform/optimize_graph.py
@@ -106,6 +106,9 @@ def optimize_graph(
         # op directly. After fuse_ops, there are only FusedElementwise ops.
         transform_special_ops,
         apply_padding,
+        # apply_padding may introduce new concats that can be fused
+        move_view_op_before_concat,
+        transform_memory_ops,
         transform_strided_ops,
         split_large_slice_scatter_ops,
         split_large_concat_ops,

--- a/python/aitemplate/compiler/transform/transform_memory_ops.py
+++ b/python/aitemplate/compiler/transform/transform_memory_ops.py
@@ -16,14 +16,15 @@
 Perform memory operator related transformations.
 """
 import copy
-from typing import List, Optional
+from typing import List
 
-from aitemplate.compiler.base import IntImm, IntVar, Operator, Tensor
+from aitemplate.compiler.base import Operator, Tensor
 
-from aitemplate.compiler.ops.tensor.dynamic_slice import dynamic_slice, MAX_INT32
+from aitemplate.compiler.ops.tensor.dynamic_slice import dynamic_slice
 from aitemplate.compiler.tensor_accessor import TensorAccessor
 from aitemplate.compiler.transform import transform_strided_ops_utils, transform_utils
 from aitemplate.compiler.transform.toposort import toposort
+from aitemplate.compiler.transform.transform_merge_slice_ops import merge_slice_ops
 
 from aitemplate.utils import graph_utils, shape_utils
 
@@ -86,7 +87,7 @@ def _update_cat_dst_ops(
         else:
             # Make a new slice op. Note that it's fine we make a new slice op from
             # another slice op, because consecutive slice ops will be merged
-            # by the _try_merge_slice_slice pass
+            # by the merge_slice_ops pass
             slice_start_indices = [0] * rank
             slice_end_indices = [None] * rank
             slice_start_indices[cat_dim] = cat_dim_offset
@@ -420,119 +421,6 @@ def _merge_split_and_cat(sorted_graph: List[Tensor]) -> List[Tensor]:  # noqa: C
     return transform_utils.sanitize_sorted_graph(sorted_graph)
 
 
-def _try_merge_slice_slice(
-    first_slice: Operator, second_slice: Operator, slice_dim: int
-) -> bool:
-    """
-    This function tries to merge two consecutive slice ops with the following
-    steps:
-        * update the start_indices and end_indices fields of the second_slice
-        * remove the first slice
-    """
-    first_slice_output = first_slice._attrs["outputs"][0]
-    first_slice_input_shape = first_slice._attrs["inputs"][0].shape()
-    second_slice_output = second_slice._attrs["outputs"][0]
-    second_slice_output_shape = second_slice_output.shape()
-    # note that all the dims of input_shape[slice_dim:] and output_shape[slice_dim:]
-    # are static at this point
-    for idx in range(slice_dim, first_slice_output._rank()):
-        first_slice_dim_offset = first_slice._attrs["start_indices"][idx]
-        # update the start and end indices of the second slice op
-        new_start = second_slice._attrs["start_indices"][idx] + first_slice_dim_offset
-        first_slice_input_dim = first_slice_input_shape[idx].value()
-        # new start index exceeds the corresponding dim value of the first slice input shape
-        if new_start >= first_slice_input_dim:
-            return False
-        new_end = new_start + second_slice_output_shape[idx].value()
-        # new end index exceeds the corresponding dim value of the first slice input shape
-        if new_end > first_slice_input_dim:
-            return False
-        first_slice_end = first_slice._attrs["end_indices"][idx]
-        second_slice_end = second_slice._attrs["end_indices"][idx]
-        if first_slice_end == MAX_INT32 == second_slice_end:
-            new_end = MAX_INT32
-        second_slice._attrs["start_indices"][idx] = new_start
-        second_slice._attrs["end_indices"][idx] = new_end
-    # remove the old strided op from the first cat's dst_ops
-    transform_utils.remove_single_tensor_op_from_sorted_graph(first_slice)
-    return True
-
-
-def _check_slice_op(slice_op: Operator, slice_dim: int) -> bool:
-    """
-    Return True if the slice_op's indices are valid for being merged
-    """
-    slice_shape = slice_op._attrs["outputs"][0].shape()
-    if not shape_utils.all_static_dimensions(slice_shape, slice_dim):
-        return False
-    # we expect normalized start_indices and end_indices
-    start_index = slice_op._attrs["start_indices"][slice_dim]
-    if start_index is None or start_index < 0:
-        return False
-    end_index = slice_op._attrs["end_indices"][slice_dim]
-    if end_index is None or end_index < 0 or end_index <= start_index:
-        return False
-    return True
-
-
-def _get_rightmost_non_dynamic_dim(shape: List[IntVar]) -> Optional[int]:
-    """
-    Return the index of the rightmost non-dynamic dim. For example, given
-    a shape [3, dyn_dim, 4, 1], it would return 2, which is the index of the
-    third dim.
-    Return None if shape[-1] is dynamic.
-    """
-    idx = 0
-    for dim in reversed(shape):
-        if not isinstance(dim, IntImm):
-            break
-        idx += 1
-    if idx == 0:
-        return None
-    return len(shape) - idx
-
-
-def _merge_slice_and_slice(sorted_graph: List[Tensor]) -> List[Tensor]:
-    # a list of tuple(first_slice, second_slice, slice_dim)
-    to_be_merged = []
-    for tensor in sorted_graph:
-        src_ops = tensor._attrs["src_ops"]
-        if len(src_ops) != 1:
-            continue
-        src_op = list(src_ops)[0]
-        if src_op._attrs["op"] != "dynamic_slice":
-            continue
-        first_slice = src_op
-        first_slice_output = first_slice._attrs["outputs"][0]
-        if first_slice_output._attrs["is_output"]:
-            continue
-        slice_dim = _get_rightmost_non_dynamic_dim(first_slice_output.shape())
-        if slice_dim is None:
-            continue
-        if not _check_slice_op(first_slice, slice_dim):
-            continue
-        next_ops = first_slice_output._attrs["dst_ops"]
-        if len(next_ops) != 1:
-            continue
-        next_op = next_ops[0]
-        if next_op._attrs["op"] != "dynamic_slice":
-            continue
-        second_slice = next_op
-        second_slice_output = second_slice._attrs["outputs"][0]
-        if first_slice_output._rank() != second_slice_output._rank():
-            continue
-        second_slice_dim = _get_rightmost_non_dynamic_dim(second_slice_output.shape())
-        if slice_dim != second_slice_dim:
-            continue
-        if not _check_slice_op(second_slice, slice_dim):
-            continue
-        to_be_merged.append([first_slice, second_slice, slice_dim])
-
-    for first_slice, second_slice, slice_dim in to_be_merged:
-        _try_merge_slice_slice(first_slice, second_slice, slice_dim)
-    return transform_utils.sanitize_sorted_graph(sorted_graph)
-
-
 def _eliminate_split_full_idx(sorted_graph: List[Tensor]) -> List[Tensor]:
     for tensor in sorted_graph:
         src_ops = tensor._attrs["src_ops"]
@@ -572,7 +460,7 @@ def transform_memory_ops(
     funcs = [
         _eliminate_split_full_idx,
         _merge_split_and_cat,
-        _merge_slice_and_slice,
+        merge_slice_ops,
         _eliminate_cat,
     ]
     num_ops = None

--- a/python/aitemplate/compiler/transform/transform_memory_ops.py
+++ b/python/aitemplate/compiler/transform/transform_memory_ops.py
@@ -16,9 +16,9 @@
 Perform memory operator related transformations.
 """
 import copy
-from typing import List
+from typing import List, Optional
 
-from aitemplate.compiler.base import Operator, Tensor
+from aitemplate.compiler.base import IntImm, IntVar, Operator, Tensor
 
 from aitemplate.compiler.ops.tensor.dynamic_slice import dynamic_slice, MAX_INT32
 from aitemplate.compiler.tensor_accessor import TensorAccessor
@@ -58,27 +58,6 @@ def _eliminate_cat(sorted_graph: List[Tensor]) -> List[Tensor]:
     return transform_utils.sanitize_sorted_graph(sorted_graph)
 
 
-def _check_slice_op(slice_op: Operator, slice_dim: int) -> bool:
-    """
-    Return True if the slice_op's indices are valid for being updated
-    """
-    slice_shape = slice_op._attrs["outputs"][0].shape()
-    if not shape_utils.all_static_dimensions(slice_shape, slice_dim):
-        return False
-    # we expect normalized start_indices and end_indices
-    nested_start_index = slice_op._attrs["start_indices"][slice_dim]
-    if nested_start_index is None or nested_start_index < 0:
-        return False
-    nested_end_index = slice_op._attrs["end_indices"][slice_dim]
-    if (
-        nested_end_index is None
-        or nested_end_index < 0
-        or nested_end_index <= nested_start_index
-    ):
-        return False
-    return True
-
-
 def _update_cat_dst_ops(
     first_cat: Operator, second_cat: Operator, cat_dim_offset: int
 ) -> None:
@@ -104,20 +83,10 @@ def _update_cat_dst_ops(
     for idx, first_cat_dst_op in enumerate(first_cat_dst_ops):
         if first_cat_dst_op is second_cat:
             continue
-        elif first_cat_dst_op._attrs["op"] == "dynamic_slice":
-            # we've inserted a dynamic slice already so we need to update the
-            # start_indices and end_indices
-            slice_op = first_cat_dst_op
-            assert _check_slice_op(slice_op, cat_dim), f"invalid {slice_op=}"
-            slice_op._attrs["start_indices"][cat_dim] += cat_dim_offset
-            if slice_op._attrs["end_indices"][cat_dim] != MAX_INT32:
-                slice_op._attrs["end_indices"][cat_dim] += cat_dim_offset
-            # remove the old strided op from the first cat's dst_ops
-            first_cat_dst_ops.remove(slice_op)
-            slice_op._attrs["inputs"][0] = second_cat_output
-            second_cat_output._attrs["dst_ops"].add(slice_op)
         else:
-            # make a new slice op
+            # Make a new slice op. Note that it's fine we make a new slice op from
+            # another slice op, because consecutive slice ops will be merged
+            # by the _try_merge_slice_slice pass
             slice_start_indices = [0] * rank
             slice_end_indices = [None] * rank
             slice_start_indices[cat_dim] = cat_dim_offset
@@ -148,8 +117,15 @@ def _is_supported_dst_op_for_first_cat(
     * a view op that is only used by a supported stride op; or
     * a view op that is indirectly (via another single-dst view op) used
       by a supported strided op.
+    Note that technically, this checking is not necessary, because we could
+    let other passes process the likely fusion patterns related to
+    concat + strided_op. However, it seems to be safer if we could add
+    more tests similar to test_fuse_strided_cat_reshape_cat but with different
+    strided ops such as gemm/layernorm/etc. To be conservative, we only
+    enable the following patterns and will remove the restriction once we
+    have more test coverage.
     """
-    view_ops = ["reshape", "flatten", "squeeze", "unsqueeze"]
+    view_ops = ["reshape", "flatten", "dynamic_slice", "squeeze", "unsqueeze"]
     # FIXME: enable other ops with input_accessors
     supported_strided_ops = ["elementwise", "fused_elementwise"]
 
@@ -222,31 +198,11 @@ def _check_first_cat(first_cat: Operator, second_cat: Operator) -> bool:
     for dst_op in first_cat_dst_ops:
         if dst_op is second_cat:
             continue
-        if _is_supported_dst_op_for_first_cat(dst_op):
-            # merging first_cat and second_cat may introduce a cycle
-            if transform_utils.is_ancestor(dst_op, second_cat):
-                return False
-            else:
-                continue
-        dst_op_type = dst_op._attrs["op"]
-        # if we are in the middle of the cat + cat transformation,
-        # we may have slice + strided_op pattern. In such a case, we
-        # need to update the slice with the new start and end indices.
-        if dst_op_type == "dynamic_slice":
-            dst_op_output = dst_op._attrs["outputs"][0]
-            slice_dst_ops = dst_op_output._attrs["dst_ops"]
-            if len(slice_dst_ops) != 1:
-                return False
-            if not _check_slice_op(dst_op, cat_dim):
-                return False
-            slice_dst_op = slice_dst_ops[0]
-            if not _is_supported_dst_op_for_first_cat(slice_dst_op):
-                return False
-            # merging first_cat and second_cat may introduce a cycle
-            if transform_utils.is_ancestor(dst_op, second_cat):
-                return False
-            continue
-        return False
+        if not _is_supported_dst_op_for_first_cat(dst_op):
+            return False
+        # merging first_cat and second_cat may introduce a cycle
+        if transform_utils.is_ancestor(dst_op, second_cat):
+            return False
     return True
 
 
@@ -464,6 +420,119 @@ def _merge_split_and_cat(sorted_graph: List[Tensor]) -> List[Tensor]:  # noqa: C
     return transform_utils.sanitize_sorted_graph(sorted_graph)
 
 
+def _try_merge_slice_slice(
+    first_slice: Operator, second_slice: Operator, slice_dim: int
+) -> bool:
+    """
+    This function tries to merge two consecutive slice ops with the following
+    steps:
+        * update the start_indices and end_indices fields of the second_slice
+        * remove the first slice
+    """
+    first_slice_output = first_slice._attrs["outputs"][0]
+    first_slice_input_shape = first_slice._attrs["inputs"][0].shape()
+    second_slice_output = second_slice._attrs["outputs"][0]
+    second_slice_output_shape = second_slice_output.shape()
+    # note that all the dims of input_shape[slice_dim:] and output_shape[slice_dim:]
+    # are static at this point
+    for idx in range(slice_dim, first_slice_output._rank()):
+        first_slice_dim_offset = first_slice._attrs["start_indices"][idx]
+        # update the start and end indices of the second slice op
+        new_start = second_slice._attrs["start_indices"][idx] + first_slice_dim_offset
+        first_slice_input_dim = first_slice_input_shape[idx].value()
+        # new start index exceeds the corresponding dim value of the first slice input shape
+        if new_start >= first_slice_input_dim:
+            return False
+        new_end = new_start + second_slice_output_shape[idx].value()
+        # new end index exceeds the corresponding dim value of the first slice input shape
+        if new_end > first_slice_input_dim:
+            return False
+        first_slice_end = first_slice._attrs["end_indices"][idx]
+        second_slice_end = second_slice._attrs["end_indices"][idx]
+        if first_slice_end == MAX_INT32 == second_slice_end:
+            new_end = MAX_INT32
+        second_slice._attrs["start_indices"][idx] = new_start
+        second_slice._attrs["end_indices"][idx] = new_end
+    # remove the old strided op from the first cat's dst_ops
+    transform_utils.remove_single_tensor_op_from_sorted_graph(first_slice)
+    return True
+
+
+def _check_slice_op(slice_op: Operator, slice_dim: int) -> bool:
+    """
+    Return True if the slice_op's indices are valid for being merged
+    """
+    slice_shape = slice_op._attrs["outputs"][0].shape()
+    if not shape_utils.all_static_dimensions(slice_shape, slice_dim):
+        return False
+    # we expect normalized start_indices and end_indices
+    start_index = slice_op._attrs["start_indices"][slice_dim]
+    if start_index is None or start_index < 0:
+        return False
+    end_index = slice_op._attrs["end_indices"][slice_dim]
+    if end_index is None or end_index < 0 or end_index <= start_index:
+        return False
+    return True
+
+
+def _get_rightmost_non_dynamic_dim(shape: List[IntVar]) -> Optional[int]:
+    """
+    Return the index of the rightmost non-dynamic dim. For example, given
+    a shape [3, dyn_dim, 4, 1], it would return 2, which is the index of the
+    third dim.
+    Return None if shape[-1] is dynamic.
+    """
+    idx = 0
+    for dim in reversed(shape):
+        if not isinstance(dim, IntImm):
+            break
+        idx += 1
+    if idx == 0:
+        return None
+    return len(shape) - idx
+
+
+def _merge_slice_and_slice(sorted_graph: List[Tensor]) -> List[Tensor]:
+    # a list of tuple(first_slice, second_slice, slice_dim)
+    to_be_merged = []
+    for tensor in sorted_graph:
+        src_ops = tensor._attrs["src_ops"]
+        if len(src_ops) != 1:
+            continue
+        src_op = list(src_ops)[0]
+        if src_op._attrs["op"] != "dynamic_slice":
+            continue
+        first_slice = src_op
+        first_slice_output = first_slice._attrs["outputs"][0]
+        if first_slice_output._attrs["is_output"]:
+            continue
+        slice_dim = _get_rightmost_non_dynamic_dim(first_slice_output.shape())
+        if slice_dim is None:
+            continue
+        if not _check_slice_op(first_slice, slice_dim):
+            continue
+        next_ops = first_slice_output._attrs["dst_ops"]
+        if len(next_ops) != 1:
+            continue
+        next_op = next_ops[0]
+        if next_op._attrs["op"] != "dynamic_slice":
+            continue
+        second_slice = next_op
+        second_slice_output = second_slice._attrs["outputs"][0]
+        if first_slice_output._rank() != second_slice_output._rank():
+            continue
+        second_slice_dim = _get_rightmost_non_dynamic_dim(second_slice_output.shape())
+        if slice_dim != second_slice_dim:
+            continue
+        if not _check_slice_op(second_slice, slice_dim):
+            continue
+        to_be_merged.append([first_slice, second_slice, slice_dim])
+
+    for first_slice, second_slice, slice_dim in to_be_merged:
+        _try_merge_slice_slice(first_slice, second_slice, slice_dim)
+    return transform_utils.sanitize_sorted_graph(sorted_graph)
+
+
 def _eliminate_split_full_idx(sorted_graph: List[Tensor]) -> List[Tensor]:
     for tensor in sorted_graph:
         src_ops = tensor._attrs["src_ops"]
@@ -503,6 +572,7 @@ def transform_memory_ops(
     funcs = [
         _eliminate_split_full_idx,
         _merge_split_and_cat,
+        _merge_slice_and_slice,
         _eliminate_cat,
     ]
     num_ops = None

--- a/python/aitemplate/compiler/transform/transform_memory_ops.py
+++ b/python/aitemplate/compiler/transform/transform_memory_ops.py
@@ -20,8 +20,10 @@ from typing import List
 
 from aitemplate.compiler.base import Operator, Tensor
 
+from aitemplate.compiler.ops.tensor.dynamic_slice import dynamic_slice, MAX_INT32
 from aitemplate.compiler.tensor_accessor import TensorAccessor
-from aitemplate.compiler.transform import transform_utils
+from aitemplate.compiler.transform import transform_strided_ops_utils, transform_utils
+from aitemplate.compiler.transform.toposort import toposort
 
 from aitemplate.utils import graph_utils, shape_utils
 
@@ -56,7 +58,130 @@ def _eliminate_cat(sorted_graph: List[Tensor]) -> List[Tensor]:
     return transform_utils.sanitize_sorted_graph(sorted_graph)
 
 
-def _try_merge_split_cat(first_op: Operator, cat: Operator) -> bool:
+def _check_slice_op(slice_op: Operator, slice_dim: int) -> bool:
+    """
+    Return True if the slice_op's indices are valid for being updated
+    """
+    slice_shape = slice_op._attrs["outputs"][0].shape()
+    if not shape_utils.all_static_dimensions(slice_shape, slice_dim):
+        return False
+    # we expect normalized start_indices and end_indices
+    nested_start_index = slice_op._attrs["start_indices"][slice_dim]
+    if nested_start_index is None or nested_start_index < 0:
+        return False
+    nested_end_index = slice_op._attrs["end_indices"][slice_dim]
+    if (
+        nested_end_index is None
+        or nested_end_index < 0
+        or nested_end_index <= nested_start_index
+    ):
+        return False
+    return True
+
+
+def _update_cat_dst_ops(
+    first_cat: Operator, second_cat: Operator, cat_dim_offset: int
+) -> None:
+    """
+    Add all the strided dst_ops of the first cat to the second and
+    make an appropriate slice op between the second cat and each dst_ops.
+    cat_dim_offset represents the offset of the first cat output appearing
+    in the second cat along the cat_dim dimension.
+    """
+    first_cat_output = first_cat._attrs["outputs"][0]
+    first_cat_dst_ops = first_cat_output._attrs["dst_ops"]
+    # the first cat does not have any strided ops
+    if len(first_cat_dst_ops) <= 1:
+        return
+    first_cat_shape = first_cat_output.shape()
+    rank = len(first_cat_shape)
+    cat_dim = first_cat._attrs["concat_dim"]
+    assert transform_strided_ops_utils.cat_split_dim_is_static(
+        first_cat, cat_dim
+    ), f"expected the {cat_dim=} of {first_cat=} to be static"
+    second_cat_output = second_cat._attrs["outputs"][0]
+    # make start_indices and end_indices for the slice
+    for idx, first_cat_dst_op in enumerate(first_cat_dst_ops):
+        if first_cat_dst_op is second_cat:
+            continue
+        elif first_cat_dst_op._attrs["op"] == "dynamic_slice":
+            # we've inserted a dynamic slice already so we need to update the
+            # start_indices and end_indices
+            slice_op = first_cat_dst_op
+            assert _check_slice_op(slice_op, cat_dim), f"invalid {slice_op=}"
+            slice_op._attrs["start_indices"][cat_dim] += cat_dim_offset
+            if slice_op._attrs["end_indices"][cat_dim] != MAX_INT32:
+                slice_op._attrs["end_indices"][cat_dim] += cat_dim_offset
+            # remove the old strided op from the first cat's dst_ops
+            first_cat_dst_ops.remove(slice_op)
+            slice_op._attrs["inputs"][0] = second_cat_output
+            second_cat_output._attrs["dst_ops"].add(slice_op)
+        else:
+            # make a new slice op
+            slice_start_indices = [0] * rank
+            slice_end_indices = [None] * rank
+            slice_start_indices[cat_dim] = cat_dim_offset
+            slice_end_indices[cat_dim] = (
+                cat_dim_offset + first_cat_shape[cat_dim].value()
+            )
+            slice_op = dynamic_slice()
+            slice_op_name = f'dynamic_slice_{idx}_{first_cat._attrs["name"]}'
+            slice_op._attrs["name"] = slice_op_name
+            slice_op._attrs["original_name"] = slice_op_name
+            slice_output = slice_op(
+                second_cat_output, slice_start_indices, slice_end_indices
+            )
+            slice_output._attrs["name"] = f"{slice_op_name}_0"
+            slice_output._attrs["dst_ops"].add(first_cat_dst_op)
+            # remove the old strided op from first cat's dst_ops
+            first_cat_dst_ops.remove(first_cat_dst_op)
+            # update the strided op's input to the newly-created slice output
+            first_cat_dst_op.replace_input_tensor(first_cat_output, slice_output)
+
+
+def _is_supported_dst_op_for_first_cat(
+    dst_op: Operator,
+) -> bool:
+    """
+    A helper function that returns True if the given dst_op is
+    * a supported strided op; or
+    * a view op that is only used by a supported stride op; or
+    * a view op that is indirectly (via another single-dst view op) used
+      by a supported strided op.
+    """
+    view_ops = ["reshape", "flatten", "squeeze", "unsqueeze"]
+    # FIXME: enable other ops with input_accessors
+    supported_strided_ops = ["elementwise", "fused_elementwise"]
+
+    def _supported_op_type(op_type):
+        if op_type in supported_strided_ops:
+            return True
+        return op_type.startswith("bmm_crr")
+
+    dst_op_type = dst_op._attrs["op"]
+    if _supported_op_type(dst_op_type):
+        return True
+    while dst_op_type in view_ops:
+        dst_op_outputs = dst_op._attrs["outputs"]
+        if len(dst_op_outputs) != 1:
+            return False
+        dst_op_output = dst_op_outputs[0]
+        if dst_op_output._attrs["is_output"]:
+            return False
+        next_dst_ops = dst_op_output._attrs["dst_ops"]
+        if len(next_dst_ops) != 1:
+            return False
+        dst_op = next_dst_ops[0]
+        dst_op_type = dst_op._attrs["op"]
+        if _supported_op_type(dst_op_type):
+            return True
+    return False
+
+
+def _check_first_cat(first_cat: Operator, second_cat: Operator) -> bool:
+    """
+    return True if the first cat is valid for fusion
+    """
     # Make sure input_accessors do not carry any strided information.
     # It may happen. For example, an input of the cat can be of a strided
     # tensor generated by slice, which takes another concat's output.
@@ -66,11 +191,144 @@ def _try_merge_split_cat(first_op: Operator, cat: Operator) -> bool:
     #     y = cat(y1, y2)
     # In such a case, we cannot merge those two concat ops.
     if not all(
+        accessor.actual_shapes is None
+        for accessor in first_cat._attrs["input_accessors"]
+    ):
+        return False
+    if not all(first_cat._attrs["input_masks"]):
+        return False
+
+    # we need to make sure all other dst ops except the second cat have input
+    # accessors for which we may generate valid strided information. We will
+    # leverage the input accessor by injecting a slice op between the merged
+    # cat and the strided op (e.g. add).
+    cat_dim = first_cat._attrs["concat_dim"]
+    first_cat_outputs = first_cat._attrs["outputs"]
+    assert (
+        len(first_cat_outputs) == 1
+    ), f"expected {first_cat_outputs=} to have a single output"
+    first_cat_output = first_cat_outputs[0]
+    first_cat_dst_ops = first_cat_output._attrs["dst_ops"]
+    if len(first_cat_dst_ops) == 1:
+        return True
+    if not transform_strided_ops_utils.cat_split_dim_is_static(first_cat, cat_dim):
+        return False
+    # we cannot leverage slice if any of the dimensions after cat_dim is dynamic
+    if not shape_utils.all_static_dimensions(first_cat_output.shape(), cat_dim):
+        return False
+
+    # we can fuse the first cat into the second only if all of the first cat's
+    # dst ops are valid
+    for dst_op in first_cat_dst_ops:
+        if dst_op is second_cat:
+            continue
+        if _is_supported_dst_op_for_first_cat(dst_op):
+            # merging first_cat and second_cat may introduce a cycle
+            if transform_utils.is_ancestor(dst_op, second_cat):
+                return False
+            else:
+                continue
+        dst_op_type = dst_op._attrs["op"]
+        # if we are in the middle of the cat + cat transformation,
+        # we may have slice + strided_op pattern. In such a case, we
+        # need to update the slice with the new start and end indices.
+        if dst_op_type == "dynamic_slice":
+            dst_op_output = dst_op._attrs["outputs"][0]
+            slice_dst_ops = dst_op_output._attrs["dst_ops"]
+            if len(slice_dst_ops) != 1:
+                return False
+            if not _check_slice_op(dst_op, cat_dim):
+                return False
+            slice_dst_op = slice_dst_ops[0]
+            if not _is_supported_dst_op_for_first_cat(slice_dst_op):
+                return False
+            # merging first_cat and second_cat may introduce a cycle
+            if transform_utils.is_ancestor(dst_op, second_cat):
+                return False
+            continue
+        return False
+    return True
+
+
+def _check_second_cat(cat: Operator) -> bool:
+    """
+    return True if the second cat is valid for fusion
+    """
+    if len(cat._attrs["outputs"]) != 1:
+        return False
+    # Similar to the first cat, make sure the second cat's input_accessors
+    # do not carry any strided information.
+    if not all(
         accessor.actual_shapes is None for accessor in cat._attrs["input_accessors"]
     ):
         return False
-    first_op_inputs = first_op._attrs["inputs"]
-    first_op_outputs = first_op._attrs["outputs"]
+    if not all(cat._attrs["input_masks"]):
+        return False
+    return True
+
+
+def _try_merge_cat_cat(first_cat: Operator, second_cat: Operator) -> bool:
+    if not _check_first_cat(first_cat, second_cat):
+        return False
+    if not _check_second_cat(second_cat):
+        return False
+    first_cat_inputs = first_cat._attrs["inputs"]
+    first_cat_outputs = first_cat._attrs["outputs"]
+    first_cat_output = first_cat_outputs[0]
+    second_cat_inputs = second_cat._attrs["inputs"]
+    second_cat_original_inputs = second_cat._attrs["original_inputs"]
+    new_cat_inputs = []
+    new_cat_original_inputs = []
+    new_cat_input_accessors = []
+    for i, second_cat_input in enumerate(second_cat_inputs):
+        if second_cat_input is first_cat_output:
+            new_cat_inputs.extend(first_cat._attrs["inputs"])
+            first_cat_original_inputs = first_cat._attrs["inputs"]
+            new_cat_original_inputs.extend(first_cat_original_inputs)
+            new_cat_input_accessors.extend(
+                copy.deepcopy(first_cat._attrs["input_accessors"])
+            )
+        else:
+            new_cat_inputs.append(second_cat_input)
+            new_cat_original_inputs.append(second_cat_original_inputs[i])
+            new_cat_input_accessors.append(second_cat._attrs["input_accessors"][i])
+
+    for tensor in new_cat_inputs:
+        if tensor in first_cat_outputs:
+            return False
+
+    # note that we have to compute cat_dim_offset before updating cat's inputs,
+    # because we determine the cat_dim_offset based on its old inputs
+    cat_dim_offset = 0
+    cat_dim = second_cat._attrs["concat_dim"]
+    for second_cat_input in second_cat._attrs["inputs"]:
+        if second_cat_input is first_cat_output:
+            break
+        cat_dim_offset += second_cat_input._size(cat_dim).value()
+
+    second_cat._attrs["inputs"] = new_cat_inputs
+    # make sure all of the input_masks values are True. We may need to
+    # change this part later when we have TensorAccessors, depending on
+    # the order of the transformations.
+    assert all(second_cat._attrs["input_masks"])
+    second_cat._attrs["input_accessors"] = new_cat_input_accessors
+    second_cat._attrs["original_inputs"] = list(new_cat_original_inputs)
+    second_cat._attrs["input_masks"] = [True] * len(new_cat_inputs)
+    for tensor in first_cat_inputs:
+        # the same tensor may be used multiple times
+        tensor._attrs["dst_ops"].discard(first_cat)
+        tensor._attrs["dst_ops"].add(second_cat)
+    # now we can move strided ops from the first cat to the merged cat with
+    # an appropriate slice op between the merged cat and each strided op
+    _update_cat_dst_ops(first_cat, second_cat, cat_dim_offset)
+    transform_utils.remove_tensor_from_sorted_graph(first_cat_output)
+    return True
+
+
+def _try_merge_split_cat(split_op: Operator, cat: Operator) -> bool:
+    # If split_op carries strided input_accessors, we skip it
+    split_op_inputs = split_op._attrs["inputs"]
+    split_op_outputs = split_op._attrs["outputs"]
     cat_inputs = cat._attrs["inputs"]
     cat_original_inputs = cat._attrs["original_inputs"]
     new_cat_inputs = []
@@ -79,29 +337,19 @@ def _try_merge_split_cat(first_op: Operator, cat: Operator) -> bool:
     i = 0
     while i < len(cat_inputs):
         matched = True
-        for j, _ in enumerate(first_op_outputs):
+        for j, _ in enumerate(split_op_outputs):
             if (i + j >= len(cat_inputs)) or (
-                cat_inputs[i + j] is not first_op_outputs[j]
+                cat_inputs[i + j] is not split_op_outputs[j]
             ):
                 matched = False
                 break
         if matched:
-            new_cat_inputs.extend(first_op._attrs["inputs"])
-            # we may not have original_inputs/input_accessors, e.g. if first_op is split
-            if "original_inputs" in first_op._attrs:
-                original_inputs = first_op._attrs["original_inputs"]
-            else:
-                original_inputs = first_op._attrs["inputs"]
-            new_cat_original_inputs.extend(original_inputs)
-            if "input_accessors" in first_op._attrs:
-                new_cat_input_accessors.extend(
-                    copy.deepcopy(first_op._attrs["input_accessors"])
-                )
-            else:
-                new_cat_input_accessors.extend(
-                    [TensorAccessor(t) for t in original_inputs]
-                )
-            i += len(first_op_outputs)
+            # split doens't have "original_inputs" attribute
+            split_op_inputs = split_op._attrs["inputs"]
+            new_cat_inputs.extend(split_op_inputs)
+            new_cat_original_inputs.extend(split_op_inputs)
+            new_cat_input_accessors.extend([TensorAccessor(t) for t in split_op_inputs])
+            i += len(split_op_outputs)
         else:
             new_cat_inputs.append(cat_inputs[i])
             new_cat_original_inputs.append(cat_original_inputs[i])
@@ -109,7 +357,7 @@ def _try_merge_split_cat(first_op: Operator, cat: Operator) -> bool:
             i += 1
 
     for tensor in new_cat_inputs:
-        if tensor in first_op_outputs:
+        if tensor in split_op_outputs:
             return False
 
     cat._attrs["inputs"] = new_cat_inputs
@@ -120,11 +368,10 @@ def _try_merge_split_cat(first_op: Operator, cat: Operator) -> bool:
     cat._attrs["input_accessors"] = new_cat_input_accessors
     cat._attrs["original_inputs"] = list(new_cat_original_inputs)
     cat._attrs["input_masks"] = [True] * len(new_cat_inputs)
-    for tensor in first_op_inputs:
-        # the same tensor may be used multiple times
-        tensor._attrs["dst_ops"].discard(first_op)
+    for tensor in split_op_inputs:
+        tensor._attrs["dst_ops"].discard(split_op)
         tensor._attrs["dst_ops"].add(cat)
-    for tensor in first_op_outputs:
+    for tensor in split_op_outputs:
         transform_utils.remove_tensor_from_sorted_graph(tensor)
     return True
 
@@ -149,7 +396,12 @@ def _merge_split_and_cat(sorted_graph: List[Tensor]) -> List[Tensor]:  # noqa: C
         cat = None
         found_cat_op = True
         for output_t in first_op._attrs["outputs"]:
-            if len(output_t._attrs["dst_ops"]) > 1:
+            # TODO: currently, we only allow concatenate output with multiple dst_ops.
+            # We may need to extend it to split ops.
+            if (
+                len(output_t._attrs["dst_ops"]) > 1
+                and first_op._attrs["op"] != "concatenate"
+            ):
                 found_cat_op = False
                 break
             # If first op is output, it can't be fused.
@@ -157,12 +409,14 @@ def _merge_split_and_cat(sorted_graph: List[Tensor]) -> List[Tensor]:  # noqa: C
                 found_cat_op = False
                 continue
             next_ops = output_t._attrs["dst_ops"]
-            if len(next_ops) != 1:
+            if len(next_ops) == 0:
                 break
-            next_op = list(next_ops)[0]
-            if next_op._attrs["op"] != "concatenate":
+            next_concats = [n for n in next_ops if n._attrs["op"] == "concatenate"]
+            # only support cases where first_cat is consumed by a single concat
+            if len(next_concats) != 1:
                 found_cat_op = False
                 break
+            next_op = next_concats[0]
             if cat is None:
                 cat = next_op
             if next_op is not cat:
@@ -181,11 +435,31 @@ def _merge_split_and_cat(sorted_graph: List[Tensor]) -> List[Tensor]:  # noqa: C
             continue
 
         to_be_merged_ops.append([first_op, cat])
+        # only add first_op to the visited set to cases where
+        # we may have chained concat cases:
+        #     concat_0 = concat(x0...)
+        #     concat_1 = concat(concat_0...)
+        #     concat_2 = concat(concat_1...)
+        # where merging concat_0 and concat_1 is invalid but merging concat_1
+        # and concat_2 is valid. If we include both first_op and cat into
+        # the visited set, we would miss the opportunity of merging concat_1
+        # and concat_2.
         visited.add(first_op)
-        visited.add(cat)
 
+    updated_cat_cat = False
     for ops in to_be_merged_ops:
-        _try_merge_split_cat(ops[0], ops[1])
+        first_op_type = ops[0]._attrs["op"]
+        if first_op_type == "split":
+            _try_merge_split_cat(ops[0], ops[1])
+        elif first_op_type == "concatenate":
+            if _try_merge_cat_cat(ops[0], ops[1]):
+                updated_cat_cat = True
+        else:
+            raise AssertionError(f"unsupported {first_op_type=} for merging with cat")
+
+    # we adjusted input/output dependencies so need to run toposort again
+    if updated_cat_cat:
+        sorted_graph = toposort(sorted_graph)
 
     return transform_utils.sanitize_sorted_graph(sorted_graph)
 

--- a/python/aitemplate/compiler/transform/transform_merge_slice_ops.py
+++ b/python/aitemplate/compiler/transform/transform_merge_slice_ops.py
@@ -1,0 +1,138 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+This file implements a pass that merges consecutive slice ops if possible.
+"""
+from typing import List, Optional
+
+from aitemplate.compiler.base import IntImm, IntVar, Operator, Tensor
+
+from aitemplate.compiler.ops.tensor.dynamic_slice import MAX_INT32
+from aitemplate.compiler.transform import transform_utils
+
+from aitemplate.utils import shape_utils
+
+
+def _try_merge_slice_slice(
+    first_slice: Operator, second_slice: Operator, slice_dim: int
+) -> bool:
+    """
+    This function tries to merge two consecutive slice ops with the following
+    steps:
+        * update the start_indices and end_indices fields of the second_slice
+        * remove the first slice
+    """
+    first_slice_output = first_slice._attrs["outputs"][0]
+    first_slice_input_shape = first_slice._attrs["inputs"][0].shape()
+    second_slice_output = second_slice._attrs["outputs"][0]
+    second_slice_output_shape = second_slice_output.shape()
+    # note that all the dims of input_shape[slice_dim:] and output_shape[slice_dim:]
+    # are static at this point
+    for idx in range(slice_dim, first_slice_output._rank()):
+        first_slice_dim_offset = first_slice._attrs["start_indices"][idx]
+        # update the start and end indices of the second slice op
+        new_start = second_slice._attrs["start_indices"][idx] + first_slice_dim_offset
+        first_slice_input_dim = first_slice_input_shape[idx].value()
+        # new start index exceeds the corresponding dim value of the first slice input shape
+        if new_start >= first_slice_input_dim:
+            return False
+        new_end = new_start + second_slice_output_shape[idx].value()
+        # new end index exceeds the corresponding dim value of the first slice input shape
+        if new_end > first_slice_input_dim:
+            return False
+        first_slice_end = first_slice._attrs["end_indices"][idx]
+        second_slice_end = second_slice._attrs["end_indices"][idx]
+        if first_slice_end == MAX_INT32 == second_slice_end:
+            new_end = MAX_INT32
+        second_slice._attrs["start_indices"][idx] = new_start
+        second_slice._attrs["end_indices"][idx] = new_end
+    # remove the old strided op from the first cat's dst_ops
+    transform_utils.remove_single_tensor_op_from_sorted_graph(first_slice)
+    return True
+
+
+def _check_slice_op(slice_op: Operator, slice_dim: int) -> bool:
+    """
+    Return True if the slice_op's indices are valid for being merged
+    """
+    slice_shape = slice_op._attrs["outputs"][0].shape()
+    if not shape_utils.all_static_dimensions(slice_shape, slice_dim):
+        return False
+    # we expect normalized start_indices and end_indices
+    start_index = slice_op._attrs["start_indices"][slice_dim]
+    if start_index is None or start_index < 0:
+        return False
+    end_index = slice_op._attrs["end_indices"][slice_dim]
+    if end_index is None or end_index < 0 or end_index <= start_index:
+        return False
+    return True
+
+
+def _get_rightmost_non_dynamic_dim(shape: List[IntVar]) -> Optional[int]:
+    """
+    Return the index of the rightmost non-dynamic dim. For example, given
+    a shape [3, dyn_dim, 4, 1], it would return 2, which is the index of the
+    third dim.
+    Return None if shape[-1] is dynamic.
+    """
+    idx = 0
+    for dim in reversed(shape):
+        if not isinstance(dim, IntImm):
+            break
+        idx += 1
+    if idx == 0:
+        return None
+    return len(shape) - idx
+
+
+def merge_slice_ops(sorted_graph: List[Tensor]) -> List[Tensor]:
+    # a list of tuple(first_slice, second_slice, slice_dim)
+    to_be_merged = []
+    for tensor in sorted_graph:
+        src_ops = tensor._attrs["src_ops"]
+        if len(src_ops) != 1:
+            continue
+        src_op = list(src_ops)[0]
+        if src_op._attrs["op"] != "dynamic_slice":
+            continue
+        first_slice = src_op
+        first_slice_output = first_slice._attrs["outputs"][0]
+        if first_slice_output._attrs["is_output"]:
+            continue
+        slice_dim = _get_rightmost_non_dynamic_dim(first_slice_output.shape())
+        if slice_dim is None:
+            continue
+        if not _check_slice_op(first_slice, slice_dim):
+            continue
+        next_ops = first_slice_output._attrs["dst_ops"]
+        if len(next_ops) != 1:
+            continue
+        next_op = next_ops[0]
+        if next_op._attrs["op"] != "dynamic_slice":
+            continue
+        second_slice = next_op
+        second_slice_output = second_slice._attrs["outputs"][0]
+        if first_slice_output._rank() != second_slice_output._rank():
+            continue
+        second_slice_dim = _get_rightmost_non_dynamic_dim(second_slice_output.shape())
+        if slice_dim != second_slice_dim:
+            continue
+        if not _check_slice_op(second_slice, slice_dim):
+            continue
+        to_be_merged.append([first_slice, second_slice, slice_dim])
+
+    for first_slice, second_slice, slice_dim in to_be_merged:
+        _try_merge_slice_slice(first_slice, second_slice, slice_dim)
+    return transform_utils.sanitize_sorted_graph(sorted_graph)

--- a/tests/unittest/compiler/test_merge_slice_ops.py
+++ b/tests/unittest/compiler/test_merge_slice_ops.py
@@ -1,0 +1,519 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import unittest
+
+import torch
+
+from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler.ops.common.epilogue import FuncEnum
+from aitemplate.frontend import IntImm, Tensor
+from aitemplate.testing import detect_target
+from aitemplate.testing.test_utils import (
+    get_random_torch_tensor,
+    get_torch_empty_tensor,
+)
+from aitemplate.utils import graph_utils, shape_utils
+
+
+class MergeSliceOpsTestCase(unittest.TestCase):
+    BATCH_SIZE = 1024
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        torch.manual_seed(0)
+
+    def __init__(self, *args, **kwargs):
+        super(MergeSliceOpsTestCase, self).__init__(*args, **kwargs)
+        self.test_count = 0
+
+    def _test_slice_slice_basic(
+        self,
+        M0,
+        N0,
+        first_slice_start_indices,
+        first_slice_end_indices,
+        second_slice_start_indices,
+        second_slice_end_indices,
+        expected_ops_cnt,
+        expected_slice_cnt,
+        test_name,
+        dtype="float16",
+    ):
+        # make a graph like below
+        # add_0 = add(x0, x1)
+        # slice_1 = slice(add_0)
+        # slice_2 = slice(slice_1)
+        # y = concat(x2, slice_2)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N0)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N0)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+
+        add_0 = ops.elementwise(FuncEnum.ADD)(X0, X1)
+        slice_1 = ops.dynamic_slice()(
+            add_0,
+            start_indices=first_slice_start_indices,
+            end_indices=first_slice_end_indices,
+        )
+        slice_2 = ops.dynamic_slice()(
+            slice_1,
+            start_indices=second_slice_start_indices,
+            end_indices=second_slice_end_indices,
+        )
+        M2 = 3
+        N2 = slice_2.shape()[-1].value()
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2), IntImm(N2)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        cat_dim = 1
+        Y = ops.concatenate()([X2, slice_2], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), expected_ops_cnt)
+        slice_ops = [op for op in sorted_ops if op._attrs["op"] == "dynamic_slice"]
+        self.assertEqual(len(slice_ops), expected_slice_cnt)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0, N0], dtype)
+            x1_pt = get_random_torch_tensor([batch, M0, N0], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2, N2], dtype)
+
+            first_slice_indices = [
+                slice(i, j)
+                for i, j in zip(first_slice_start_indices, first_slice_end_indices)
+            ]
+            second_slice_indices = [
+                slice(i, j)
+                for i, j in zip(second_slice_start_indices, second_slice_end_indices)
+            ]
+            add_0_pt = x0_pt + x1_pt
+            slice_1_pt = add_0_pt[first_slice_indices]
+            slice_2_pt = slice_1_pt[second_slice_indices]
+            y_pt = torch.cat([x2_pt, slice_2_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {
+                "x0": x0_pt,
+                "x1": x1_pt,
+                "x2": x2_pt,
+            }
+            outputs = [y]
+            module.run_with_tensors(inputs, outputs)
+            torch.testing.assert_close(y_pt, y, atol=1e-2, rtol=1e-2)
+
+    def test_slice_slice_basic(self):
+        self._test_slice_slice_basic(
+            M0=10,
+            N0=18,
+            first_slice_start_indices=[0, 2, 1],
+            first_slice_end_indices=[None, None, 15],
+            second_slice_start_indices=[0, 1, 3],
+            second_slice_end_indices=[None, None, 5],
+            expected_ops_cnt=3,
+            expected_slice_cnt=1,
+            test_name="slice_slice_basic_0",
+            dtype="float16",
+        )
+        self._test_slice_slice_basic(
+            M0=10,
+            N0=18,
+            first_slice_start_indices=[0, 2, 0],
+            first_slice_end_indices=[None, 10, None],
+            second_slice_start_indices=[0, 2, 0],
+            second_slice_end_indices=[None, 4, None],
+            expected_ops_cnt=2,
+            expected_slice_cnt=0,
+            test_name="slice_slice_basic_1",
+            dtype="float16",
+        )
+        self._test_slice_slice_basic(
+            M0=10,
+            N0=18,
+            first_slice_start_indices=[0, 2, 3],
+            first_slice_end_indices=[None, 10, 12],
+            second_slice_start_indices=[0, 2, 1],
+            second_slice_end_indices=[None, None, 6],
+            expected_ops_cnt=3,
+            expected_slice_cnt=1,
+            test_name="slice_slice_basic_2",
+            dtype="float16",
+        )
+
+    def _test_slice_slice_2(
+        self,
+        M0,
+        N0,
+        first_slice_start_indices,
+        first_slice_end_indices,
+        second_slice_start_indices,
+        second_slice_end_indices,
+        third_slice_start_indices,
+        third_slice_end_indices,
+        expected_ops_cnt,
+        expected_slice_cnt,
+        test_name,
+        dtype="float16",
+    ):
+        # make a graph like below
+        # add_0 = add(x0, x1)
+        # slice_1 = slice(add_0)
+        # slice_2 = slice(slice_1)
+        # slice_3 = slice(slice_2)
+        # y = add(slice_3, x2)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N0)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N0)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+
+        add_0 = ops.elementwise(FuncEnum.ADD)(X0, X1)
+        slice_1 = ops.dynamic_slice()(
+            add_0,
+            start_indices=first_slice_start_indices,
+            end_indices=first_slice_end_indices,
+        )
+        slice_2 = ops.dynamic_slice()(
+            slice_1,
+            start_indices=second_slice_start_indices,
+            end_indices=second_slice_end_indices,
+        )
+        slice_3 = ops.dynamic_slice()(
+            slice_2,
+            start_indices=third_slice_start_indices,
+            end_indices=third_slice_end_indices,
+        )
+        M2 = slice_3.shape()[-2].value()
+        N2 = slice_3.shape()[-1].value()
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2), IntImm(N2)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        Y = ops.elementwise(FuncEnum.ADD)(slice_3, X2)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), expected_ops_cnt)
+        slice_ops = [op for op in sorted_ops if op._attrs["op"] == "dynamic_slice"]
+        self.assertEqual(len(slice_ops), expected_slice_cnt)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0, N0], dtype)
+            x1_pt = get_random_torch_tensor([batch, M0, N0], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2, N2], dtype)
+
+            first_slice_indices = [
+                slice(i, j)
+                for i, j in zip(first_slice_start_indices, first_slice_end_indices)
+            ]
+            second_slice_indices = [
+                slice(i, j)
+                for i, j in zip(second_slice_start_indices, second_slice_end_indices)
+            ]
+            third_slice_indices = [
+                slice(i, j)
+                for i, j in zip(third_slice_start_indices, third_slice_end_indices)
+            ]
+            add_0_pt = x0_pt + x1_pt
+            slice_1_pt = add_0_pt[first_slice_indices]
+            slice_2_pt = slice_1_pt[second_slice_indices]
+            slice_3_pt = slice_2_pt[third_slice_indices]
+            y_pt = slice_3_pt + x2_pt
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {
+                "x0": x0_pt,
+                "x1": x1_pt,
+                "x2": x2_pt,
+            }
+            outputs = [y]
+            module.run_with_tensors(inputs, outputs)
+            torch.testing.assert_close(y_pt, y, atol=1e-2, rtol=1e-2)
+
+    def test_slice_slice_2(self):
+        self._test_slice_slice_2(
+            M0=20,
+            N0=30,
+            first_slice_start_indices=[0, 1, 2],
+            first_slice_end_indices=[None, 15, 28],
+            second_slice_start_indices=[0, 2, 2],
+            second_slice_end_indices=[None, 10, 9],
+            third_slice_start_indices=[0, 2, 1],
+            third_slice_end_indices=[None, 5, 3],
+            expected_ops_cnt=3,
+            expected_slice_cnt=1,
+            test_name="slice_slice_2",
+            dtype="float16",
+        )
+        self._test_slice_slice_2(
+            M0=20,
+            N0=30,
+            first_slice_start_indices=[0, 1, 2],
+            first_slice_end_indices=[None, 15, 28],
+            second_slice_start_indices=[0, 2, 2],
+            second_slice_end_indices=[None, None, 9],
+            third_slice_start_indices=[0, 2, 1],
+            third_slice_end_indices=[None, 5, None],
+            expected_ops_cnt=3,
+            expected_slice_cnt=1,
+            test_name="slice_slice_2",
+            dtype="float16",
+        )
+
+    def _test_slice_slice_3(
+        self,
+        input_shape,
+        first_slice_start_indices,
+        first_slice_end_indices,
+        second_slice_start_indices,
+        second_slice_end_indices,
+        expected_ops_cnt,
+        expected_slice_cnt,
+        test_name,
+        dtype="float16",
+    ):
+        # make a graph like below
+        # add_0 = add(x0, x0)
+        # slice_1 = slice(add_0)
+        # Y = slice(slice_1)
+        X0 = Tensor(
+            shape=input_shape,
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+
+        add_0 = ops.elementwise(FuncEnum.ADD)(X0, X0)
+        slice_1 = ops.dynamic_slice()(
+            add_0,
+            start_indices=first_slice_start_indices,
+            end_indices=first_slice_end_indices,
+        )
+        Y = ops.dynamic_slice()(
+            slice_1,
+            start_indices=second_slice_start_indices,
+            end_indices=second_slice_end_indices,
+        )
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), expected_ops_cnt)
+        slice_ops = [op for op in sorted_ops if op._attrs["op"] == "dynamic_slice"]
+        self.assertEqual(len(slice_ops), expected_slice_cnt)
+
+        x0_pt = get_random_torch_tensor(input_shape, dtype)
+
+        first_slice_indices = [
+            slice(i, j)
+            for i, j in zip(first_slice_start_indices, first_slice_end_indices)
+        ]
+        second_slice_indices = [
+            slice(i, j)
+            for i, j in zip(second_slice_start_indices, second_slice_end_indices)
+        ]
+        add_0_pt = x0_pt + x0_pt
+        slice_1_pt = add_0_pt[first_slice_indices]
+        y_pt = slice_1_pt[second_slice_indices]
+
+        y = get_torch_empty_tensor(y_pt.size(), dtype)
+        inputs = {"x0": x0_pt}
+        outputs = [y]
+        module.run_with_tensors(inputs, outputs)
+        torch.testing.assert_close(y_pt, y, atol=1e-2, rtol=1e-2)
+
+    def test_slice_slice_3(self):
+        self._test_slice_slice_3(
+            input_shape=[2, 3, 2],
+            first_slice_start_indices=[0, 1, 0],
+            first_slice_end_indices=[None, 2, None],
+            second_slice_start_indices=[0, 0, 1],
+            second_slice_end_indices=[None, None, 2],
+            expected_ops_cnt=2,
+            expected_slice_cnt=1,
+            test_name="slice_slice_3",
+            dtype="float16",
+        )
+        self._test_slice_slice_3(
+            input_shape=[2, 1, 10, 10, 10],
+            first_slice_start_indices=[0, 0, 1, 0, 0],
+            first_slice_end_indices=[None, None, -1, None, None],
+            second_slice_start_indices=[0, 0, 0, 1, 0],
+            second_slice_end_indices=[None, None, None, 2, None],
+            expected_ops_cnt=2,
+            expected_slice_cnt=1,
+            test_name="slice_slice_3",
+            dtype="float16",
+        )
+
+    def _test_non_fusible_slice_slice(
+        self,
+        M0,
+        N0,
+        first_slice_start_indices,
+        first_slice_end_indices,
+        second_slice_start_indices,
+        second_slice_end_indices,
+        expected_ops_cnt,
+        expected_slice_cnt,
+        test_name,
+        dtype="float16",
+    ):
+        # make a graph like below
+        # add_0 = add(x0, x1)
+        # slice_1 = slice(add_0)
+        # slice_2 = slice(slice_1)
+        # y = concat(x2, slice_1, slice_2)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N0)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N0)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+
+        add_0 = ops.elementwise(FuncEnum.ADD)(X0, X1)
+        slice_1 = ops.dynamic_slice()(
+            add_0,
+            start_indices=first_slice_start_indices,
+            end_indices=first_slice_end_indices,
+        )
+        slice_1_N = slice_1.shape()[-1].value()
+        slice_2 = ops.dynamic_slice()(
+            slice_1,
+            start_indices=second_slice_start_indices,
+            end_indices=second_slice_end_indices,
+        )
+        M2 = 3
+        N2 = slice_2.shape()[-1].value()
+        assert N0 == slice_1_N == N2, f"expected {N0=} == {slice_1_N=} == {N2=}"
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2), IntImm(N2)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        cat_dim = 1
+        Y = ops.concatenate()([X2, slice_1, slice_2], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), expected_ops_cnt)
+        slice_ops = [op for op in sorted_ops if op._attrs["op"] == "dynamic_slice"]
+        self.assertEqual(len(slice_ops), expected_slice_cnt)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0, N0], dtype)
+            x1_pt = get_random_torch_tensor([batch, M0, N0], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2, N2], dtype)
+
+            first_slice_indices = [
+                slice(i, j)
+                for i, j in zip(first_slice_start_indices, first_slice_end_indices)
+            ]
+            second_slice_indices = [
+                slice(i, j)
+                for i, j in zip(second_slice_start_indices, second_slice_end_indices)
+            ]
+            add_0_pt = x0_pt + x1_pt
+            slice_1_pt = add_0_pt[first_slice_indices]
+            slice_2_pt = slice_1_pt[second_slice_indices]
+            y_pt = torch.cat([x2_pt, slice_1_pt, slice_2_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {
+                "x0": x0_pt,
+                "x1": x1_pt,
+                "x2": x2_pt,
+            }
+            outputs = [y]
+            module.run_with_tensors(inputs, outputs)
+            torch.testing.assert_close(y_pt, y, atol=1e-2, rtol=1e-2)
+
+    def test_non_fusible_slice_slice(self):
+        self._test_non_fusible_slice_slice(
+            M0=10,
+            N0=18,
+            first_slice_start_indices=[0, 2, 0],
+            first_slice_end_indices=[None, 10, None],
+            second_slice_start_indices=[0, 2, 0],
+            second_slice_end_indices=[None, 4, None],
+            expected_ops_cnt=3,
+            expected_slice_cnt=1,
+            test_name="slice_slice_non_fusible",
+            dtype="float16",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/compiler/test_transform_memory_ops.py
+++ b/tests/unittest/compiler/test_transform_memory_ops.py
@@ -17,13 +17,14 @@ import unittest
 import torch
 
 from aitemplate.compiler import compile_model, ops, transform
+from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntImm, IntVar, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
     get_random_torch_tensor,
     get_torch_empty_tensor,
 )
-from aitemplate.utils import graph_utils
+from aitemplate.utils import graph_utils, shape_utils
 
 from parameterized import parameterized
 
@@ -33,6 +34,10 @@ class MemoryOpTransformationTestCase(unittest.TestCase):
     M = 10
     N = 128
     USE_DYNAMIC_BATCH = False
+
+    def __init__(self, *args, **kwargs):
+        super(MemoryOpTransformationTestCase, self).__init__(*args, **kwargs)
+        self.test_count = 0
 
     def _prepare_cat_elimination_graph(self, dtype="float16"):
         X0 = Tensor(
@@ -469,6 +474,562 @@ class MemoryOpTransformationTestCase(unittest.TestCase):
         )
         self.assertTrue(torch.allclose(out_pt0, out0, atol=1e-1, rtol=1e-2))
         self.assertTrue(torch.allclose(out_pt1, out1, atol=1e-1, rtol=1e-2))
+
+    def _test_fuse_strided_cat_cat(self, M0, M1, N, test_name, dtype="float16"):
+        # make a graph like below:
+        # concat_0 = concatenate(x0, x1)
+        # add_1 = add(concat_0, x2)
+        # concat_2 = concatenate(x0, concat_0)
+        # reduce_3 = reduce_sum(add_1)
+        # reduce_4 = reduce_sum(concat_2)
+        # y = add(reduce_3, reduce_4)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1), IntImm(N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        M2 = M0 + M1
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2), IntImm(N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        cat_dim = 1
+        concat_0 = ops.concatenate()([X0, X1], dim=cat_dim)
+        add_1 = ops.elementwise(FuncEnum.ADD)(concat_0, X2)
+        concat_2 = ops.concatenate()([X0, concat_0], dim=cat_dim)
+        reduce_dim = cat_dim
+        reduce_3 = ops.reduce_sum(reduce_dim)(add_1)
+        reduce_4 = ops.reduce_sum(reduce_dim)(concat_2)
+        Y = ops.elementwise(FuncEnum.ADD)(reduce_3, reduce_4)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 5)
+        concat_cnt = 0
+        for sorted_op in sorted_ops:
+            op_type = sorted_op._attrs["op"]
+            # dynamic_slice is fused into add
+            self.assertTrue(op_type != "dynamic_slice")
+            if op_type == "concatenate":
+                concat_cnt += 1
+        self.assertEqual(concat_cnt, 1)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0, N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1, N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2, N], dtype)
+
+            concat_0_pt = torch.cat([x0_pt, x1_pt], dim=cat_dim)
+            add_1_pt = concat_0_pt + x2_pt
+            concat_2_pt = torch.cat([x0_pt, concat_0_pt], dim=cat_dim)
+            reduce_3_pt = torch.sum(add_1_pt, reduce_dim)
+            reduce_4_pt = torch.sum(concat_2_pt, reduce_dim)
+            y_pt = reduce_3_pt + reduce_4_pt
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {
+                "x0": x0_pt,
+                "x1": x1_pt,
+                "x2": x2_pt,
+            }
+            outputs = [y]
+            module.run_with_tensors(inputs, outputs)
+            torch.testing.assert_close(y_pt, y, atol=0.1, rtol=0.1)
+
+    def test_fuse_strided_cat_cat(self):
+        self._test_fuse_strided_cat_cat(
+            M0=3,
+            M1=4,
+            N=9,
+            test_name="test_fuse_strided_cat_cat",
+        )
+        self._test_fuse_strided_cat_cat(
+            M0=2,
+            M1=4,
+            N=8,
+            test_name="test_fuse_strided_cat_cat",
+        )
+
+    def _test_fuse_strided_cat_reshape_cat(
+        self, M0, M1, M3, N, test_name, dtype="float16"
+    ):
+        # make a graph like below:
+        # concat_0 = concatenate(x0, x1)
+        # reshape_1 = reshape(concat_0)
+        # add_2 = add(reshape_1, x2)
+        # concat_3 = concatenate(x0, reshape_1)
+        # reduce_4 = reduce_sum(add_2)
+        # reduce_5 = reduce_sum(concat_3)
+        # y = add(reduce_4, reduce_5)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1), IntImm(N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        M2 = M0 + M1
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2 * N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        X3 = Tensor(
+            shape=[batch_dim, IntImm(M3 * N)],
+            dtype=dtype,
+            name="x3",
+            is_input=True,
+        )
+        cat_dim = 1
+        concat_0 = ops.concatenate()([X0, X1], dim=cat_dim)
+        reshape_to_shape_1 = [-1, M2 * N]
+        reshape_1 = ops.reshape()(concat_0, reshape_to_shape_1)
+        add_2 = ops.elementwise(FuncEnum.ADD)(reshape_1, X2)
+        concat_3 = ops.concatenate()([X3, reshape_1], dim=cat_dim)
+        reduce_dim = cat_dim
+        reduce_4 = ops.reduce_sum(reduce_dim)(add_2)
+        reduce_5 = ops.reduce_sum(reduce_dim)(concat_3)
+        Y = ops.elementwise(FuncEnum.ADD)(reduce_4, reduce_5)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 5)
+        concat_cnt = 0
+        for sorted_op in sorted_ops:
+            op_type = sorted_op._attrs["op"]
+            # dynamic_slice is fused into add
+            self.assertTrue(op_type != "dynamic_slice")
+            if op_type == "concatenate":
+                concat_cnt += 1
+        self.assertEqual(concat_cnt, 1)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0, N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1, N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2 * N], dtype)
+            x3_pt = get_random_torch_tensor([batch, M3 * N], dtype)
+
+            concat_0_pt = torch.cat([x0_pt, x1_pt], dim=cat_dim)
+            reshape_1_pt = torch.reshape(concat_0_pt, reshape_to_shape_1)
+            add_2_pt = reshape_1_pt + x2_pt
+            concat_3_pt = torch.cat([x3_pt, reshape_1_pt], dim=cat_dim)
+            reduce_4_pt = torch.sum(add_2_pt, reduce_dim)
+            reduce_5_pt = torch.sum(concat_3_pt, reduce_dim)
+            y_pt = reduce_4_pt + reduce_5_pt
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {
+                "x0": x0_pt,
+                "x1": x1_pt,
+                "x2": x2_pt,
+                "x3": x3_pt,
+            }
+            outputs = [y]
+            module.run_with_tensors(inputs, outputs)
+            torch.testing.assert_close(y_pt, y, atol=0.1, rtol=0.1)
+
+    def test_fuse_strided_cat_reshape_cat(self):
+        self._test_fuse_strided_cat_reshape_cat(
+            M0=2,
+            M1=4,
+            M3=3,
+            N=8,
+            test_name="test_fuse_strided_cat_reshape_cat",
+        )
+
+    def _test_fuse_strided_cat_reshape_cat_2(
+        self, M0, M1, M2, M3, N, test_name, dtype="float16"
+    ):
+        # make a graph like below:
+        # add_0 = add(x0, x1)  # 2d
+        # concat_1 = concatenate(add_0, x2) # 2d
+        # reshape_2 = reshape(concat_1) # 3d
+        # add_3 = add(reshape_2, x4) # 3d
+        # concat_4 = concatenate(x3, reshape_2, x3) # 3d
+        # reshape_5 = reshape(concat_4) # 2d
+        # add_6 = add(reshape_5, x6) # 2d
+        # concat_7 = concatenate(x0, reshape_5, x0)
+        # reshape_8 = reshape(add_3) # 2d
+        # reduce_9 = reduce_sum(reshape_8)
+        # reduce_10 = reduce_sum(add_6)
+        # reduce_11 = reduce_sum(concat_7)
+        # add_12 = add(reduce_9, reduce_10)
+        # y = add(add_12, reduce_11)
+        assert M0 == M1, f"expected {M0=} to be equal to {M1=}"
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0 * N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1 * N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2 * N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        X3 = Tensor(
+            shape=[batch_dim, IntImm(M3), IntImm(N)],
+            dtype=dtype,
+            name="x3",
+            is_input=True,
+        )
+        M4 = M0 + M2
+        X4 = Tensor(
+            shape=[batch_dim, IntImm(M4), IntImm(N)],
+            dtype=dtype,
+            name="x4",
+            is_input=True,
+        )
+        cat_dim = 1
+        add_0 = ops.elementwise(FuncEnum.ADD)(X0, X1)
+        concat_1 = ops.concatenate()([add_0, X2], dim=cat_dim)
+        reshape_2 = ops.reshape()(concat_1, [-1, M0 + M2, N])
+        add_3 = ops.elementwise(FuncEnum.ADD)(reshape_2, X4)
+        concat_4 = ops.concatenate()([X3, reshape_2, X3], dim=cat_dim)  # 3d
+        reshape_to_shape_5 = (
+            sum([t.shape()[cat_dim].value() for t in [X3, reshape_2, X3]]) * N
+        )
+        reshape_5 = ops.reshape()(concat_4, [-1, reshape_to_shape_5])  # 2d
+        X6 = Tensor(
+            shape=[batch_dim, IntImm(reshape_to_shape_5)],
+            dtype=dtype,
+            name="x6",
+            is_input=True,
+        )
+        add_6 = ops.elementwise(FuncEnum.ADD)(reshape_5, X6)
+        concat_7 = ops.concatenate()([X0, reshape_5, X0], dim=cat_dim)  # 2d
+        reshape_8 = ops.reshape()(add_3, [-1, (M0 + M2) * N])  # 2d
+        reduce_dim = cat_dim
+        reduce_9 = ops.reduce_sum(reduce_dim)(reshape_8)
+        reduce_10 = ops.reduce_sum(reduce_dim)(add_6)
+        reduce_11 = ops.reduce_sum(reduce_dim)(concat_7)
+        add_12 = ops.elementwise(FuncEnum.ADD)(reduce_9, reduce_10)
+        Y = ops.elementwise(FuncEnum.ADD)(add_12, reduce_11)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 8)
+        concat_cnt = 0
+        for sorted_op in sorted_ops:
+            op_type = sorted_op._attrs["op"]
+            # dynamic_slice is fused into add
+            self.assertTrue(op_type != "dynamic_slice")
+            if op_type == "concatenate":
+                concat_cnt += 1
+        self.assertEqual(concat_cnt, 1)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0 * N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1 * N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2 * N], dtype)
+            x3_pt = get_random_torch_tensor([batch, M3, N], dtype)
+            x4_pt = get_random_torch_tensor([batch, M4, N], dtype)
+            x6_pt = get_random_torch_tensor([batch, reshape_to_shape_5], dtype)
+            add_0_pt = x0_pt + x1_pt
+            concat_1_pt = torch.cat([add_0_pt, x2_pt], dim=cat_dim)
+            reshape_2_pt = torch.reshape(concat_1_pt, [-1, M0 + M2, N])
+            add_3_pt = reshape_2_pt + x4_pt
+            concat_4_pt = torch.cat([x3_pt, reshape_2_pt, x3_pt], dim=cat_dim)
+            reshape_5_pt = torch.reshape(concat_4_pt, [-1, reshape_to_shape_5])
+            add_6_pt = reshape_5_pt + x6_pt
+            concat_7_pt = torch.cat([x0_pt, reshape_5_pt, x0_pt], dim=cat_dim)
+            reshape_8_pt = torch.reshape(add_3_pt, [-1, (M0 + M2) * N])
+            reduce_9_pt = torch.sum(reshape_8_pt, reduce_dim)
+            reduce_10_pt = torch.sum(add_6_pt, reduce_dim)
+            reduce_11_pt = torch.sum(concat_7_pt, reduce_dim)
+            add_12_pt = reduce_9_pt + reduce_10_pt
+            y_pt = add_12_pt + reduce_11_pt
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {
+                "x0": x0_pt,
+                "x1": x1_pt,
+                "x2": x2_pt,
+                "x3": x3_pt,
+                "x4": x4_pt,
+                "x6": x6_pt,
+            }
+            outputs = [y]
+            module.run_with_tensors(inputs, outputs)
+            torch.testing.assert_close(y_pt, y, atol=0.1, rtol=0.1)
+
+    def test_fuse_strided_cat_reshape_cat_2(self):
+        self._test_fuse_strided_cat_reshape_cat_2(
+            M0=2,
+            M1=2,
+            M2=2,
+            M3=1,
+            N=2,
+            test_name="test_fuse_strided_cat_reshape_cat_2",
+        )
+
+    def _test_fuse_strided_cat_reshape_cat_3(
+        self, M0, M1, M2, M3, N, test_name, dtype="float16"
+    ):
+        # make a graph like below:
+        # add_0 = add(x0, x1)  # 2d
+        # concat_1 = concatenate(add_0, x2) # 2d
+        # reshape_2 = reshape(concat_1) # 3d
+        # add_3 = add(reshape_2, x4) # 3d
+        # concat_4 = concatenate(x3, concat_1, x3) # 2d
+        # reshape_5 = reshape(concat_4) # 2d
+        # add_6 = add(reshape_5, x6) # 2d
+        # concat_7 = concatenate(x0, reshape_5, x0)
+        # reshape_8 = reshape(add_3) # 2d
+        # reduce_9 = reduce_sum(reshape_8)
+        # reduce_10 = reduce_sum(add_6)
+        # reduce_11 = reduce_sum(concat_7)
+        # add_12 = add(reduce_9, reduce_10)
+        # y = add(add_12, reduce_11)
+        assert M0 == M1, f"expected {M0=} to be equal to {M1=}"
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0 * N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M1 * N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M2 * N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        X3 = Tensor(
+            shape=[batch_dim, IntImm(M3), IntImm(N)],
+            dtype=dtype,
+            name="x3",
+            is_input=True,
+        )
+        M4 = M0 + M2
+        X4 = Tensor(
+            shape=[batch_dim, IntImm(M4), IntImm(N)],
+            dtype=dtype,
+            name="x4",
+            is_input=True,
+        )
+        cat_dim = 1
+        add_0 = ops.elementwise(FuncEnum.ADD)(X0, X1)
+        concat_1 = ops.concatenate()([add_0, X2], dim=cat_dim)
+        reshape_2 = ops.reshape()(concat_1, [-1, M0 + M2, N])
+        add_3 = ops.elementwise(FuncEnum.ADD)(reshape_2, X4)
+        concat_4 = ops.concatenate()([X3, reshape_2, X3], dim=cat_dim)  # 3d
+        reshape_to_shape_5 = (
+            sum([t.shape()[cat_dim].value() for t in [X3, reshape_2, X3]]) * N
+        )
+        reshape_5 = ops.reshape()(concat_4, [-1, reshape_to_shape_5])  # 2d
+        X6 = Tensor(
+            shape=[batch_dim, IntImm(reshape_to_shape_5)],
+            dtype=dtype,
+            name="x6",
+            is_input=True,
+        )
+        add_6 = ops.elementwise(FuncEnum.ADD)(reshape_5, X6)
+        concat_7 = ops.concatenate()([X0, reshape_5, X0], dim=cat_dim)  # 2d
+        reshape_8 = ops.reshape()(add_3, [-1, (M0 + M2) * N])  # 2d
+        reduce_dim = cat_dim
+        reduce_9 = ops.reduce_sum(reduce_dim)(reshape_8)
+        reduce_10 = ops.reduce_sum(reduce_dim)(add_6)
+        reduce_11 = ops.reduce_sum(reduce_dim)(concat_7)
+        add_12 = ops.elementwise(FuncEnum.ADD)(reduce_9, reduce_10)
+        Y = ops.elementwise(FuncEnum.ADD)(add_12, reduce_11)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 8)
+        concat_cnt = 0
+        for sorted_op in sorted_ops:
+            op_type = sorted_op._attrs["op"]
+            # dynamic_slice is fused into add
+            self.assertTrue(op_type != "dynamic_slice")
+            if op_type == "concatenate":
+                concat_cnt += 1
+        self.assertEqual(concat_cnt, 1)
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0 * N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M1 * N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M2 * N], dtype)
+            x3_pt = get_random_torch_tensor([batch, M3, N], dtype)
+            x4_pt = get_random_torch_tensor([batch, M4, N], dtype)
+            x6_pt = get_random_torch_tensor([batch, reshape_to_shape_5], dtype)
+            add_0_pt = x0_pt + x1_pt
+            concat_1_pt = torch.cat([add_0_pt, x2_pt], dim=cat_dim)
+            reshape_2_pt = torch.reshape(concat_1_pt, [-1, M0 + M2, N])
+            add_3_pt = reshape_2_pt + x4_pt
+            concat_4_pt = torch.cat([x3_pt, reshape_2_pt, x3_pt], dim=cat_dim)
+            reshape_5_pt = torch.reshape(concat_4_pt, [-1, reshape_to_shape_5])
+            add_6_pt = reshape_5_pt + x6_pt
+            concat_7_pt = torch.cat([x0_pt, reshape_5_pt, x0_pt], dim=cat_dim)
+            reshape_8_pt = torch.reshape(add_3_pt, [-1, (M0 + M2) * N])
+            reduce_9_pt = torch.sum(reshape_8_pt, reduce_dim)
+            reduce_10_pt = torch.sum(add_6_pt, reduce_dim)
+            reduce_11_pt = torch.sum(concat_7_pt, reduce_dim)
+            add_12_pt = reduce_9_pt + reduce_10_pt
+            y_pt = add_12_pt + reduce_11_pt
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {
+                "x0": x0_pt,
+                "x1": x1_pt,
+                "x2": x2_pt,
+                "x3": x3_pt,
+                "x4": x4_pt,
+                "x6": x6_pt,
+            }
+            outputs = [y]
+            module.run_with_tensors(inputs, outputs)
+            torch.testing.assert_close(y_pt, y, atol=0.1, rtol=0.1)
+
+    def test_fuse_strided_cat_reshape_cat_3(self):
+        self._test_fuse_strided_cat_reshape_cat_3(
+            M0=2,
+            M1=2,
+            M2=2,
+            M3=1,
+            N=2,
+            test_name="test_fuse_strided_cat_reshape_cat_3",
+        )
+
+    def _test_non_fusible_strided_cat_cat(self, M0, N, test_name, dtype="float16"):
+        # make a graph like below:
+        # concat_0 = concatenate(x0, x1)
+        # add_1 = add(concat_0, x2)
+        # y = concatenate(concat_0, add_1)
+        batch_sizes = [1, self.BATCH_SIZE]
+        batch_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_0")
+        X0 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N)],
+            dtype=dtype,
+            name="x0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[batch_dim, IntImm(M0), IntImm(N)],
+            dtype=dtype,
+            name="x1",
+            is_input=True,
+        )
+        X2 = Tensor(
+            shape=[batch_dim, IntImm(M0 + M0), IntImm(N)],
+            dtype=dtype,
+            name="x2",
+            is_input=True,
+        )
+        cat_dim = 1
+        concat_0 = ops.concatenate()([X0, X1], dim=cat_dim)
+        add_1 = ops.elementwise(FuncEnum.ADD)(concat_0, X2)
+        Y = ops.concatenate()([concat_0, add_1], dim=cat_dim)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+
+        # Gen module.
+        target = detect_target()
+        dll_name = f"test_{self.test_count}.so"
+        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        self.test_count += 1
+        sorted_graph = module.debug_sorted_graph
+        sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
+        self.assertEqual(len(sorted_ops), 3)
+        concat_cnt = 0
+        output_cat = None
+        for sorted_op in sorted_ops:
+            op_type = sorted_op._attrs["op"]
+            if op_type == "concatenate":
+                concat_cnt += 1
+                if sorted_op._attrs["outputs"][0] == Y:
+                    output_cat = sorted_op
+        self.assertEqual(concat_cnt, 2)
+        self.assertEqual(output_cat._attrs["input_masks"], [True, False])
+
+        for batch in [1, self.BATCH_SIZE]:
+            x0_pt = get_random_torch_tensor([batch, M0, N], dtype)
+            x1_pt = get_random_torch_tensor([batch, M0, N], dtype)
+            x2_pt = get_random_torch_tensor([batch, M0 + M0, N], dtype)
+
+            concat_0_pt = torch.cat([x0_pt, x1_pt], dim=cat_dim)
+            add_1_pt = concat_0_pt + x2_pt
+            y_pt = torch.cat([concat_0_pt, add_1_pt], dim=cat_dim)
+
+            y = get_torch_empty_tensor(y_pt.size(), dtype)
+            inputs = {
+                "x0": x0_pt,
+                "x1": x1_pt,
+                "x2": x2_pt,
+            }
+            outputs = [y]
+            module.run_with_tensors(inputs, outputs)
+            torch.testing.assert_close(y_pt, y, atol=0.1, rtol=0.1)
+
+    def test_non_fusible_strided_cat_cat(self):
+        self._test_non_fusible_strided_cat_cat(
+            M0=2,
+            N=8,
+            test_name="test_non_fusible_strided_cat_cat",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, our transform_memory_ops pass was only able to merge concat ops with a single dst_op. This PR extended the pass to hanlde cases where the first concat may take multiple dst ops. The basic idea is that we generate a slice op for each non-concat dst op of the first concat's output. This slice op consumes the first concat's output and feeds into the original non-concat dst op.

Currently, we restrict our implementation to elementwise ops and bmm_ccr being extra dst ops as they may be fused with the input slice. We will support more strided ops with corresponding tests later.