### PR TITLE
Mem efficient attention with variable lengths

### DIFF
--- a/python/aitemplate/backend/cuda/attention/mem_eff_attention.py
+++ b/python/aitemplate/backend/cuda/attention/mem_eff_attention.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 #
 """
-attention kernel codegen for CUDA.
+Attention kernel codegen for CUDA.
 """
 from typing import Any, Dict
 
@@ -24,35 +24,51 @@ from aitemplate.backend.backend_spec import CUDASpec
 
 # pylint: disable=C0301
 
-FUNC_TEMPLATE = jinja2.Template(
+CUDA_CHECK = """
+#ifndef CUDA_CHECK_ME_ATTN
+#define CUDA_CHECK_ME_ATTN(expr, msg)                                          \\
+  do {                                                                         \\
+    cudaError_t status = (expr);                                               \\
+    if (status != cudaSuccess) {                                               \\
+      std::cerr << msg << " at " << __FILE__ << ": " << __LINE__ << std::endl; \\
+      throw std::runtime_error(cudaGetErrorString(status));                    \\
+    }                                                                          \\
+  } while (0)
+#endif // CUDA_CHECK_ME_ATTN
+"""
+
+FUNC_TEMPLATE_KERNEL_FWD = jinja2.Template(
     """
 #include <iostream>
 #include <cuda_fp16.h>
 #include "cutlass/cutlass.h"
 #include "cutlass/gemm/device/default_gemm_configuration.h"
-// TODO: this include should be removed. There's a bug in CUTLASS, the
-// header containing cutlass::gemm::warp::WarpSize is not being included.
-// Until the fix is upstreamed, just inject it here instead.
-#include "cutlass/gemm/warp/mma.h"
 #include "gemm_kernel_utils.h"
-#include "kernel_forward.h"
+
+#include "mem_eff_attention/kernel_forward.h"
+
 
 using namespace gemm_kernel_utils;
+
+{{cuda_check}}
 
 {{func_signature}}
 {
 
     /*
+    The code is based on fused_multihead_attention_fixed_seqlen.cu example in CUTLASS repo:
+    https://github.com/NVIDIA/cutlass/blob/209faf7b94ce4ba573d27389fb643962e75d0581/examples/41_fused_multi_head_attention/fused_multihead_attention_fixed_seqlen.cu
+
     problem_sizes0 [b, m, n, k]
     [head_number * batch_size, m, mkv, k0]
-    [head_number * batch_size, seq_length, seq_length_kv, head_size]
+    [head_number * batch_size, seq_length_q, seq_length_kv, head_size]
 
     problem_sizes1
     [head_number * batch_size, m, k1, mkv]
-    [head_number * batch_size, seq_length, head_size_v, seq_length_kv]
+    [head_number * batch_size, seq_length_q, head_size_v, seq_length_kv]
 
-    m = seq_len
-    n = seq_len
+    m = seq_len_q
+    n = seq_len_kv
     k = head_size
 
     Q: B, M, K
@@ -60,11 +76,11 @@ using namespace gemm_kernel_utils;
     P: B, M, N
     V: B, N, K
     O: B, M, K
-    output: bs, num_head, seq_len, head_size
+    output: bs, seq_len_q, num_head, head_size
     */
 
 
-    using ArchTag = cutlass::arch::Sm80;
+    using ArchTag = cutlass::arch::Sm{{arch}};
     constexpr bool kIs64x64 = {{kIs64x64}};
     constexpr bool kSingleValueIteration = {{kSingleValueIteration}};
 
@@ -111,7 +127,6 @@ using namespace gemm_kernel_utils;
         kSingleValueIteration
     >;
 
-    int block_O_size = (*batch_size) * seq_len * num_heads * head_size_v;
     typename Attention::Params p;
     {
         // set parameters
@@ -120,8 +135,16 @@ using namespace gemm_kernel_utils;
         p.value_ptr = static_cast<{{elem_input_type}}*>(value);
         p.logsumexp_ptr = nullptr; // Only needed for bw
         p.output_accum_ptr = nullptr;
+
+        if (!fixed_seq_length_q) {
+            p.seqlens_q_ptr = lengths_q;
+        }
+        if (!fixed_seq_length_kv) {
+            p.seqlens_k_ptr = lengths_kv;
+        }
+
         if (Attention::kNeedsOutputAccumulatorBuffer) {
-          p.output_accum_ptr = accum_ptr;
+          p.output_accum_ptr = static_cast<float*>(workspace);
         }
         p.output_ptr = static_cast<{{elem_input_type}}*>(output);
 
@@ -129,7 +152,7 @@ using namespace gemm_kernel_utils;
         p.num_batches = *batch_size;
         p.head_dim = head_size;
         p.head_dim_value = head_size_v;
-        p.num_queries = seq_len;
+        p.num_queries = seq_len_q;
         p.num_keys = seq_len_kv;
         p.causal = is_causal;
 
@@ -138,14 +161,14 @@ using namespace gemm_kernel_utils;
         p.k_strideM = head_size;
         p.v_strideM = head_size_v;
 
-        p.q_strideH = p.q_strideM * seq_len;
+        p.q_strideH = p.q_strideM * seq_len_q;
         p.k_strideH = p.k_strideM * seq_len_kv;
         p.v_strideH = p.v_strideM * seq_len_kv;
         p.o_strideH = head_size_v;
         p.q_strideB = p.q_strideH * num_heads;
         p.k_strideB = p.k_strideH * num_heads;
         p.v_strideB = p.v_strideH * num_heads;
-        p.o_strideB = head_size_v * seq_len * num_heads;
+        p.o_strideB = head_size_v * seq_len_q * num_heads;
     }
 
     // launch kernel
@@ -173,22 +196,467 @@ using namespace gemm_kernel_utils;
 )
 
 
+FUNC_TEMPLATE_GROUPED_FMHA = jinja2.Template(
+    """
+#include <vector>
+#include <iostream>
+#include <cuda_fp16.h>
+
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/util/device_memory.h"
+#include "cutlass/util/tensor_view_io.h"
+#include "cutlass/util/host_tensor.h"
+#include "cutlass/util/reference/host/gemm_complex.h"
+#include "cutlass/util/reference/device/gemm_complex.h"
+#include "cutlass/util/reference/host/tensor_compare.h"
+#include "cutlass/util/reference/host/tensor_copy.h"
+#include "cutlass/util/reference/device/tensor_fill.h"
+#include "cutlass/util/reference/host/tensor_norm.h"
+
+#include "cutlass/gemm/device/default_gemm_configuration.h"
+#include "gemm_kernel_utils.h"
+#include "cutlass/gemm/device/gemm_grouped.h"
+
+#include "cutlass/fast_math.h"
+
+#include "default_fmha_grouped.h"
+
+using namespace gemm_kernel_utils;
+
+{{cuda_check}}
+
+{{func_signature}}
+
+{
+  /*
+  The code is based on fused_multihead_attention_variable_seqlen.cu example in CUTLASS repo:
+  https://github.com/NVIDIA/cutlass/blob/209faf7b94ce4ba573d27389fb643962e75d0581/examples/41_fused_multi_head_attention/fused_multihead_attention_variable_seqlen.cu
+
+  problem_sizes0 [b, m, n, k]
+  [head_number * batch_size, mq, mkv, k0]
+  [head_number * batch_size, seq_length_q, seq_length_kv, head_size]
+
+  problem_sizes1
+  [head_number * batch_size, mq, k1, mkv]
+  [head_number * batch_size, seq_length_q, head_size_v, seq_length_kv]
+
+  m = seq_len_q
+  n = seq_len_kv
+  k = head_size
+
+  Q: B, M, K
+  K: B, N, K
+  P: B, M, N
+  V: B, N, K
+  O: B, M, K
+  output: bs, seq_len_q, num_head, head_size
+
+  Note that the output shape is different from the CUTLASS example.
+  */
+  //
+  int problem_count = (*batch_size) * num_heads;
+
+  /////// Calculate offsets of FMHA arguments in the workspace //////
+
+  int used_memory = 0;
+  // Space for problem sizes for each problem
+  int size_problem_sizes = sizeof(cutlass::gemm::GemmCoord) * problem_count;
+  cutlass::gemm::GemmCoord* problem_sizes_device0 =
+      static_cast<cutlass::gemm::GemmCoord*>(workspace + used_memory);
+  used_memory += size_problem_sizes;
+  cutlass::gemm::GemmCoord* problem_sizes_device1 =
+      static_cast<cutlass::gemm::GemmCoord*>(workspace + used_memory);
+  used_memory += size_problem_sizes;
+  // Space for leading dimensions of tensors in each problem
+  int size_ld = sizeof(int64_t) * problem_count;
+  int64_t* ldq = static_cast<int64_t*>(workspace + used_memory);
+  used_memory += size_ld;
+  int64_t* ldk = static_cast<int64_t*>(workspace + used_memory);
+  used_memory += size_ld;
+  int64_t* ldv = static_cast<int64_t*>(workspace + used_memory);
+  used_memory += size_ld;
+  int64_t* ldo = static_cast<int64_t*>(workspace + used_memory);
+  used_memory += size_ld;
+
+  using ArchTag = cutlass::arch::Sm{{arch}};
+  constexpr bool kIs64x64 = {{kIs64x64}};
+  constexpr bool kSingleValueIteration = {{kSingleValueIteration}};
+
+  // Set grid size
+  constexpr int64_t kQueriesPerBlock = kIs64x64 ? 64 : 32;
+  constexpr int64_t kKeysPerBlock = kIs64x64 ? 64 : 128;
+  if (kIs64x64 && head_size_v > kKeysPerBlock) {
+    std::cerr
+        << "WARNING: you will get better performance with `kIs64x64=false`";
+  }
+  if (kSingleValueIteration && head_size_v > kKeysPerBlock) {
+    std::cerr << "ERROR  : Use kSingleValueIteration to keep output in RF. "
+                 "This requires to have `head_size <= kKeysPerBlock` "
+                 "but head_size_v="
+              << head_size_v << " and kKeysPerBlock=" << kKeysPerBlock << "";
+    return;
+  }
+  if (!kSingleValueIteration && head_size_v <= kKeysPerBlock) {
+    std::cerr
+        << "WARNING: you will get better performance with `kSingleValueIteration=true` (keeps the output in RF rather than GMEM)";
+  }
+
+  using GemmType = DefaultGemmType<ArchTag, {{elem_input_type}}>;
+  using OpClass = typename GemmType::OpClass;
+  using DefaultConfig =
+      typename cutlass::gemm::device::DefaultGemmConfiguration<
+          OpClass,
+          ArchTag,
+          {{elem_input_type}},
+          {{elem_input_type}},
+          {{elem_input_type}}, // ElementC
+          float // ElementAccumulator
+          >;
+
+  // If the head_size already meets the alignment requirement, then
+  // it's safe to mark mem_align to be true to maximize the alignment
+  // benefit. Otherwise, assign false to it to use the minimal alignment.
+  constexpr const bool mem_align = ({{head_size}} % DefaultConfig::kAlignmentA == 0) &&
+      ({{head_size}} % DefaultConfig::kAlignmentB == 0);
+
+  cutlass::gemm::kernel::GroupScheduleMode const GroupScheduleMode_ =
+      cutlass::gemm::kernel::GroupScheduleMode::kDeviceOnly;
+
+  using AttentionKernel = typename cutlass::gemm::kernel::DefaultFMHAGrouped<
+      {{elem_input_type}}, // scalar_t
+      ArchTag,
+      mem_align,
+      kQueriesPerBlock,
+      kKeysPerBlock,
+      kSingleValueIteration,
+      GroupScheduleMode_>::FMHAKernel;
+  using Attention = cutlass::gemm::device::GemmGrouped<AttentionKernel>;
+
+  if (({{head_size}} % AttentionKernel::kAlignmentQ != 0) ||
+      ({{head_size}} % AttentionKernel::kAlignmentK != 0)) {
+    std::cerr << "Error at " << __FILE__ << ": " << __LINE__ <<
+        "head_size not aligned! head_size has to be divisible by " <<
+        std::to_string(AttentionKernel::kAlignmentQ) << " and " <<
+        std::to_string(AttentionKernel::kAlignmentK) + ", but got {{head_size}}."
+        << std::endl;
+    return;
+  }
+
+  // If we need a separate buffer for output accumulation
+  static bool const kNeedsOutputAccumulatorBuffer =
+      Attention::GemmKernel::kNeedsOutputAccumulatorBuffer;
+
+  // Problem sizes with actual sequence lengths
+  std::vector<cutlass::gemm::GemmCoord> problem_sizes0;
+  std::vector<cutlass::gemm::GemmCoord> problem_sizes1;
+  // Problem sizes with "full" sequence lengths
+  std::vector<cutlass::gemm::GemmCoord> problem_sizes0_full;
+  std::vector<cutlass::gemm::GemmCoord> problem_sizes1_full;
+
+  problem_sizes0.reserve(problem_count);
+  problem_sizes1.reserve(problem_count);
+  problem_sizes0_full.reserve(problem_count);
+  problem_sizes1_full.reserve(problem_count);
+
+  // Copy sequence lengths from device to host, if they are not fixed
+  std::vector<int> mq_real_buf; // Target sequence lengths
+  std::vector<int> mkv_real_buf; // Source sequence lengths
+  if (!fixed_seq_length_q) {
+    mq_real_buf.resize(*batch_size);
+    CUDA_CHECK_ME_ATTN(
+      cudaMemcpyAsync(
+        mq_real_buf.data(), lengths_q, *batch_size * sizeof(int), cudaMemcpyDeviceToHost, stream),
+      "Error when copying target sequence lengths from device!");
+  }
+  if (!fixed_seq_length_kv) {
+    mkv_real_buf.resize(*batch_size);
+    CUDA_CHECK_ME_ATTN(
+      cudaMemcpyAsync(
+        mkv_real_buf.data(), lengths_kv,  *batch_size * sizeof(int), cudaMemcpyDeviceToHost, stream),
+        "Error when copying source sequence lengths from device!");
+  }
+  if (!fixed_seq_length_q || !fixed_seq_length_kv) {
+    CUDA_CHECK_ME_ATTN(cudaStreamSynchronize(stream),
+          "Error when synchronizing stream after copying sequence lengths from device!");
+  }
+
+  int mq_full = seq_len_q;
+  int mkv_full = seq_len_kv;
+
+  for (int i = 0; i < *batch_size; ++i) {
+    // Problems belonging to the same batch share the same seq len
+    // Source sequence length
+    int mkv_real = fixed_seq_length_kv ? mkv_full : mkv_real_buf.at(i);
+    // Target sequence length
+    int mq_real = fixed_seq_length_q ? mq_full : mq_real_buf.at(i);
+
+    int k0 = head_size;
+    int k1 = head_size_v;
+
+    // Create sizes of two GEMM problems for each of batch_size * num_heads attention problems
+    for (int j = 0; j < num_heads; ++j) {
+      cutlass::gemm::GemmCoord problem0(mq_real, mkv_real, k0);
+      cutlass::gemm::GemmCoord problem1(mq_real, k1, mkv_real);
+      problem_sizes0.push_back(problem0);
+      problem_sizes1.push_back(problem1);
+
+      cutlass::gemm::GemmCoord problem0_full(mq_full, mkv_full, k0);
+      cutlass::gemm::GemmCoord problem1_full(mq_full, k1, mkv_full);
+      problem_sizes0_full.push_back(problem0_full);
+      problem_sizes1_full.push_back(problem1_full);
+    }
+  }
+
+  // Move problem sizes to the device
+  CUDA_CHECK_ME_ATTN(
+    cudaMemcpyAsync(
+      problem_sizes_device0,
+      problem_sizes0.data(),
+      size_problem_sizes,
+      cudaMemcpyHostToDevice,
+      stream),
+    "Error when copying problem sizes 0 to device!");
+  CUDA_CHECK_ME_ATTN(
+    cudaMemcpyAsync(
+      problem_sizes_device1,
+      problem_sizes1.data(),
+      size_problem_sizes,
+      cudaMemcpyHostToDevice,
+      stream),
+    "Error when copying problem sizes 1 to device!");
+
+  // Offsets of input, buffer, and output matrices in memory
+  std::vector<int64_t> offset_Q_full;
+  std::vector<int64_t> offset_K_full;
+  std::vector<int64_t> offset_V_full;
+  std::vector<int64_t> offset_O_full;
+
+  // Leading dimensions of matrices of each problem
+  std::vector<int64_t> ldq_host;
+  std::vector<int64_t> ldk_host;
+  std::vector<int64_t> ldv_host;
+  std::vector<int64_t> ldo_host;
+  ldq_host.resize(problem_count);
+  ldk_host.resize(problem_count);
+  ldv_host.resize(problem_count);
+  ldo_host.resize(problem_count);
+
+  using scalar_t = typename Attention::GemmKernel::scalar_t;
+  using accum_t = typename Attention::GemmKernel::accum_t;
+  using output_t = typename Attention::GemmKernel::output_t;
+  using output_accum_t = typename Attention::GemmKernel::output_accum_t;
+
+  using ElementQ = scalar_t;
+  using ElementK = scalar_t;
+  using ElementP = accum_t;
+  using ElementAccumulator = accum_t;
+  using ElementV = scalar_t;
+  using ElementO = output_t;
+  using ElementOAccum = output_accum_t;
+
+  // Arrays of pointers to matrices for each problem
+  int size_ptrs = sizeof(ElementQ*) * problem_count;
+  ElementQ** ptr_Q = static_cast<ElementQ**>(workspace + used_memory);
+  used_memory += size_ptrs;
+  ElementK** ptr_K = static_cast<ElementK**>(workspace + used_memory);
+  used_memory += size_ptrs;
+  ElementV** ptr_V = static_cast<ElementV**>(workspace + used_memory);
+  used_memory += size_ptrs;
+  ElementO** ptr_O = static_cast<ElementO**>(workspace + used_memory);
+  used_memory += size_ptrs;
+  ElementOAccum** ptr_O_accumulate =
+      static_cast<ElementOAccum**>(workspace + used_memory);
+  used_memory += size_ptrs;
+
+  int64_t total_elements_Q_full = 0;
+  int64_t total_elements_K_full = 0;
+  int64_t total_elements_V_full = 0;
+  //int64_t total_elements_O_full = 0;
+  int64_t total_elements_O_at_batch_start = 0;
+
+  // Pointers to matrices and leading dimensions for each problem are first
+  // formed on the host and then copied to the device.
+
+  for (int32_t i_batch = 0; i_batch < *batch_size; ++i_batch) {
+    int64_t total_elements_O_in_current_batch = 0;
+    for (int32_t i_heads = 0; i_heads < num_heads; ++i_heads) {
+      int64_t i = i_batch * num_heads + i_heads;
+      auto problem0 = problem_sizes0.at(i);
+      auto problem1 = problem_sizes1.at(i);
+
+      auto problem0_full = problem_sizes0_full.at(i);
+      auto problem1_full = problem_sizes1_full.at(i);
+
+      /*
+      Below we specify leading dimensions of each matix, assuming the following
+      layouts and dimensions:
+
+      using LayoutQ = cutlass::layout::RowMajor;
+      using LayoutK = cutlass::layout::ColumnMajor;
+      using LayoutV = cutlass::layout::RowMajor;
+      using LayoutO = cutlass::layout::RowMajor;
+
+      ldq_host.at(i) = LayoutQ::packed({problem0.m(), problem0.k()}).stride(0);
+      ldk_host.at(i) = LayoutK::packed({problem0.k(), problem0.n()}).stride(0);
+      ldv_host.at(i) = LayoutV::packed({problem1.k(), problem1.n()}).stride(0);
+      ldo_host.at(i) = LayoutO::packed({problem1.m(), problem1.n()}).stride(0);
+      */
+
+      ldq_host.at(i) = problem0.k(); // K, rowmajor
+      ldk_host.at(i) = problem0.k(); // K, columnmajor
+      ldv_host.at(i) = problem1.n(); // K, rowmajor
+      // Since we want output in shape [b, seq_len_q, num_head, head_size] and
+      // not [b, num_head, seq_len_q, head_size], ldo is different from the
+      // CUTLASS example. Each next row of O is now separated from the previous
+      // one by head_size * num_heads, instead of just head_size.
+      ldo_host.at(i) = problem1.n() * num_heads; // K * num_heads, rowmajor
+
+      offset_Q_full.push_back(total_elements_Q_full);
+      offset_K_full.push_back(total_elements_K_full);
+      offset_V_full.push_back(total_elements_V_full);
+      // To write the output in shape [b, seq_len_q, num_head, head_size]
+      // instead of [b, num_head, seq_len_q, head_size], we place rows of O
+      // from the same batch but different heads at stride head_size from
+      // each other (and not seq_len_q * head_size).
+      offset_O_full.push_back(
+          total_elements_O_at_batch_start + i_heads * problem1_full.n());
+
+      int64_t elements_Q_full = problem0_full.m() * problem0_full.k();
+      int64_t elements_K_full = problem0_full.k() * problem0_full.n();
+      int64_t elements_V_full = problem1_full.k() * problem1_full.n();
+      int64_t elements_O_full = problem1_full.m() * problem1_full.n();
+
+      total_elements_Q_full += elements_Q_full;
+      total_elements_K_full += elements_K_full;
+      total_elements_V_full += elements_V_full;
+      total_elements_O_in_current_batch += elements_O_full;
+    }
+    total_elements_O_at_batch_start += total_elements_O_in_current_batch;
+  }
+
+  CUDA_CHECK_ME_ATTN(
+    cudaMemcpyAsync(ldq, ldq_host.data(), size_ld, cudaMemcpyHostToDevice, stream),
+    "Error when copying leading dimensions of Q matrices to device!");
+  CUDA_CHECK_ME_ATTN(
+    cudaMemcpyAsync(ldk, ldk_host.data(), size_ld, cudaMemcpyHostToDevice, stream),
+    "Error when copying leading dimensions of K matrices to device!");
+  CUDA_CHECK_ME_ATTN(
+    cudaMemcpyAsync(ldv, ldv_host.data(), size_ld, cudaMemcpyHostToDevice, stream),
+    "Error when copying leading dimensions of V matrices to device!");
+  CUDA_CHECK_ME_ATTN(
+    cudaMemcpyAsync(ldo, ldo_host.data(), size_ld, cudaMemcpyHostToDevice, stream),
+    "Error when copying leading dimensions of O matrices to device!");
+
+  // Buffer for output accumulation, if necessary
+  float* accum_ptr = static_cast<float*>(workspace + used_memory);
+
+  std::vector<ElementQ*> ptr_Q_host(problem_count);
+  std::vector<ElementK*> ptr_K_host(problem_count);
+  std::vector<ElementV*> ptr_V_host(problem_count);
+  std::vector<ElementO*> ptr_O_host(problem_count);
+  std::vector<ElementOAccum*> ptr_O_accumulate_host(problem_count);
+
+  for (int32_t i = 0; i < problem_count; ++i) {
+    ptr_Q_host.at(i) = static_cast<ElementQ*>(query) + offset_Q_full.at(i);
+    ptr_K_host.at(i) = static_cast<ElementK*>(key) + offset_K_full.at(i);
+    ptr_V_host.at(i) = static_cast<ElementV*>(value) + offset_V_full.at(i);
+    ptr_O_host.at(i) = static_cast<ElementO*>(output) + offset_O_full.at(i);
+
+    if (kNeedsOutputAccumulatorBuffer) {
+      ptr_O_accumulate_host.at(i) =
+        static_cast<ElementOAccum*>(accum_ptr) + offset_O_full.at(i);
+    }
+  }
+  CUDA_CHECK_ME_ATTN(
+    cudaMemcpyAsync(
+      ptr_Q, ptr_Q_host.data(), size_ptrs, cudaMemcpyHostToDevice, stream),
+    "Error when copying pointers to Q matrices to device!");
+  CUDA_CHECK_ME_ATTN(
+    cudaMemcpyAsync(
+      ptr_K, ptr_K_host.data(), size_ptrs, cudaMemcpyHostToDevice, stream),
+    "Error when copying pointers to K matrices to device!");
+  CUDA_CHECK_ME_ATTN(
+    cudaMemcpyAsync(
+      ptr_V, ptr_V_host.data(), size_ptrs, cudaMemcpyHostToDevice, stream),
+    "Error when copying pointers to V matrices to device!");
+  CUDA_CHECK_ME_ATTN(
+    cudaMemcpyAsync(
+      ptr_O, ptr_O_host.data(), size_ptrs, cudaMemcpyHostToDevice, stream),
+    "Error when copying pointers to O matrices to device!");
+
+  if (kNeedsOutputAccumulatorBuffer) {
+    CUDA_CHECK_ME_ATTN(
+      cudaMemcpyAsync(
+        ptr_O_accumulate,
+        ptr_O_accumulate_host.data(),
+        size_ptrs,
+        cudaMemcpyHostToDevice,
+        stream),
+      "Error when copying pointers to accumulator buffers to device!");
+  }
+
+  int threadblock_count =
+      Attention::sufficient(problem_sizes1.data(), problem_count);
+  typename Attention::Arguments args(
+      problem_sizes_device0,
+      problem_sizes_device1,
+      problem_count,
+      threadblock_count,
+      ptr_Q,
+      ptr_K,
+      nullptr, // ptr_P isn't used by grouped FMHA
+      ptr_V,
+      ptr_O,
+      ptr_O_accumulate,
+      ldq,
+      ldk,
+      nullptr, // ldp isn't used by grouped FMHA
+      ldv,
+      ldo,
+      is_causal,
+      problem_sizes1.data());
+
+  Attention fmha;
+  cutlass::Status status = fmha.initialize(args, nullptr, stream);
+  if (status != cutlass::Status::kSuccess) {
+    std::cerr << "Failed to initialize CUTLASS Grouped FMHA kernel."
+              << std::endl;
+    return;
+  }
+
+  // Run the grouped FMHA object
+  status = fmha.run(stream);
+  if (status != cutlass::Status::kSuccess) {
+    std::cerr << "Failed to run CUTLASS Grouped FMHA kernel." << std::endl;
+    return;
+  }
+}
+
+    """
+)
+
+
 FUNC_SIGNATURE = jinja2.Template(
     """
 void {{func_name}}(void* output,
                    void* query,
                    void* key,
                    void* value,
-                   float* accum_ptr,
                    int64_t* batch_size,
-                   int seq_len,
                    int seq_len_kv,
+                   int seq_len_q,
                    int num_heads,
                    int head_size,
                    int head_size_v,
                    float p_dropout,
                    float softmax_scale,
                    bool is_causal,
+                   bool fixed_seq_length_kv,
+                   int32_t* lengths_kv,
+                   bool fixed_seq_length_q,
+                   int32_t* lengths_q,
+                   void* workspace,
                    cudaStream_t stream)
     """
 )
@@ -204,16 +672,21 @@ FUNC_CALL_TEMPLATE = jinja2.Template(
 {{indent}}{{func_name}}(
 {{indent}}    {{output}},
 {{indent}}    {{query}}, {{key}}, {{value}},
-{{indent}}    {{accum_ptr}},
 {{indent}}    {{batch_size}},
-{{indent}}    {{seq_len}},
 {{indent}}    {{seq_len_kv}},
+{{indent}}    {{seq_len_q}},
 {{indent}}    {{num_heads}},
 {{indent}}    {{head_size}},
 {{indent}}    {{head_size_v}},
 {{indent}}    {{p_dropout}},
 {{indent}}    {{softmax_scale}},
-{{indent}}    {{is_causal}}, stream /* default stream */
+{{indent}}    {{is_causal}},
+{{indent}}    {{fixed_seq_length_kv}},
+{{indent}}    {{lengths_kv}},
+{{indent}}    {{fixed_seq_length_q}},
+{{indent}}    {{lengths_q}},
+{{indent}}    global_workspace_,
+{{indent}}    stream /* default stream */
 {{indent}});
     """
 )
@@ -226,12 +699,19 @@ def mem_eff_attention_gen_function(func_attrs: Dict[str, Any]) -> str:
     elem_input_type = backend_spec.dtype_to_lib_type(
         func_attrs["inputs"][0]._attrs["dtype"]
     )
-    return FUNC_TEMPLATE.render(
+    if func_attrs["use_grouped_fmha"]:
+        func_template = FUNC_TEMPLATE_GROUPED_FMHA
+    else:
+        func_template = FUNC_TEMPLATE_KERNEL_FWD
+
+    return func_template.render(
         elem_input_type=elem_input_type,
         head_size=func_attrs["head_size"],
         func_signature=FUNC_SIGNATURE.render(func_name=func_attrs["name"]),
         kIs64x64="true" if func_attrs["head_size"] <= 64 else "false",
         kSingleValueIteration="true" if func_attrs["head_size"] <= 128 else "false",
+        cuda_check=CUDA_CHECK,
+        arch=func_attrs["arch"],
     )
 
 
@@ -247,7 +727,7 @@ def mem_eff_attention_gen_function_call(func_attrs, indent="  "):
     """the function for generating a function call for attention"""
     output_name = ""
     assert len(func_attrs["outputs"]) == 1
-    assert len(func_attrs["inputs"]) == 3
+    assert len(func_attrs["inputs"]) in [3, 4, 5]
 
     output_name = func_attrs["outputs"][0]._attrs["name"]
 
@@ -255,10 +735,24 @@ def mem_eff_attention_gen_function_call(func_attrs, indent="  "):
     k_name = func_attrs["inputs"][1]._attrs["name"]
     v_name = func_attrs["inputs"][2]._attrs["name"]
 
+    variable_seq_length_kv = func_attrs["variable_seq_length_kv"]
+    variable_seq_length_q = func_attrs["variable_seq_length_q"]
+
+    lengths_name_kv = "nullptr"
+    lengths_name_q = "nullptr"
+
+    if variable_seq_length_kv:
+        assert len(func_attrs["inputs"]) > 3
+        lengths_name_kv = func_attrs["inputs"][3]._attrs["name"]
+    if variable_seq_length_q:
+        idx_len_q = 3 + variable_seq_length_kv
+        assert len(func_attrs["inputs"]) > idx_len_q
+        lengths_name_q = func_attrs["inputs"][idx_len_q]._attrs["name"]
+
     x = func_attrs["inputs"][0]
     xshape = x._attrs["shape"]
     batch_size = "&" + xshape[0]._attrs["name"]
-    seq_len = x._attrs["shape"][2]._attrs["values"][0]
+    seq_len_q = x._attrs["shape"][2]._attrs["values"][0]
 
     num_heads = x._attrs["shape"][1]._attrs["values"][0]
     head_size = x._attrs["shape"][3]._attrs["values"][0]
@@ -276,15 +770,18 @@ def mem_eff_attention_gen_function_call(func_attrs, indent="  "):
         query=q_name,
         key=k_name,
         value=v_name,
-        accum_ptr="reinterpret_cast<float*>(global_workspace_)",
         batch_size=batch_size,
-        seq_len=seq_len,
         seq_len_kv=seq_len_kv,
+        seq_len_q=seq_len_q,
         num_heads=num_heads,
         head_size=head_size,
         head_size_v=head_size_v,
         p_dropout=p_dropout,
         softmax_scale=softmax_scale,
         is_causal="true" if is_causal else "false",
+        fixed_seq_length_kv="false" if variable_seq_length_kv else "true",
+        lengths_kv=f"static_cast<int32_t*>({lengths_name_kv})",
+        fixed_seq_length_q="false" if variable_seq_length_q else "true",
+        lengths_q=f"static_cast<int32_t*>({lengths_name_q})",
         indent=indent,
     )

--- a/python/aitemplate/compiler/ops/attention/mem_eff_attention.py
+++ b/python/aitemplate/compiler/ops/attention/mem_eff_attention.py
@@ -16,16 +16,19 @@
 Flash attention.
 """
 import itertools
+import logging
 from collections import OrderedDict
-from typing import List
+from typing import List, Optional, Tuple
 
 import jinja2
 import numpy as np
 
 from aitemplate import backend
 from aitemplate.backend import registry
-from aitemplate.compiler.base import Operator, Tensor
+from aitemplate.compiler.base import IntVar, Operator, Tensor
 from aitemplate.utils import shape_utils
+
+_LOGGER = logging.getLogger(__name__)
 
 # pylint: disable=C0103,W0221,W0102,W0223
 
@@ -58,7 +61,14 @@ class mem_eff_attention(Operator):
     where :math:`head_i = \text{Attention}(QW_i^Q, KW_i^K, VW_i^V)`.
     """
 
-    def __init__(self, causal, dropout=0) -> None:
+    def __init__(
+        self,
+        causal,
+        dropout=0,
+        variable_seq_length_kv=False,
+        variable_seq_length_q=False,
+        use_grouped_fmha=False,
+    ) -> None:
         """Initialize attention module"""
         super().__init__()
         assert dropout == 0
@@ -66,8 +76,11 @@ class mem_eff_attention(Operator):
         self._attrs["has_profiler"] = False
         self._attrs["dropout"] = dropout
         self._attrs["causal"] = causal
+        self._attrs["variable_seq_length_kv"] = variable_seq_length_kv
+        self._attrs["variable_seq_length_q"] = variable_seq_length_q
         self._attrs["head_size"] = -1
         self._attrs["workspace"] = 0
+        self._attrs["use_grouped_fmha"] = use_grouped_fmha
         self.exec_key_template = EXEC_KEY_TEMPLATE
         self.shape_eval_template = SHAPE_FUNC_TEMPLATE
 
@@ -113,7 +126,14 @@ class mem_eff_attention(Operator):
         ]
         return output_shape
 
-    def __call__(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
+    def __call__(
+        self,
+        q: Tensor,
+        k: Tensor,
+        v: Tensor,
+        lengths_kv: Optional[Tensor] = None,
+        lengths_q: Optional[Tensor] = None,
+    ) -> Tensor:
         """call the op
 
         Parameters
@@ -131,13 +151,21 @@ class mem_eff_attention(Operator):
         self._attrs["head_size"] = head_size_v
 
         self._attrs["inputs"] = [q, k, v]
+        if self._attrs["variable_seq_length_kv"]:
+            assert lengths_kv is not None
+            self._attrs["inputs"].append(lengths_kv)
+        if self._attrs["variable_seq_length_q"]:
+            assert lengths_q is not None
+            self._attrs["inputs"].append(lengths_q)
         self._set_depth()
         self._extract_exec_path(q)
         output_shape = self._infer_shapes(q, v)
 
-        o_shape = [var._attrs["values"][-1] for var in output_shape]
-        if o_shape[-1] > 128:
-            self._attrs["workspace"] = 4 * np.prod(o_shape)
+        required_workspace_size = self._compute_required_workspace(
+            output_shape, q._attrs["shape"], k._attrs["shape"]
+        )
+        self._attrs["workspace"] = required_workspace_size
+        _LOGGER.debug(f"Required workspace size: {required_workspace_size}")
         output = Tensor(
             output_shape,
             src_ops={self},
@@ -145,6 +173,58 @@ class mem_eff_attention(Operator):
         )
         self._attrs["outputs"] = [output]
         return output
+
+    def _compute_required_workspace(
+        self,
+        output_shape: Tuple[IntVar, IntVar, IntVar, IntVar],
+        q_shape: Tuple[IntVar, IntVar, IntVar, IntVar],
+        k_shape: Tuple[IntVar, IntVar, IntVar, IntVar],
+    ) -> int:
+        """
+        Compute workspace size required for attention op.
+        """
+        is_float32 = self._attrs["inputs"][0]._attrs["dtype"] not in [
+            "float16",
+            "bfloat16",
+        ]
+
+        o_shape = [var._attrs["values"][-1] for var in output_shape]
+        # We need a separate buffer of output accumulation
+        # - when the intermediate output can't fit into the register file.
+        # - when the accumulation type (float) is different from the output type.
+        # See https://github.com/NVIDIA/cutlass/blob/209faf7b94ce4ba573d27389fb643962e75d0581/examples/41_fused_multi_head_attention/fmha_grouped.h#L79-L95
+        needs_output_accum_buffer = (o_shape[-1] > 128) or not is_float32
+        if needs_output_accum_buffer:  # Needs output accumulator buffer
+            size_of_accum_element = 4  # Accumulation is always in float
+            accu_size = size_of_accum_element * np.prod(o_shape)
+        else:
+            accu_size = 0
+
+        # The backend which uses kernel_forward.h only needs accumulator buffer
+        if not self._attrs["use_grouped_fmha"]:
+            return accu_size
+
+        # Number of problems is batch_size * num_heads
+        problem_count = q_shape[0].upper_bound() * q_shape[1].upper_bound()
+
+        size_of_int = 4
+        size_of_int64 = 8
+        # GEMM size is specified by 3 ints: m, n, k
+        size_of_gemm_coord = 3 * size_of_int
+
+        # There are two GEMM sizes for each problem, corresponding to 2 matrix
+        # multiplications in attention
+        problem_sizes_size = 2 * size_of_gemm_coord * problem_count
+
+        # For each problem, need space for leading dimensions of 5 matrices:
+        # Q, K, V, O. Leading dimensions are in int64.
+        ld_sizes = 4 * size_of_int64 * problem_count
+
+        # For each problem, pointers to 5 matrices: Q, K, V, O, O_accum
+        size_of_ptr = 8  # 64-bit arch
+        ptrs_sizes = 5 * size_of_ptr * problem_count
+        total_size = problem_sizes_size + accu_size + ld_sizes + ptrs_sizes
+        return total_size
 
     def _get_op_attributes(self):
         target_attrs = ["causal"]
@@ -176,6 +256,7 @@ class mem_eff_attention(Operator):
     def gen_function(self) -> str:
         """call backend functions"""
         target = backend.target.Target.current()
+        self._attrs["arch"] = target._arch
         func_key = "{target}.{op}.gen_function".format(
             target=target.name(), op=self._attrs["op"]
         )

--- a/static/include/cuda_device_functions.h
+++ b/static/include/cuda_device_functions.h
@@ -365,7 +365,8 @@ inline DeviceError GetLastError() {
 }
 
 inline std::string GetLastErrorString() {
-  return cudaGetErrorString(cudaGetLastError());
+  auto err = cudaGetLastError();
+  return cudaGetErrorString(err);
 }
 
 inline DeviceError StreamSynchronize(StreamType stream) {

--- a/static/include/kernels/mem_eff_attention/kernel_forward.h
+++ b/static/include/kernels/mem_eff_attention/kernel_forward.h
@@ -1,0 +1,952 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2023 NVIDIA CORPORATION & AFFILIATES. All rights
+ *reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holdvr nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+// This code has been adapted from
+// https://github.com/NVIDIA/cutlass/blob/77549ae6c8cf31c7ac4c8b88180a8708a8683da4/examples/41_fused_multi_head_attention/kernel_forward.h
+
+#pragma once
+
+#ifdef HAS_PYTORCH
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/library.h>
+#endif
+
+#include <cmath>
+#include <vector>
+
+#include "cutlass/bfloat16.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/layout/matrix.h"
+#include "cutlass/layout/vector.h"
+#include "cutlass/numeric_types.h"
+
+#include "attention_scaling_coefs_updater.h"
+#include "cutlass/epilogue/threadblock/default_epilogue_simt.h"
+#include "cutlass/epilogue/threadblock/default_epilogue_tensor_op.h"
+#include "cutlass/epilogue/threadblock/default_epilogue_volta_tensor_op.h"
+#include "cutlass/gemm/device/default_gemm_configuration.h"
+#include "cutlass/gemm/kernel/default_gemm.h"
+#include "cutlass/gemm/threadblock/default_mma.h"
+#include "cutlass/gemm/threadblock/default_mma_core_simt.h"
+#include "cutlass/gemm/threadblock/default_mma_core_sm70.h"
+#include "cutlass/gemm/threadblock/default_mma_core_sm75.h"
+#include "cutlass/gemm/threadblock/default_mma_core_sm80.h"
+#include "cutlass/gemm/threadblock/threadblock_swizzle.h"
+#include "cutlass/matrix_shape.h"
+#include "cutlass/platform/platform.h"
+#include "cutlass/transform/threadblock/predicated_tile_iterator.h"
+
+// From
+// fbcode/aitemplate/AITemplate/fb/3rdparty/cutlass/examples/41_fused_multi_head_attention/
+#include "debug_utils.h"
+#include "epilogue_pipelined.h"
+#include "epilogue_rescale_output.h"
+#include "find_default_mma.h"
+#include "gemm_kernel_utils.h"
+#include "mma_from_smem.h"
+
+#include <inttypes.h>
+
+using namespace gemm_kernel_utils;
+
+namespace {
+template <typename scalar_t, typename Arch>
+constexpr int getWarpsPerSm() {
+  return (
+      Arch::kMinComputeCapability >= 80 &&
+              !cutlass::platform::is_same<scalar_t, float>::value
+          ? 16
+          : 12);
+}
+} // namespace
+
+template <
+    // The datatype of Q/K/V
+    typename scalar_t_,
+    // Architecture we are targeting (eg `cutlass::arch::Sm80`)
+    typename ArchTag,
+    // If Q/K/V are correctly aligned in memory and we can run a fast kernel
+    bool isAligned_,
+    int kQueriesPerBlock,
+    int kKeysPerBlock,
+    bool kSingleValueIteration // = `value.shape[-1] <= kKeysPerBlock`
+    >
+struct AttentionKernel {
+  using scalar_t = scalar_t_;
+  using accum_t = float;
+  using lse_scalar_t = float;
+  using output_t = scalar_t;
+  // Accumulator between 2 iterations
+  // Using `accum_t` improves perf on f16 at the cost of
+  // numerical errors
+  using output_accum_t = accum_t;
+  static constexpr bool kIsAligned = isAligned_;
+  static constexpr int32_t kAlignLSE = 32; // block size of backward
+  static constexpr bool kPreloadV = ArchTag::kMinComputeCapability >= 80 &&
+      cutlass::sizeof_bits<scalar_t>::value == 16;
+  static constexpr bool kKeepOutputInRF = kSingleValueIteration;
+  static constexpr bool kNeedsOutputAccumulatorBuffer = !kKeepOutputInRF &&
+      !cutlass::platform::is_same<output_accum_t, output_t>::value;
+
+  static_assert(kQueriesPerBlock % 32 == 0, "");
+  static_assert(kKeysPerBlock % 32 == 0, "");
+  static constexpr int kNumWarpsPerBlock =
+      kQueriesPerBlock * kKeysPerBlock / (32 * 32);
+  static constexpr int kWarpSize = 32;
+
+  // Launch bounds
+  static constexpr int kNumThreads = kWarpSize * kNumWarpsPerBlock;
+  static constexpr int kMinBlocksPerSm =
+      getWarpsPerSm<scalar_t, ArchTag>() / kNumWarpsPerBlock;
+
+  struct Params {
+    // Input tensors
+    scalar_t* query_ptr; // [num_queries, num_heads, head_dim]
+    scalar_t* key_ptr; // [num_keys, num_heads, head_dim]
+    scalar_t* value_ptr; // [num_keys, num_heads, head_dim_value]
+    int32_t* seqlens_q_ptr = nullptr;
+    int32_t* seqlens_k_ptr = nullptr;
+
+    // Output tensors
+    output_t* output_ptr; // [num_queries, num_heads, head_dim_value]
+    output_accum_t*
+        output_accum_ptr; // [num_queries, num_heads, head_dim_value]
+    lse_scalar_t* logsumexp_ptr; // [num_heads, num_queries] - can be null
+
+    // Dimensions/strides
+    int32_t head_dim;
+    int32_t head_dim_value;
+    int32_t num_queries;
+    int32_t num_keys;
+
+    bool causal;
+
+    int32_t q_strideM;
+    int32_t k_strideM;
+    int32_t v_strideM;
+
+    // Everything below is only used in `advance_to_block`
+    // and shouldn't use registers
+    int32_t q_strideH;
+    int32_t k_strideH;
+    int32_t v_strideH;
+    int32_t o_strideH;
+    int64_t q_strideB;
+    int64_t k_strideB;
+    int64_t v_strideB;
+    int64_t o_strideB;
+    int32_t num_batches;
+    int32_t num_heads;
+
+    CUTLASS_HOST_DEVICE int32_t o_strideM() const {
+      // Note: Note in sync with cutlass' main branch!! Make sure to apply
+      // when updating cutlass.
+      return head_dim_value * num_heads;
+    }
+
+    // Moves pointers to what we should process
+    // Returns "false" if there is no work to do
+    CUTLASS_DEVICE bool advance_to_block() {
+      auto batch_id = blockIdx.z;
+      auto head_id = blockIdx.y;
+      auto query_start = blockIdx.x * kQueriesPerBlock;
+
+      auto lse_dim = ceil_div((int32_t)num_queries, kAlignLSE) * kAlignLSE;
+
+      // In case of variable target sequence lengths, get real sequence length
+      // for this batch
+      if (seqlens_q_ptr != nullptr) {
+        num_queries = seqlens_q_ptr[batch_id];
+        if (query_start >= num_queries) {
+          return false;
+        }
+      }
+      // In case of variable source sequence lengths, get real sequence length
+      // for this batch
+      if (seqlens_k_ptr != nullptr) {
+        num_keys = seqlens_k_ptr[batch_id];
+      }
+
+      query_ptr += batch_id * q_strideB;
+      key_ptr += batch_id * k_strideB;
+      value_ptr += batch_id * v_strideB;
+      output_ptr += batch_id * o_strideB;
+      if (output_accum_ptr != nullptr) {
+        output_accum_ptr += batch_id * o_strideB;
+      }
+
+      // Advance to the current batch / head / query_start
+      query_ptr += query_start * q_strideM + head_id * q_strideH;
+      key_ptr += head_id * k_strideH;
+      value_ptr += head_id * v_strideH;
+      output_ptr += int64_t(query_start) * o_strideM() + head_id * o_strideH;
+
+      if (output_accum_ptr != nullptr) {
+        output_accum_ptr +=
+            int64_t(query_start) * o_strideM() + head_id * o_strideH;
+      } else {
+        // Accumulate directly in the destination buffer (eg for f32)
+        output_accum_ptr = (accum_t*)output_ptr;
+      }
+      if (logsumexp_ptr != nullptr) {
+        // lse[batch_id, head_id, query_start]
+        logsumexp_ptr +=
+            batch_id * lse_dim * num_heads + head_id * lse_dim + query_start;
+      }
+
+      num_queries -= query_start;
+      if (causal) {
+        num_keys = cutlass::fast_min(
+            int32_t(query_start + kQueriesPerBlock), num_keys);
+      }
+      num_batches = 0; // no longer used after
+
+      // Make sure the compiler knows these variables are the same on all
+      // the threads of the warp.
+      query_ptr = warp_uniform(query_ptr);
+      key_ptr = warp_uniform(key_ptr);
+      value_ptr = warp_uniform(value_ptr);
+      output_ptr = warp_uniform(output_ptr);
+      output_accum_ptr = warp_uniform(output_accum_ptr);
+      logsumexp_ptr = warp_uniform(logsumexp_ptr);
+      num_queries = warp_uniform(num_queries);
+      num_keys = warp_uniform(num_keys);
+      head_dim = warp_uniform(head_dim);
+      head_dim_value = warp_uniform(head_dim_value);
+      return true;
+    }
+
+    __host__ dim3 getBlocksGrid() const {
+      return dim3(
+          ceil_div(num_queries, (int32_t)kQueriesPerBlock),
+          num_heads,
+          num_batches);
+    }
+    __host__ dim3 getThreadsGrid() const {
+      return dim3(kWarpSize, kNumWarpsPerBlock, 1);
+    }
+  };
+
+  struct MM0 {
+    /*
+      In this first matmul, we compute a block of `Q @ K.T`.
+      While the calculation result is still hot in registers, we update
+      `mi`, `m_prime`, `s_prime` in shared-memory, and then store this value
+      into a shared-memory ("AccumulatorSharedStorage") that is used later as
+      operand A for the second matmul (see MM1)
+    */
+    using GemmType = DefaultGemmType<ArchTag, scalar_t>;
+
+    using OpClass = typename GemmType::OpClass;
+    using DefaultConfig =
+        typename cutlass::gemm::device::DefaultGemmConfiguration<
+            OpClass,
+            ArchTag,
+            scalar_t,
+            scalar_t,
+            scalar_t, // ElementC
+            accum_t // ElementAccumulator
+            >;
+    static constexpr int kAlignmentA =
+        kIsAligned ? DefaultConfig::kAlignmentA : GemmType::kMinimumAlignment;
+    static constexpr int kAlignmentB =
+        kIsAligned ? DefaultConfig::kAlignmentB : GemmType::kMinimumAlignment;
+    using ThreadblockShape = cutlass::gemm::
+        GemmShape<kQueriesPerBlock, kKeysPerBlock, GemmType::ThreadK>;
+    using WarpShape = cutlass::gemm::GemmShape<32, 32, GemmType::WarpK>;
+    using DefaultMma = typename cutlass::gemm::threadblock::FindDefaultMma<
+        scalar_t, // ElementA,
+        cutlass::layout::RowMajor, // LayoutA,
+        kAlignmentA,
+        scalar_t, // ElementB,
+        cutlass::layout::ColumnMajor, // LayoutB,
+        kAlignmentB,
+        accum_t,
+        cutlass::layout::RowMajor, // LayoutC,
+        OpClass,
+        ArchTag, // ArchTag
+        ThreadblockShape, // ThreadblockShape
+        WarpShape, // WarpShape
+        typename GemmType::InstructionShape, // InstructionShape
+        DefaultConfig::kStages, // Should use `DefaultConfig::kStages`, but that
+                                // uses too much smem
+        typename GemmType::Operator // Operator
+        >::DefaultMma;
+    using MmaCore = typename DefaultMma::MmaCore;
+    using IteratorA = typename DefaultMma::IteratorA;
+    using IteratorB = typename DefaultMma::IteratorB;
+    using Mma = typename DefaultMma::ThreadblockMma;
+    using ScalingCoefsUpdater = typename DefaultAttentionScalingCoefsUpdater<
+        typename Mma::Operator::IteratorC,
+        accum_t,
+        kWarpSize>::Updater;
+    static_assert(
+        MmaCore::WarpCount::kM * MmaCore::WarpCount::kN *
+                MmaCore::WarpCount::kK ==
+            kNumWarpsPerBlock,
+        "");
+
+    // Epilogue to store to shared-memory in a format that we can use later for
+    // the second matmul
+    using B2bGemm = typename cutlass::gemm::threadblock::B2bGemm<
+        typename Mma::Operator::IteratorC,
+        typename Mma::Operator,
+        scalar_t,
+        WarpShape,
+        ThreadblockShape>;
+    using AccumulatorSharedStorage = typename B2bGemm::AccumulatorSharedStorage;
+  };
+
+  struct MM1 {
+    /**
+      Second matmul: perform `attn @ V` where `attn` is the attention (not
+      normalized) and stored in shared memory
+    */
+    using GemmType = DefaultGemmType<ArchTag, scalar_t>;
+
+    using OpClass = typename GemmType::OpClass;
+    using DefaultConfig =
+        typename cutlass::gemm::device::DefaultGemmConfiguration<
+            OpClass,
+            ArchTag,
+            scalar_t,
+            scalar_t,
+            output_accum_t, // ElementC
+            accum_t // ElementAccumulator
+            >;
+    static constexpr int kAlignmentA = DefaultConfig::kAlignmentA; // from smem
+    static constexpr int kAlignmentB =
+        kIsAligned ? DefaultConfig::kAlignmentB : GemmType::kMinimumAlignment;
+    using ThreadblockShape = cutlass::gemm::
+        GemmShape<kQueriesPerBlock, kKeysPerBlock, GemmType::ThreadK>;
+    using WarpShape = cutlass::gemm::GemmShape<32, 32, GemmType::WarpK>;
+    using InstructionShape = typename GemmType::InstructionShape;
+
+    using LayoutB = cutlass::layout::RowMajor;
+    using DefaultGemm = cutlass::gemm::kernel::DefaultGemm<
+        scalar_t, // ElementA,
+        cutlass::layout::RowMajor, // LayoutA,
+        kAlignmentA,
+        scalar_t, // ElementB,
+        LayoutB, // LayoutB,
+        kAlignmentB,
+        output_accum_t,
+        cutlass::layout::RowMajor, // LayoutC,
+        accum_t,
+        OpClass,
+        ArchTag,
+        ThreadblockShape,
+        WarpShape,
+        typename GemmType::InstructionShape,
+        typename DefaultConfig::EpilogueOutputOp,
+        void, // ThreadblockSwizzle - not used
+        DefaultConfig::kStages,
+        false, // SplitKSerial
+        typename GemmType::Operator>;
+
+    using DefaultMmaFromSmem =
+        typename cutlass::gemm::threadblock::DefaultMmaFromSharedMemory<
+            typename DefaultGemm::Mma,
+            typename MM0::AccumulatorSharedStorage>;
+    using Mma = typename DefaultMmaFromSmem::Mma;
+    using IteratorB = typename Mma::IteratorB;
+    using WarpCount = typename Mma::WarpCount;
+    static_assert(
+        WarpCount::kM * WarpCount::kN * WarpCount::kK == kNumWarpsPerBlock,
+        "");
+
+    using DefaultEpilogue = typename DefaultGemm::Epilogue;
+    using OutputTileIterator =
+        typename cutlass::epilogue::threadblock::PredicatedTileIterator<
+            typename DefaultEpilogue::OutputTileIterator::ThreadMap,
+            output_t>;
+    using OutputTileIteratorAccum =
+        typename cutlass::epilogue::threadblock::PredicatedTileIterator<
+            typename DefaultEpilogue::OutputTileIterator::ThreadMap,
+            output_accum_t>;
+
+    struct SharedStorageMM1 {
+      typename Mma::SharedStorage mm;
+    };
+  };
+
+  static constexpr int64_t kAlignmentQ = MM0::kAlignmentA;
+  static constexpr int64_t kAlignmentK = MM0::kAlignmentB;
+  static constexpr int64_t kAlignmentV = 1;
+
+  // Shared storage - depends on kernel params
+  struct ScalingCoefs {
+    cutlass::Array<accum_t, kQueriesPerBlock> m_prime;
+    cutlass::Array<accum_t, kQueriesPerBlock> s_prime;
+    cutlass::Array<accum_t, kQueriesPerBlock> mi;
+  };
+
+  struct SharedStorageEpilogueAtEnd : ScalingCoefs {
+    struct SharedStorageAfterMM0 {
+      // Everything here might be overwritten during MM0
+      typename MM0::AccumulatorSharedStorage si;
+      typename MM1::SharedStorageMM1 mm1;
+    };
+
+    union {
+      typename MM0::Mma::SharedStorage mm0;
+      SharedStorageAfterMM0 after_mm0;
+      typename MM1::DefaultEpilogue::SharedStorage epilogue;
+    };
+
+    CUTLASS_DEVICE typename MM1::DefaultEpilogue::SharedStorage&
+    epilogue_shared_storage() {
+      return epilogue;
+    }
+  };
+
+  struct SharedStorageEpilogueInLoop : ScalingCoefs {
+    struct SharedStorageAfterMM0 {
+      // Everything here might be overwritten during MM0
+      typename MM0::AccumulatorSharedStorage si;
+      typename MM1::SharedStorageMM1 mm1;
+      typename MM1::DefaultEpilogue::SharedStorage epilogue;
+    };
+
+    union {
+      typename MM0::Mma::SharedStorage mm0;
+      SharedStorageAfterMM0 after_mm0;
+    };
+
+    CUTLASS_DEVICE typename MM1::DefaultEpilogue::SharedStorage&
+    epilogue_shared_storage() {
+      return after_mm0.epilogue;
+    }
+  };
+
+  using SharedStorage = typename cutlass::platform::conditional<
+      kSingleValueIteration || kKeepOutputInRF,
+      SharedStorageEpilogueAtEnd,
+      SharedStorageEpilogueInLoop>::type;
+
+  static bool __host__ check_supported(Params const& p) {
+    CHECK_ALIGNED_PTR(p.query_ptr, kAlignmentQ);
+    CHECK_ALIGNED_PTR(p.key_ptr, kAlignmentK);
+    CHECK_ALIGNED_PTR(p.value_ptr, kAlignmentV);
+    XFORMERS_CHECK(
+        p.q_strideM % kAlignmentQ == 0, "query is not correctly aligned");
+    XFORMERS_CHECK(
+        p.k_strideM % kAlignmentK == 0, "key is not correctly aligned");
+    XFORMERS_CHECK(
+        p.v_strideM % kAlignmentV == 0, "value is not correctly aligned");
+    XFORMERS_CHECK(
+        p.q_strideH % kAlignmentQ == 0, "query is not correctly aligned");
+    XFORMERS_CHECK(
+        p.k_strideH % kAlignmentK == 0, "key is not correctly aligned");
+    XFORMERS_CHECK(
+        p.v_strideH % kAlignmentV == 0, "value is not correctly aligned");
+    return true;
+  }
+
+  static void CUTLASS_DEVICE attention_kernel(Params& p) {
+    // In this block, we will only ever:
+    // - read query[query_start:query_end, :]
+    // - write to output[query_start:query_end, :]
+
+    extern __shared__ char smem_buffer[];
+    SharedStorage& shared_storage = *((SharedStorage*)smem_buffer);
+    auto& m_prime = shared_storage.m_prime;
+    auto& s_prime = shared_storage.s_prime;
+    [[maybe_unused]] auto& si = shared_storage.after_mm0.si;
+    auto& mi = shared_storage.mi;
+
+    static_assert(kQueriesPerBlock < kNumWarpsPerBlock * kWarpSize, "");
+    if (thread_id() < kQueriesPerBlock) {
+      s_prime[thread_id()] = accum_t(0);
+      m_prime[thread_id()] =
+          -cutlass::platform::numeric_limits<accum_t>::infinity();
+      mi[thread_id()] = -cutlass::platform::numeric_limits<accum_t>::infinity();
+    }
+    typename MM1::Mma::FragmentC accum_o;
+    accum_o.clear();
+
+    auto createOutputIter = [&](int col) -> typename MM1::OutputTileIterator {
+      using OutputTileIterator = typename MM1::OutputTileIterator;
+      return OutputTileIterator(
+          typename OutputTileIterator::Params{(int32_t)p.o_strideM()},
+          p.output_ptr,
+          typename OutputTileIterator::TensorCoord{
+              p.num_queries, p.head_dim_value},
+          thread_id(),
+          {0, col});
+    };
+
+    auto createOutputAccumIter = [&](int col) ->
+        typename MM1::OutputTileIteratorAccum {
+          using OutputTileIteratorAccum = typename MM1::OutputTileIteratorAccum;
+          return OutputTileIteratorAccum(
+              typename OutputTileIteratorAccum::Params{(int32_t)p.o_strideM()},
+              p.output_accum_ptr,
+              typename OutputTileIteratorAccum::TensorCoord{
+                  p.num_queries, p.head_dim_value},
+              thread_id(),
+              {0, col});
+        };
+
+    // Iterate through keys
+    for (int32_t iter_key_start = 0; iter_key_start < p.num_keys;
+         iter_key_start += kKeysPerBlock) {
+      int32_t problem_size_0_m =
+          cutlass::fast_min((int32_t)kQueriesPerBlock, p.num_queries);
+      int32_t problem_size_0_n = cutlass::fast_min(
+          int32_t(kKeysPerBlock), p.num_keys - iter_key_start);
+      int32_t const& problem_size_0_k = p.head_dim;
+      int32_t const& problem_size_1_n = p.head_dim_value;
+      int32_t const& problem_size_1_k = problem_size_0_n;
+
+      auto prologueV = [&](int blockN) {
+        typename MM1::Mma::IteratorB iterator_V(
+            typename MM1::IteratorB::Params{MM1::LayoutB(p.v_strideM)},
+            p.value_ptr + iter_key_start * p.v_strideM,
+            {problem_size_1_k, problem_size_1_n},
+            thread_id(),
+            cutlass::MatrixCoord{0, blockN * MM1::Mma::Shape::kN});
+        MM1::Mma::prologue(
+            shared_storage.after_mm0.mm1.mm,
+            iterator_V,
+            thread_id(),
+            problem_size_1_k);
+      };
+
+      __syncthreads(); // Need to have shared memory initialized, and `m_prime`
+                       // updated from end of prev iter
+      //
+      // MATMUL: Q.K_t
+      //
+      // Computes the block-matrix product of:
+      // (a) query[query_start:query_end, :]
+      // with
+      // (b) key[iter_key_start:iter_key_start + kKeysPerBlock]
+      // and stores that into `shared_storage.si`
+      //
+
+      // Compute threadblock location
+      cutlass::gemm::GemmCoord tb_tile_offset = {0, 0, 0};
+
+      cutlass::MatrixCoord tb_offset_A{
+          tb_tile_offset.m() * MM0::Mma::Shape::kM, tb_tile_offset.k()};
+
+      cutlass::MatrixCoord tb_offset_B{
+          tb_tile_offset.k(), tb_tile_offset.n() * MM0::Mma::Shape::kN};
+
+      // Construct iterators to A and B operands
+      typename MM0::IteratorA iterator_A(
+          typename MM0::IteratorA::Params(
+              typename MM0::MmaCore::LayoutA(p.q_strideM)),
+          p.query_ptr,
+          {problem_size_0_m, problem_size_0_k},
+          thread_id(),
+          tb_offset_A);
+
+      typename MM0::IteratorB iterator_B(
+          typename MM0::IteratorB::Params(
+              typename MM0::MmaCore::LayoutB(p.k_strideM)),
+          p.key_ptr + iter_key_start * p.k_strideM,
+          {problem_size_0_k, problem_size_0_n},
+          thread_id(),
+          tb_offset_B);
+
+      auto my_warp_id = warp_id();
+      auto my_lane_id = lane_id();
+
+      // Construct thread-scoped matrix multiply
+      typename MM0::Mma mma(
+          shared_storage.mm0, thread_id(), my_warp_id, my_lane_id);
+
+      typename MM0::Mma::FragmentC accum;
+
+      accum.clear();
+
+      auto gemm_k_iterations =
+          (problem_size_0_k + MM0::Mma::Shape::kK - 1) / MM0::Mma::Shape::kK;
+
+      // Compute threadblock-scoped matrix multiply-add
+      mma(gemm_k_iterations, accum, iterator_A, iterator_B, accum);
+      __syncthreads();
+
+      if (kPreloadV) {
+        prologueV(0);
+      }
+
+      typename MM0::Mma::Operator::IteratorC::TensorCoord
+          iteratorC_tile_offset = {
+              (tb_tile_offset.m() * MM0::Mma::WarpCount::kM) +
+                  (my_warp_id % MM0::Mma::WarpCount::kM),
+              (tb_tile_offset.n() * MM0::Mma::WarpCount::kN) +
+                  (my_warp_id / MM0::Mma::WarpCount::kM)};
+
+      // Mask out last if causal
+      if (p.causal && p.num_keys - iter_key_start <= kKeysPerBlock) {
+        auto query_start = blockIdx.x * kQueriesPerBlock;
+        auto lane_offset = MM0::ScalingCoefsUpdater::get_lane_offset(
+            lane_id(), warp_id(), iteratorC_tile_offset);
+        int32_t last_col;
+        MM0::ScalingCoefsUpdater::iterateRows(
+            lane_offset,
+            [&](int accum_m) {
+              last_col = query_start + accum_m - iter_key_start;
+            },
+            [&](int accum_m, int accum_n, int idx) {
+              if (accum_n > last_col) {
+                accum[idx] =
+                    -cutlass::platform::numeric_limits<accum_t>::infinity();
+              }
+            },
+            [&](int accum_m) {});
+      }
+      DISPATCH_BOOL(iter_key_start == 0, kIsFirst, ([&] {
+                      DISPATCH_BOOL(
+                          p.num_keys - iter_key_start >= kKeysPerBlock,
+                          kFullColumns,
+                          ([&] {
+                            // Update `mi` from accum stored in registers
+                            // Also updates `accum` with accum[i] <-
+                            // exp(accum[i] * scale
+                            // - mi)
+                            MM0::ScalingCoefsUpdater::update<
+                                kQueriesPerBlock,
+                                kFullColumns,
+                                kIsFirst,
+                                kKeepOutputInRF>(
+                                accum_o,
+                                accum,
+                                mi,
+                                m_prime,
+                                s_prime,
+                                lane_id(),
+                                thread_id(),
+                                warp_id(),
+                                p.num_keys - iter_key_start,
+                                iteratorC_tile_offset,
+                                1.0f / cutlass::fast_sqrt(float(p.head_dim)));
+                          }));
+                    }));
+
+      // Output results to shared-memory
+      int warp_idx_mn_0 = my_warp_id %
+          (MM0::Mma::Base::WarpCount::kM * MM0::Mma::Base::WarpCount::kN);
+      auto output_tile_coords = cutlass::MatrixCoord{
+          warp_idx_mn_0 % MM0::Mma::Base::WarpCount::kM,
+          warp_idx_mn_0 / MM0::Mma::Base::WarpCount::kM};
+
+      MM0::B2bGemm::accumToSmem(
+          shared_storage.after_mm0.si, accum, my_lane_id, output_tile_coords);
+
+      __syncthreads();
+
+      //
+      // MATMUL: Attn . V
+      // Run the matmul `attn @ V` for a block of attn and V.
+      // `attn` is read from shared memory (in `shared_storage_si`)
+      // `V` is read from global memory (with iterator_B)
+      //
+
+      const int64_t nBlockN = kSingleValueIteration
+          ? 1
+          : ceil_div(
+                (int64_t)problem_size_1_n, int64_t(MM1::ThreadblockShape::kN));
+      for (int blockN = 0; blockN < nBlockN; ++blockN) {
+        int gemm_k_iterations =
+            (problem_size_1_k + MM1::Mma::Shape::kK - 1) / MM1::Mma::Shape::kK;
+
+        // Compute threadblock-scoped matrix multiply-add and store it in accum
+        // (in registers)
+        if (!kPreloadV) {
+          __syncthreads(); // we share shmem between mma and epilogue
+        }
+
+        typename MM1::Mma::IteratorB iterator_V(
+            typename MM1::IteratorB::Params{MM1::LayoutB(p.v_strideM)},
+            p.value_ptr + iter_key_start * p.v_strideM,
+            {problem_size_1_k, problem_size_1_n},
+            thread_id(),
+            cutlass::MatrixCoord{0, blockN * MM1::Mma::Shape::kN});
+        typename MM1::Mma mma_pv(
+            shared_storage.after_mm0.mm1.mm,
+            shared_storage.after_mm0.si,
+            (int)thread_id(),
+            (int)warp_id(),
+            (int)lane_id(),
+            (int)problem_size_1_k);
+        mma_pv.set_prologue_done(kPreloadV);
+        if (!kKeepOutputInRF) {
+          accum_o.clear();
+        }
+        mma_pv(gemm_k_iterations, accum_o, iterator_V, accum_o);
+        __syncthreads();
+
+        if (kPreloadV && !kSingleValueIteration && blockN + 1 < nBlockN) {
+          prologueV(blockN + 1);
+        }
+
+        if (!kKeepOutputInRF) {
+          DISPATCH_BOOL(
+              iter_key_start == 0, kIsFirst, ([&] {
+                DISPATCH_BOOL(
+                    (iter_key_start + kKeysPerBlock) >= p.num_keys,
+                    kIsLast,
+                    ([&] {
+                      using DefaultEpilogue = typename MM1::DefaultEpilogue;
+                      using DefaultOp =
+                          typename MM1::DefaultConfig::EpilogueOutputOp;
+                      using ElementCompute = typename DefaultOp::ElementCompute;
+                      using EpilogueOutputOp = typename cutlass::epilogue::
+                          thread::MemoryEfficientAttentionNormalize<
+                              typename cutlass::platform::conditional<
+                                  kIsLast,
+                                  output_t,
+                                  output_accum_t>::type,
+                              output_accum_t,
+                              DefaultOp::kCount,
+                              typename DefaultOp::ElementAccumulator,
+                              ElementCompute,
+                              kIsFirst,
+                              kIsLast,
+                              cutlass::Array<ElementCompute, kQueriesPerBlock>>;
+                      using Epilogue = typename cutlass::epilogue::threadblock::
+                          EpiloguePipelined<
+                              typename DefaultEpilogue::Shape,
+                              typename MM1::Mma::Operator,
+                              DefaultEpilogue::kPartitionsK,
+                              typename cutlass::platform::conditional<
+                                  kIsLast,
+                                  typename MM1::OutputTileIterator,
+                                  typename MM1::OutputTileIteratorAccum>::type,
+                              typename DefaultEpilogue::
+                                  AccumulatorFragmentIterator,
+                              typename DefaultEpilogue::WarpTileIterator,
+                              typename DefaultEpilogue::SharedLoadIterator,
+                              EpilogueOutputOp,
+                              typename DefaultEpilogue::Padding,
+                              DefaultEpilogue::kFragmentsPerIteration,
+                              true, // IterationsUnroll
+                              typename MM1::OutputTileIteratorAccum // Read
+                                                                    // iterator
+                              >;
+
+                      int col = blockN * MM1::Mma::Shape::kN;
+                      auto source_iter = createOutputAccumIter(col);
+                      auto dest_iter = call_conditional<
+                          kIsLast,
+                          decltype(createOutputIter),
+                          decltype(createOutputAccumIter)>::
+                          apply(createOutputIter, createOutputAccumIter, col);
+                      EpilogueOutputOp rescale(s_prime, m_prime);
+                      Epilogue epilogue(
+                          shared_storage.epilogue_shared_storage(),
+                          thread_id(),
+                          warp_id(),
+                          lane_id());
+                      epilogue(rescale, dest_iter, accum_o, source_iter);
+                    }));
+              }));
+          if (!kSingleValueIteration) {
+            __syncthreads();
+          }
+        }
+      }
+      __syncthreads(); // we modify `m_prime` after
+    }
+
+    if (kKeepOutputInRF) {
+      constexpr bool kIsFirst = true;
+      constexpr bool kIsLast = true;
+      using DefaultEpilogue = typename MM1::DefaultEpilogue;
+      using DefaultOp = typename MM1::DefaultConfig::EpilogueOutputOp;
+      using ElementCompute = typename DefaultOp::ElementCompute;
+      using EpilogueOutputOp =
+          typename cutlass::epilogue::thread::MemoryEfficientAttentionNormalize<
+              output_t, // output
+              output_accum_t, // source
+              DefaultOp::kCount,
+              typename DefaultOp::ElementAccumulator, // accum
+              output_accum_t, // compute
+              kIsFirst,
+              kIsLast,
+              cutlass::Array<ElementCompute, kQueriesPerBlock>>;
+      using Epilogue =
+          typename cutlass::epilogue::threadblock::EpiloguePipelined<
+              typename DefaultEpilogue::Shape,
+              typename MM1::Mma::Operator,
+              DefaultEpilogue::kPartitionsK,
+              typename MM1::OutputTileIterator, // destination
+              typename DefaultEpilogue::AccumulatorFragmentIterator,
+              typename DefaultEpilogue::WarpTileIterator,
+              typename DefaultEpilogue::SharedLoadIterator,
+              EpilogueOutputOp,
+              typename DefaultEpilogue::Padding,
+              DefaultEpilogue::kFragmentsPerIteration,
+              true, // IterationsUnroll
+              typename MM1::OutputTileIteratorAccum // source tile
+              >;
+      auto dest_iter = createOutputIter(0);
+      EpilogueOutputOp rescale(s_prime, m_prime);
+      Epilogue epilogue(
+          shared_storage.epilogue_shared_storage(),
+          thread_id(),
+          warp_id(),
+          lane_id());
+      epilogue(rescale, dest_iter, accum_o);
+    }
+
+    // 7. Calculate logsumexp
+    // To make the backward easier, we pad logsumexp with `inf`
+    // this avoids a few bound checks, and is not more expensive during fwd
+    static_assert(kQueriesPerBlock < kNumWarpsPerBlock * kWarpSize, "");
+    if (p.logsumexp_ptr && thread_id() < kQueriesPerBlock) {
+      auto lse_dim = ceil_div((int32_t)p.num_queries, kAlignLSE) * kAlignLSE;
+      if (thread_id() < p.num_queries) {
+        p.logsumexp_ptr[thread_id()] = accum_t(mi[thread_id()]) +
+            cutlass::fast_log(accum_t(s_prime[thread_id()]));
+      } else if (thread_id() < lse_dim) {
+        p.logsumexp_ptr[thread_id()] =
+            cutlass::platform::numeric_limits<accum_t>::infinity();
+      }
+    }
+  }
+
+  static CUTLASS_DEVICE int8_t lane_id() {
+    return threadIdx.x;
+  }
+  static CUTLASS_DEVICE int8_t warp_id() {
+    return threadIdx.y;
+  }
+  static CUTLASS_DEVICE int16_t thread_id() {
+    return threadIdx.x + threadIdx.y * blockDim.x;
+  }
+};
+
+template <typename AK>
+__global__ void __launch_bounds__(AK::kNumThreads, AK::kMinBlocksPerSm)
+    attention_kernel_batched_impl(typename AK::Params p) {
+  if (!p.advance_to_block()) {
+    return;
+  }
+  AK::attention_kernel(p);
+}
+
+template <typename AK>
+__global__ void __launch_bounds__(AK::kNumThreads, AK::kMinBlocksPerSm)
+    attention_kernel_batched(typename AK::Params params);
+
+#define _ATTENTION_KERNEL_FORWARD_BEGIN(...)                                  \
+  template <>                                                                 \
+  __global__ void __launch_bounds__(                                          \
+      __VA_ARGS__::kNumThreads, __VA_ARGS__::kMinBlocksPerSm)                 \
+      attention_kernel_batched<__VA_ARGS__>(typename __VA_ARGS__::Params p) { \
+    using Kernel = __VA_ARGS__;
+#define _ATTENTION_KERNEL_FORWARD_END() }
+
+#ifdef __CUDA_ARCH__
+#define __CUDA_ARCH_OR_ZERO__ __CUDA_ARCH__
+#else
+#define __CUDA_ARCH_OR_ZERO__ 0
+#endif
+
+#define INSTANTIATE_ATTENTION_KERNEL_FORWARD(              \
+    ARCH,                                                  \
+    SCALAR_T,                                              \
+    IS_ALIGNED,                                            \
+    QUERIES_PER_BLOCK,                                     \
+    KEYS_PER_BLOCK,                                        \
+    SINGLE_VALUE_ITER)                                     \
+  _ATTENTION_KERNEL_FORWARD_BEGIN(AttentionKernel<         \
+                                  SCALAR_T,                \
+                                  cutlass::arch::Sm##ARCH, \
+                                  IS_ALIGNED,              \
+                                  QUERIES_PER_BLOCK,       \
+                                  KEYS_PER_BLOCK,          \
+                                  SINGLE_VALUE_ITER>)      \
+  if (!p.advance_to_block()) {                             \
+    return;                                                \
+  }                                                        \
+  Kernel::attention_kernel(p);                             \
+  _ATTENTION_KERNEL_FORWARD_END();
+
+#define INSTANTIATE_ATTENTION_KERNEL_FORWARD_DISABLED(              \
+    ARCH,                                                           \
+    SCALAR_T,                                                       \
+    IS_ALIGNED,                                                     \
+    QUERIES_PER_BLOCK,                                              \
+    KEYS_PER_BLOCK,                                                 \
+    SINGLE_VALUE_ITER)                                              \
+  _ATTENTION_KERNEL_FORWARD_BEGIN(AttentionKernel<                  \
+                                  SCALAR_T,                         \
+                                  cutlass::arch::Sm##ARCH,          \
+                                  IS_ALIGNED,                       \
+                                  QUERIES_PER_BLOCK,                \
+                                  KEYS_PER_BLOCK,                   \
+                                  SINGLE_VALUE_ITER>)               \
+  printf(                                                           \
+      "FATAL: this function is for sm%d, but was built for sm%d\n", \
+      int(ARCH),                                                    \
+      int(__CUDA_ARCH_OR_ZERO__));                                  \
+  _ATTENTION_KERNEL_FORWARD_END();
+
+// All kernels are disabled by default
+#define INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(...) \
+  INSTANTIATE_ATTENTION_KERNEL_FORWARD_DISABLED(50, __VA_ARGS__)
+#define INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM70(...) \
+  INSTANTIATE_ATTENTION_KERNEL_FORWARD_DISABLED(70, __VA_ARGS__)
+#define INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM75(...) \
+  INSTANTIATE_ATTENTION_KERNEL_FORWARD_DISABLED(75, __VA_ARGS__)
+#define INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(...) \
+  INSTANTIATE_ATTENTION_KERNEL_FORWARD_DISABLED(80, __VA_ARGS__)
+
+// Enable the right one based on __CUDA_ARCH__
+#ifndef __CUDA_ARCH__
+#elif __CUDA_ARCH__ < 500
+#error "Need cuda arch at least 5.0"
+#elif __CUDA_ARCH__ < 700
+#undef INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50
+#define INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(...) \
+  INSTANTIATE_ATTENTION_KERNEL_FORWARD(50, __VA_ARGS__)
+#elif __CUDA_ARCH__ < 750
+#undef INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM70
+#define INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM70(...) \
+  INSTANTIATE_ATTENTION_KERNEL_FORWARD(70, __VA_ARGS__)
+#elif __CUDA_ARCH__ < 800
+#undef INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM75
+#define INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM75(...) \
+  INSTANTIATE_ATTENTION_KERNEL_FORWARD(75, __VA_ARGS__)
+#elif __CUDA_ARCH__ >= 800
+#undef INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80
+#define INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(...) \
+  INSTANTIATE_ATTENTION_KERNEL_FORWARD(80, __VA_ARGS__)
+#endif

--- a/static/include/model.h
+++ b/static/include/model.h
@@ -22,7 +22,8 @@ namespace ait {
 inline void DeviceCheckLastError(const char* file, int line) {
   auto device_error = GetLastError();
   if (device_error != GetDeviceSuccess()) {
-    std::string msg = std::string("Got error: ") + GetLastErrorString() +
+    std::string msg = std::string("Got error: ") +
+        cudaGetErrorString(device_error) +
         " enum: " + std::to_string(device_error) + " at " + file + ": " +
         std::to_string(line);
     LOG(ERROR) << msg;

--- a/tests/unittest/ops/test_attention.py
+++ b/tests/unittest/ops/test_attention.py
@@ -15,6 +15,7 @@
 """
 Unittests for flash_attention Operator.
 """
+import itertools
 import logging
 import math
 import os
@@ -28,12 +29,15 @@ from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import benchmark_pt, detect_target
 from aitemplate.testing.test_utils import (
-    filter_test_cases_by_test_env,
+    filter_test_cases_by_params,
     get_random_torch_tensor,
+    TestEnv,
 )
 from aitemplate.utils.torch_utils import string_to_torch_dtype
 
 from einops import rearrange, repeat
+
+from parameterized import parameterized
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -69,6 +73,21 @@ def index_first_axis(x, indices):
 
 def attention_ref(qkv, attn_mask, dropout_p, upcast=False, causal=False):
     """
+    Reference implementation of scaled dot-product attention. For benchmarking
+    purposes, when possible we use torch.nn.functional.scaled_dot_product_attention,
+    which calls optimized mem.effient and flash attention kernels.
+    """
+    if True or (causal and attn_mask is not None):
+        # SDPA doesn't support causal and custom masks simultaneously,
+        # fall back on manual implementation
+        return attention_ref_math(
+            qkv, attn_mask, dropout_p, upcast=upcast, causal=causal
+        )
+    return attention_ref_sdpa(qkv, attn_mask, dropout_p, upcast=upcast, causal=causal)
+
+
+def attention_ref_sdpa(qkv, attn_mask, dropout_p, upcast=False, causal=False):
+    """
     Arguments:
         qkv: (batch_size, seqlen, 3, nheads, head_dim)
         attn_mask: (batch_size, seqlen)
@@ -78,10 +97,39 @@ def attention_ref(qkv, attn_mask, dropout_p, upcast=False, causal=False):
         attention: softmax after dropout
     """
     q, k, v = (qkv.float() if upcast else qkv).unbind(dim=2)
+    q = q.transpose(1, 2)  # to (batch_size, nheads, seqlen, head_dim)
+    k = k.transpose(1, 2)
+    v = v.transpose(1, 2)
+    if attn_mask is not None:
+        # to (batch_size, nheads, seqlen, seqlen)
+        attn_mask = attn_mask.reshape(q.shape[0], 1, 1, q.shape[2])
+    output = torch.nn.functional.scaled_dot_product_attention(
+        q, k, v, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=causal
+    )
+    output = output.transpose(1, 2)  # to (batch_size, seqlen, nheads, head_dim)
+    return output.to(dtype=qkv.dtype)
+
+
+def attention_ref_math(qkv, attn_mask, dropout_p, upcast=False, causal=False):
+    """
+    Arguments:
+        qkv: (batch_size, seqlen, 3, nheads, head_dim)
+        attn_mask: (batch_size, seqlen), or (batch_size, target_len, seqlen),
+            or (batch_size, nheads, target_len, seqlen), or broadcastable to that shape.
+        dropout_p: float
+    Output:
+        output: (batch_size, seqlen, nheads, head_dim)
+        attention: softmax after dropout
+    """
+    q, k, v = (qkv.float() if upcast else qkv).unbind(dim=2)
     seqlen = qkv.shape[1]
     d = qkv.shape[-1]
     scores = torch.einsum("bthd,bshd->bhts", q, k / math.sqrt(d))
-    scores.masked_fill_(rearrange(~attn_mask, "b s -> b 1 1 s"), float("-inf"))
+    if len(attn_mask.shape) == 2:
+        attn_mask_expanded = rearrange(attn_mask, "b s -> b 1 1 s")
+    elif len(attn_mask.shape) == 3:
+        attn_mask_expanded = rearrange(attn_mask, "b t s -> b 1 t s")
+    scores.masked_fill_(~attn_mask_expanded, float("-inf"))
     if causal:
         causal_mask = torch.triu(
             torch.ones(seqlen, seqlen, dtype=torch.bool, device=qkv.device), 1
@@ -170,136 +218,138 @@ class AttentionTestCase(unittest.TestCase):
         torch_dtype = string_to_torch_dtype(dtype)
         d = n // nheads
 
-        x = torch.randn(
-            batch_size,
-            seqlen,
-            n,
-            device="cuda",
-            dtype=torch_dtype,
-            requires_grad=True,
-        )
-        Wqkv = torch.nn.Linear(
-            nheads * d,
-            3 * nheads * d,
-            device=device,
-            dtype=torch_dtype,
-        )
+        with torch.no_grad():
+            x = torch.randn(
+                batch_size,
+                seqlen,
+                n,
+                device="cuda",
+                dtype=torch_dtype,
+            )
+            Wqkv = torch.nn.Linear(
+                nheads * d,
+                3 * nheads * d,
+                device=device,
+                dtype=torch_dtype,
+            )
 
-        lengths = torch.tensor(
-            [seqlen] * batch_size, dtype=torch.int, device="cuda"
-        ).reshape(-1, 1)
-        attention_mask_bool = (
-            repeat(torch.arange(seqlen, device="cuda"), "s -> b s", b=batch_size)
-            < lengths
-        )
-        attention_mask = torch.zeros(
-            batch_size,
-            seqlen,
-            device="cuda",
-            dtype=torch_dtype,
-        )
-        attention_mask = rearrange(attention_mask, "b s -> b 1 1 s")
+            lengths = torch.tensor(
+                [seqlen] * batch_size, dtype=torch.int, device="cuda"
+            ).reshape(-1, 1)
+            attention_mask_bool = (
+                repeat(torch.arange(seqlen, device="cuda"), "s -> b s", b=batch_size)
+                < lengths
+            )
+            attention_mask = torch.zeros(
+                batch_size,
+                seqlen,
+                device="cuda",
+                dtype=torch_dtype,
+            )
+            attention_mask = rearrange(attention_mask, "b s -> b 1 1 s")
 
-        x_unpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(
-            x, attention_mask_bool
-        )
-        qkv_unpad = (
-            rearrange(Wqkv(x_unpad), "nnz (t h d) -> nnz t h d", t=3, h=nheads)
-            .detach()
-            .requires_grad_()
-        )
-        qkv = (
-            rearrange(Wqkv(x), "b s (t h d) -> b s t h d", t=3, h=nheads)
-            .detach()
-            .requires_grad_()
-        )
-        output = attention_ref(qkv, attention_mask_bool, dropout_p, causal=causal)
-        y_pt = output.detach()
+            x_unpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(
+                x, attention_mask_bool
+            )
+            qkv_unpad = rearrange(
+                Wqkv(x_unpad), "nnz (t h d) -> nnz t h d", t=3, h=nheads
+            )
+            qkv = rearrange(Wqkv(x), "b s (t h d) -> b s t h d", t=3, h=nheads)
+            y_pt = attention_ref(qkv, attention_mask_bool, dropout_p, causal=causal)
 
-        total, _, num_heads, head_size = qkv_unpad.shape
+            total, _, num_heads, head_size = qkv_unpad.shape
 
-        X1 = Tensor(
-            shape=[total, 3, num_heads, head_size],
-            dtype=dtype,
-            name="qkv",
-            is_input=True,
-        )
-        X2 = Tensor(
-            shape=[batch_size + 1],
-            dtype="int32",
-            name="cu_seqlens",
-            is_input=True,
-        )
+            X1 = Tensor(
+                shape=[total, 3, num_heads, head_size],
+                dtype=dtype,
+                name="qkv",
+                is_input=True,
+            )
+            X2 = Tensor(
+                shape=[batch_size + 1],
+                dtype="int32",
+                name="cu_seqlens",
+                is_input=True,
+            )
 
-        flash_attention_op = ops.flash_attention(
-            batch_size=batch_size,
-            dropout=dropout_p,
-            max_seq_len=max_seqlen_in_batch,
-            causal=causal,
-        )
-        if copy_op:
             flash_attention_op = ops.flash_attention(
-                **flash_attention_op._get_op_attributes()
+                batch_size=batch_size,
+                dropout=dropout_p,
+                max_seq_len=max_seqlen_in_batch,
+                causal=causal,
             )
-        Y = flash_attention_op(X1, X2)
-        Y._attrs["is_output"] = True
-        Y._attrs["name"] = "output"
+            if copy_op:
+                flash_attention_op = ops.flash_attention(
+                    **flash_attention_op._get_op_attributes()
+                )
+            Y = flash_attention_op(X1, X2)
+            Y._attrs["is_output"] = True
+            Y._attrs["name"] = "output"
 
-        if rebuild:
-            target = detect_target()
-            module = compile_model(Y, target, "./tmp", test_name)
-        else:
-            module = Model(os.path.join("./tmp", test_name, "test.so"))
+            if rebuild:
+                target = detect_target()
+                module = compile_model(Y, target, "./tmp", test_name)
+            else:
+                module = Model(os.path.join("./tmp", test_name, "test.so"))
 
-        x1 = qkv_unpad.detach().to(torch_dtype).cuda()
-        x2 = cu_seqlens.detach().to(torch.int32).cuda()
-        inputs = {"qkv": x1, "cu_seqlens": x2}
-        y = torch.empty(
-            [total, num_heads, head_size],
-            dtype=torch_dtype,
-            device="cuda",
-        )
-        module.run_with_tensors(inputs, [y])
-
-        # Warm up.
-        for _ in range(5):
+            x1 = qkv_unpad.to(torch_dtype).cuda()
+            x2 = cu_seqlens.to(torch.int32).cuda()
+            inputs = {"qkv": x1, "cu_seqlens": x2}
+            y = torch.empty(
+                [total, num_heads, head_size],
+                dtype=torch_dtype,
+                device="cuda",
+            )
             module.run_with_tensors(inputs, [y])
-        # Benchmark.
-        time_per_iter_ms, time_std, _ = module.benchmark_with_tensors(
-            inputs,
-            [y],
-            count=100,
-        )
-        _LOGGER.info(f"benchmark flash-attn time: {time_per_iter_ms}")
 
-        y = y.reshape((batch_size, -1, nheads, d))
-        torch.testing.assert_close(y, y_pt, atol=1e-3, rtol=1e-3)
-
-        if benchmark_pt:
-            from aitemplate.testing.benchmark_pt import benchmark_torch_function
-
-            func = attention_ref
-            args = (
-                qkv.to(torch_dtype).cuda(),
-                attention_mask_bool.cuda(),
-                dropout_p,
-                False,
-                False,
+            # Warm up.
+            for _ in range(5):
+                module.run_with_tensors(inputs, [y])
+            # Benchmark.
+            time_per_iter_ms, time_std, _ = module.benchmark_with_tensors(
+                inputs,
+                [y],
+                count=100,
             )
-            duration = benchmark_torch_function(100, func, *args)
-            print(
-                f"PT:  BS: {batch_size}, Time per iter: {duration:.2f}ms, QPS: {batch_size / duration:.2f}"
-            )
+            _LOGGER.info(f"benchmark flash-attn time: {time_per_iter_ms}")
 
-    def test_flash_attention_sm80(self):
+            y = y.reshape((batch_size, -1, nheads, d))
+            torch.testing.assert_close(y, y_pt, atol=1e-3, rtol=1e-3)
+
+            if benchmark_pt:
+                from aitemplate.testing.benchmark_pt import benchmark_torch_function
+
+                func = attention_ref
+                args = (
+                    qkv.to(torch_dtype).cuda(),
+                    attention_mask_bool.cuda(),
+                    dropout_p,
+                    False,
+                    False,
+                )
+                duration = benchmark_torch_function(100, func, *args)
+                print(
+                    f"PT:  BS: {batch_size}, Time per iter: {duration:.2f}ms, QPS: {batch_size / duration:.2f}"
+                )
+
+    @parameterized.expand(
+        filter_test_cases_by_params(
+            {
+                # Flash attention requires A100
+                TestEnv.CUDA_SM80: [("float16")],
+            }
+        ),
+        skip_on_empty=True,
+    )
+    def test_flash_attention(self, dtype):
         self._test_flash_attention(
-            test_name="flash_attention_fp16",
-            dtype="float16",
+            test_name=f"flash_attention_{dtype}",
+            dtype=dtype,
         )
         self._test_flash_attention(
-            test_name="flash_attention_fp16_copy_op",
+            test_name=f"flash_attention_{dtype}_copy_op",
             copy_op=True,
-            dtype="float16",
+            dtype=dtype,
         )
 
     def _test_attention(
@@ -393,10 +443,18 @@ class AttentionTestCase(unittest.TestCase):
             )
             _LOGGER.info(f"benchmark compiler model time: {time_per_iter_ms}")
 
-    def test_attention_rocm(self):
+    @parameterized.expand(
+        filter_test_cases_by_params(
+            {
+                TestEnv.ROCM: [("float16")],
+            }
+        ),
+        skip_on_empty=True,
+    )
+    def test_attention_rocm(self, dtype):
         self._test_attention(
-            test_name="attention_fp16",
-            dtype="float16",
+            test_name=f"attention_{dtype}",
+            dtype=dtype,
         )
 
     def _test_mem_eff_attention(
@@ -415,222 +473,379 @@ class AttentionTestCase(unittest.TestCase):
         benchmark_pt=False,
         copy_op=False,
         use_perm=True,
+        variable_seq_length_kv=False,
+        variable_seq_length_q=False,
+        skip_pt=False,
+        use_grouped_fmha=False,
         atol=1e-3,
         rtol=1e-3,
     ):
+        """
+        Use skip_pt to avoid CUDA OOM when benchmarking with problem sizes
+        which are too large for the PT implementation.
+        """
+        # Can't skip PT computation if we are benchmarking it
+        assert not (benchmark_pt and skip_pt)
+
         torch_dtype = string_to_torch_dtype(dtype)
         d = n // nheads
 
-        x = torch.randn(
-            batch_size,
-            seqlen,
-            n,
-            device="cuda",
-            dtype=torch_dtype,
-            requires_grad=True,
-        )
-        Wqkv = torch.nn.Linear(
-            nheads * d,
-            3 * nheads * d,
-            device=device,
-            dtype=torch_dtype,
-        )
+        with torch.no_grad():
+            x = torch.randn(
+                batch_size,
+                seqlen,
+                n,
+                device="cuda",
+                dtype=torch_dtype,
+            )
+            Wqkv = torch.nn.Linear(
+                nheads * d,
+                3 * nheads * d,
+                device=device,
+                dtype=torch_dtype,
+            )
 
-        lengths = torch.tensor(
-            [seqlen] * batch_size, dtype=torch.int, device="cuda"
-        ).reshape(-1, 1)
-        attention_mask_bool = (
-            repeat(torch.arange(seqlen, device="cuda"), "s -> b s", b=batch_size)
-            < lengths
-        )
-        attention_mask = torch.zeros(
-            batch_size,
-            seqlen,
-            device="cuda",
-            dtype=torch_dtype,
-        )
-        attention_mask = rearrange(attention_mask, "b s -> b 1 1 s")
+            if variable_seq_length_kv:
+                lengths_kv = torch.randint(0, seqlen + 1, size=(batch_size, 1))
+                lengths_kv = lengths_kv.to(device="cuda")
+            else:
+                lengths_kv = torch.tensor(
+                    [seqlen] * batch_size, dtype=torch.int, device="cuda"
+                ).reshape(-1, 1)
 
-        x_unpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(
-            x, attention_mask_bool
-        )
-        qkv_unpad = (
-            rearrange(Wqkv(x_unpad), "nnz (t h d) -> nnz t h d", t=3, h=nheads)
-            .detach()
-            .requires_grad_()
-        )
-        qkv = (
-            rearrange(Wqkv(x), "b s (t h d) -> b s t h d", t=3, h=nheads)
-            .detach()
-            .requires_grad_()
-        )
-        q, k, v = torch.split(qkv, 1, dim=2)
-        output = attention_ref(qkv, attention_mask_bool, dropout_p, causal=causal)
-        y_pt = output.detach()
+            if variable_seq_length_q:
+                lengths_q = torch.randint(0, seqlen + 1, size=(batch_size, 1))
+                lengths_q = lengths_q.to(device="cuda")
+            else:
+                lengths_q = torch.tensor(
+                    [seqlen] * batch_size, dtype=torch.int, device="cuda"
+                ).reshape(-1, 1)
 
-        total, _, num_heads, head_size = qkv_unpad.shape
+            seq_range = torch.arange(seqlen, device="cuda")
+            attention_mask_bool_kv = (
+                seq_range.unsqueeze(0).expand((batch_size, seqlen)) < lengths_kv
+            ).unsqueeze(1)
 
-        Q = Tensor(
-            shape=[batch_size, num_heads, seqlen, head_size],
-            dtype=dtype,
-            name="q",
-            is_input=True,
-        )
-        K = Tensor(
-            shape=[batch_size, num_heads, seqlen, head_size],
-            dtype=dtype,
-            name="k",
-            is_input=True,
-        )
-        V = Tensor(
-            shape=[batch_size, num_heads, seqlen, head_size],
-            dtype=dtype,
-            name="v",
-            is_input=True,
-        )
+            attention_mask_bool_q = (
+                seq_range.unsqueeze(0).expand((batch_size, seqlen)) < lengths_q
+            ).unsqueeze(2)
 
-        mem_eff_attention_op = ops.mem_eff_attention(
-            causal=causal,
-        )
-        if copy_op:
+            x_unpad, indices, cu_seqlens, max_seqlen_in_batch = unpad_input(
+                x, attention_mask_bool_kv
+            )
+            qkv_unpad = rearrange(
+                Wqkv(x_unpad), "nnz (t h d) -> nnz t h d", t=3, h=nheads
+            )
+            qkv = rearrange(Wqkv(x), "b s (t h d) -> b s t h d", t=3, h=nheads)
+            q, k, v = torch.split(qkv, 1, dim=2)
+            if not skip_pt:
+                y_pt = attention_ref(
+                    qkv, attention_mask_bool_kv, dropout_p, causal=causal
+                )
+
+            total, _, num_heads, head_size = qkv_unpad.shape
+
+            Q = Tensor(
+                shape=[batch_size, num_heads, seqlen, head_size],
+                dtype=dtype,
+                name="q",
+                is_input=True,
+            )
+            K = Tensor(
+                shape=[batch_size, num_heads, seqlen, head_size],
+                dtype=dtype,
+                name="k",
+                is_input=True,
+            )
+            V = Tensor(
+                shape=[batch_size, num_heads, seqlen, head_size],
+                dtype=dtype,
+                name="v",
+                is_input=True,
+            )
+
+            if variable_seq_length_kv:
+                L_kv = Tensor(
+                    shape=[batch_size, 1],
+                    dtype="int",
+                    name="lengths_kv",
+                    is_input=True,
+                )
+            if variable_seq_length_q:
+                L_q = Tensor(
+                    shape=[batch_size, 1],
+                    dtype="int",
+                    name="lengths_q",
+                    is_input=True,
+                )
+
             mem_eff_attention_op = ops.mem_eff_attention(
-                **mem_eff_attention_op._get_op_attributes()
+                causal=causal,
+                variable_seq_length_kv=variable_seq_length_kv,
+                variable_seq_length_q=variable_seq_length_q,
+                use_grouped_fmha=use_grouped_fmha,
+            )
+            if copy_op:
+                mem_eff_attention_op = ops.mem_eff_attention(
+                    **mem_eff_attention_op._get_op_attributes()
+                )
+
+            Y = mem_eff_attention_op(
+                Q,
+                K,
+                V,
+                L_kv if variable_seq_length_kv else None,
+                L_q if variable_seq_length_q else None,
             )
 
-        Y = mem_eff_attention_op(Q, K, V)
+            Y._attrs["is_output"] = True
+            Y._attrs["name"] = "output"
 
-        Y._attrs["is_output"] = True
-        Y._attrs["name"] = "output"
+            if rebuild:
+                target = detect_target()
+                module = compile_model(Y, target, "./tmp", test_name)
+            else:
+                module = Model(os.path.join("./tmp", test_name, "test.so"))
 
-        if rebuild:
-            target = detect_target()
-            module = compile_model(Y, target, "./tmp", test_name)
+            q = torch.permute(q, (0, 3, 2, 1, 4)).reshape(
+                batch_size, num_heads, seqlen, head_size
+            )
+            k = torch.permute(k, (0, 3, 2, 1, 4)).reshape(
+                batch_size, num_heads, seqlen, head_size
+            )
+            v = torch.permute(v, (0, 3, 2, 1, 4)).reshape(
+                batch_size, num_heads, seqlen, head_size
+            )
+
+            inputs = {
+                "q": q.to(torch_dtype).contiguous(),
+                "k": k.to(torch_dtype).contiguous(),
+                "v": v.to(torch_dtype).contiguous(),
+            }
+            if variable_seq_length_kv:
+                inputs["lengths_kv"] = lengths_kv.to(torch.int).contiguous()
+            if variable_seq_length_q:
+                inputs["lengths_q"] = lengths_q.to(torch.int).contiguous()
+
+            y = torch.empty(
+                [batch_size, seqlen, num_heads, head_size],
+                dtype=torch_dtype,
+                device="cuda",
+            )
+            module.run_with_tensors(inputs, [y])
+
+            ret = {}
+
+            if benchmark_ait or benchmark_pt:
+                print(
+                    f"batch_size = {batch_size}, nheads = {nheads}, seqlen = {seqlen}, n = {n}, causal = {causal}, dtype = {dtype}"
+                )
+                print(
+                    f"variable_seq_length_kv = {variable_seq_length_kv}, variable_seq_length_q = {variable_seq_length_q}"
+                )
+
+            if benchmark_ait:
+                # Warm up.
+                for _ in range(5):
+                    module.run_with_tensors(inputs, [y])
+                # Benchmark AIT
+                time_per_iter_ms, time_std, _ = module.benchmark_with_tensors(
+                    inputs,
+                    [y],
+                    count=100,
+                )
+                print(
+                    f"AIT benchmark eff-mem-attn time per iter: {time_per_iter_ms:.2f}ms"
+                )
+
+                ret["ait_time_per_iter_ms"] = time_per_iter_ms
+
+            # y ~ [batch_size, seqlen, num_heads, head_size]
+            # attention_mask_bool_q ~ [batch_size, seqlen, 1]
+            if variable_seq_length_q:
+                y = y.masked_fill_(~attention_mask_bool_q.unsqueeze(2), 0.0)
+                if not skip_pt:
+                    y_pt = y_pt.masked_fill_(~attention_mask_bool_q.unsqueeze(2), 0.0)
+
+            if not skip_pt:
+                torch.testing.assert_close(
+                    y, y_pt.to(torch_dtype), atol=atol, rtol=rtol, equal_nan=True
+                )
+
+            if benchmark_pt:
+                from aitemplate.testing.benchmark_pt import benchmark_torch_function
+
+                func = attention_ref
+                args = (
+                    qkv.to(torch_dtype).cuda(),
+                    attention_mask_bool_kv.cuda(),
+                    dropout_p,
+                    False,
+                    False,
+                )
+                duration = benchmark_torch_function(100, func, *args)
+                print(
+                    f"PT benchmark eff-mem-attn time per iter: {duration:.2f}ms, BS: {batch_size}, QPS: {batch_size / duration:.2f}"
+                )
+
+                ret["pt_time_per_iter_ms"] = duration
+
+        return ret
+
+    @parameterized.expand(
+        itertools.product(
+            filter_test_cases_by_params(
+                {
+                    TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
+                    TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],
+                }
+            ),
+            [False, True],  # variable_seq_length_kv
+            [False, True],  # variable_seq_length_q
+            [False, True],  # causal
+        ),
+    )
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_mem_eff_attention(
+        self,
+        dtype: str,
+        variable_seq_length_kv: bool,
+        variable_seq_length_q: bool,
+        causal: bool,
+    ):
+        if dtype == "bfloat16":
+            atol = 1e-2
+            rtol = 1e-2
         else:
-            module = Model(os.path.join("./tmp", test_name, "test.so"))
-
-        q = torch.permute(q, (0, 3, 2, 1, 4)).reshape(
-            batch_size, num_heads, seqlen, head_size
-        )
-        k = torch.permute(k, (0, 3, 2, 1, 4)).reshape(
-            batch_size, num_heads, seqlen, head_size
-        )
-        v = torch.permute(v, (0, 3, 2, 1, 4)).reshape(
-            batch_size, num_heads, seqlen, head_size
-        )
-
-        inputs = {
-            "q": q.detach().to(torch_dtype).cuda().contiguous(),
-            "k": k.detach().to(torch_dtype).cuda().contiguous(),
-            "v": v.detach().to(torch_dtype).cuda().contiguous(),
-        }
-
-        y = torch.empty(
-            [batch_size, seqlen, num_heads, head_size],
-            dtype=torch_dtype,
-            device="cuda",
-        )
-        module.run_with_tensors(inputs, [y])
-
-        if benchmark_ait:
-            # Warm up.
-            for _ in range(5):
-                module.run_with_tensors(inputs, [y])
-            # Benchmark AIT
-            time_per_iter_ms, time_std, _ = module.benchmark_with_tensors(
-                inputs,
-                [y],
-                count=100,
-            )
-            _LOGGER.info(f"benchmark eff-mem-attn time: {time_per_iter_ms}")
-
-        torch.testing.assert_close(y, y_pt.to(torch_dtype), atol=atol, rtol=rtol)
-
-        if benchmark_pt:
-            from aitemplate.testing.benchmark_pt import benchmark_torch_function
-
-            func = attention_ref
-            args = (
-                qkv.to(torch_dtype).cuda(),
-                attention_mask_bool.cuda(),
-                dropout_p,
-                False,
-                False,
-            )
-            duration = benchmark_torch_function(100, func, *args)
-            print(
-                f"PT:  BS: {batch_size}, Time per iter: {duration:.2f}ms, QPS: {batch_size / duration:.2f}"
-            )
-
-    def test_mem_eff_attention_fp16_sm80(self):
-        for use_perm in [False, True]:
-            self._test_mem_eff_attention(
-                use_perm=use_perm,
-                test_name=f"mem_eff_attention_fp16_{use_perm}",
-                dtype="float16",
-            )
-            self._test_mem_eff_attention(
-                use_perm=use_perm,
-                causal=True,
-                test_name=f"mem_eff_attention_fp16_{use_perm}_causal",
-                dtype="float16",
-            )
+            atol = 1e-3
+            rtol = 1e-3
+        for use_grouped_fmha in [True, False]:
             self._test_mem_eff_attention(
                 batch_size=16,
                 nheads=4,
                 seqlen=8,
                 n=80,
-                use_perm=use_perm,
-                test_name="mem_eff_attention_fp16_nheads_20",
-                dtype="float16",
+                variable_seq_length_kv=variable_seq_length_kv,
+                variable_seq_length_q=variable_seq_length_q,
+                causal=causal,
+                use_grouped_fmha=use_grouped_fmha,
+                test_name=f"mem_eff_attention_{dtype}_{causal}_{variable_seq_length_kv}_{variable_seq_length_q}_small",
+                dtype=dtype,
+                atol=atol,
+                rtol=rtol,
             )
-            # self._test_mem_eff_attention(batch_size=1, nheads=8, seqlen=8, n=64, use_perm=use_perm, test_name="mem_eff_attention1")
-            # self._test_mem_eff_attention(batch_size=16, nheads=8, seqlen=8, n=512, use_perm=use_perm, test_name="mem_eff_attention2")
-            # self._test_mem_eff_attention(batch_size=16, nheads=8, seqlen=8, n=1024, use_perm=use_perm, test_name="mem_eff_attention3")
-            # self._test_mem_eff_attention(batch_size=16, nheads=8, seqlen=16, n=1024, use_perm=use_perm, test_name="mem_eff_attention4")
-            # self._test_mem_eff_attention(batch_size=1, nheads=8, seqlen=16, n=64, use_perm=use_perm, test_name="mem_eff_attention5")
+            self._test_mem_eff_attention(
+                variable_seq_length_kv=variable_seq_length_kv,
+                variable_seq_length_q=variable_seq_length_q,
+                causal=causal,
+                test_name=f"mem_eff_attention_{dtype}_{causal}_{variable_seq_length_kv}_{variable_seq_length_q}",
+                dtype=dtype,
+                atol=atol,
+                rtol=rtol,
+            )
 
+        # self._test_mem_eff_attention(batch_size=1, nheads=8, seqlen=8, n=64, use_perm=use_perm, test_name="mem_eff_attention1")
+        # self._test_mem_eff_attention(batch_size=16, nheads=8, seqlen=8, n=512, use_perm=use_perm, test_name="mem_eff_attention2")
+        # self._test_mem_eff_attention(batch_size=16, nheads=8, seqlen=8, n=1024, use_perm=use_perm, test_name="mem_eff_attention3")
+        # self._test_mem_eff_attention(batch_size=16, nheads=8, seqlen=16, n=1024, use_perm=use_perm, test_name="mem_eff_attention4")
+        # self._test_mem_eff_attention(batch_size=1, nheads=8, seqlen=16, n=64, use_perm=use_perm, test_name="mem_eff_attention5")
+
+    @unittest.skip("Skip benchmarking in CI.")
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_mem_eff_attention_benchmark(
+        self,
+    ):
+        causal = False
+        res = []
+        for num_heads in [16]:
+            for batch_size, nheads, seqlen, n, skip_pt in (
+                # Larger head dimension
+                (1, num_heads, 1024, 1024, False),
+                (16, num_heads, 1024, 1024, False),
+                (64, num_heads, 1024, 1024, False),
+                (128, num_heads, 1024, 1024, False),
+                (1, num_heads, 1024, 2048, False),
+                (16, num_heads, 1024, 2048, False),
+                (64, num_heads, 1024, 2048, False),
+                (128, num_heads, 1024, 2048, False),
+                # Larger batch size
+                (1024, num_heads, 128, 512, True),
+                (1024, num_heads, 256, 512, True),
+                (1024, num_heads, 512, 512, True),
+                # Larger seq len
+                (128, num_heads, 1024, 512, True),
+                (128, num_heads, 2048, 512, True),
+                (128, num_heads, 4096, 512, True),
+            ):
+                for use_grouped_fmha in [True, False]:
+                    for dtype in ("float16", "float32"):
+                        for variable_seq_length_kv in [False, True]:
+                            for variable_seq_length_q in [False, True]:
+                                print("---------------------------------------------")
+                                run_res = self._test_mem_eff_attention(
+                                    batch_size=batch_size,
+                                    nheads=nheads,
+                                    seqlen=seqlen,
+                                    n=n,
+                                    variable_seq_length_kv=variable_seq_length_kv,
+                                    variable_seq_length_q=variable_seq_length_q,
+                                    causal=causal,
+                                    use_grouped_fmha=use_grouped_fmha,
+                                    benchmark_ait=True,
+                                    benchmark_pt=not skip_pt,
+                                    skip_pt=skip_pt,
+                                    test_name=f"mem_eff_attention_{dtype}_{causal}_{variable_seq_length_kv}_{variable_seq_length_q}_small",
+                                    dtype=dtype,
+                                )
+
+                                run_res.update(
+                                    {
+                                        "dtype": dtype,
+                                        "batch_size": batch_size,
+                                        "nheads": nheads,
+                                        "seqlen": seqlen,
+                                        "n": n,
+                                        "variable_seq_length_kv": variable_seq_length_kv,
+                                        "variable_seq_length_q": variable_seq_length_q,
+                                        "causal": causal,
+                                        "use_grouped_fmha": use_grouped_fmha,
+                                    }
+                                )
+                                res.append(run_res)
+                                print("Intermediate result:")
+                                print(res)
+            print("Final result:")
+            print(res)
+
+    @parameterized.expand(
+        itertools.product(
+            filter_test_cases_by_params(
+                {
+                    # Don't run this test on V100: the binary crashes
+                    # with 'misaligned address' error.
+                    TestEnv.CUDA_SM80: [("float16")],
+                }
+            ),
+            [False, True],  # variable_seq_length_kv
+            [False, True],  # variable_seq_length_q
+        ),
+        skip_on_empty=True,
+    )
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
     @unittest.expectedFailure
-    def test_mem_eff_attention_invalid_head_size_fp16_sm80(self):
+    def test_mem_eff_attention_invalid_head_size(
+        self, dtype, variable_seq_length_kv, variable_seq_length_q
+    ):
         self._test_mem_eff_attention(
             batch_size=16,
             nheads=8,
             seqlen=8,
             n=80,
-            test_name="mem_eff_attention_fp16_invalid_head_size",
-            dtype="float16",
+            variable_seq_length_kv=variable_seq_length_kv,
+            variable_seq_length_q=variable_seq_length_q,
+            test_name=f"mem_eff_attention_invalid_head_size_{dtype}_{variable_seq_length_kv}_{variable_seq_length_q}",
+            dtype=dtype,
         )
-
-    def test_mem_eff_attention_fp32_sm80(self):
-        for use_perm in [False, True]:
-            self._test_mem_eff_attention(
-                use_perm=use_perm,
-                test_name=f"mem_eff_attention_fp32_{use_perm}",
-                dtype="float32",
-            )
-            self._test_mem_eff_attention(
-                use_perm=use_perm,
-                causal=True,
-                test_name=f"mem_eff_attention_fp32_{use_perm}_causal",
-                dtype="float32",
-            )
-
-    def test_mem_eff_attention_bf16(self):
-        for use_perm in [False, True]:
-            self._test_mem_eff_attention(
-                use_perm=use_perm,
-                test_name=f"mem_eff_attention_bf16_{use_perm}",
-                dtype="bfloat16",
-                atol=1e-2,
-                rtol=1e-2,
-            )
-            self._test_mem_eff_attention(
-                use_perm=use_perm,
-                causal=True,
-                test_name=f"mem_eff_attention_bf16_{use_perm}_causal",
-                dtype="bfloat16",
-                atol=1e-2,
-                rtol=1e-2,
-            )
 
     def _test_cross_attention(
         self,
@@ -654,148 +869,132 @@ class AttentionTestCase(unittest.TestCase):
     ):
         torch_dtype = string_to_torch_dtype(dtype)
 
-        q = torch.randn(
-            batch_size,
-            seqlen,
-            num_heads,
-            head_size,
-            device="cuda",
-            dtype=torch_dtype,
-        )
-        k = torch.randn(
-            batch_size,
-            seqlen_kv,
-            num_heads,
-            head_size,
-            device="cuda",
-            dtype=torch_dtype,
-        )
-        v = torch.randn(
-            batch_size,
-            seqlen_kv,
-            num_heads,
-            head_size_v,
-            device="cuda",
-            dtype=torch_dtype,
-        )
+        with torch.no_grad():
+            q = torch.randn(
+                batch_size,
+                seqlen,
+                num_heads,
+                head_size,
+                device="cuda",
+                dtype=torch_dtype,
+            )
+            k = torch.randn(
+                batch_size,
+                seqlen_kv,
+                num_heads,
+                head_size,
+                device="cuda",
+                dtype=torch_dtype,
+            )
+            v = torch.randn(
+                batch_size,
+                seqlen_kv,
+                num_heads,
+                head_size_v,
+                device="cuda",
+                dtype=torch_dtype,
+            )
 
-        output = ref_cross_attention(q, k, v)
-        y_pt = output.detach()
+            y_pt = ref_cross_attention(q, k, v)
 
-        Q = Tensor(
-            shape=[batch_size, num_heads, seqlen, head_size],
-            dtype=dtype,
-            name="q",
-            is_input=True,
-        )
-        K = Tensor(
-            shape=[batch_size, num_heads, seqlen_kv, head_size],
-            dtype=dtype,
-            name="k",
-            is_input=True,
-        )
-        V = Tensor(
-            shape=[batch_size, num_heads, seqlen_kv, head_size_v],
-            dtype=dtype,
-            name="v",
-            is_input=True,
-        )
+            Q = Tensor(
+                shape=[batch_size, num_heads, seqlen, head_size],
+                dtype=dtype,
+                name="q",
+                is_input=True,
+            )
+            K = Tensor(
+                shape=[batch_size, num_heads, seqlen_kv, head_size],
+                dtype=dtype,
+                name="k",
+                is_input=True,
+            )
+            V = Tensor(
+                shape=[batch_size, num_heads, seqlen_kv, head_size_v],
+                dtype=dtype,
+                name="v",
+                is_input=True,
+            )
 
-        mem_eff_attention_op = ops.mem_eff_attention(
-            causal=causal,
-        )
-        if copy_op:
             mem_eff_attention_op = ops.mem_eff_attention(
-                **mem_eff_attention_op._get_op_attributes()
+                causal=causal,
             )
-        Y = mem_eff_attention_op(Q, K, V)
-        Y._attrs["is_output"] = True
-        Y._attrs["name"] = "output"
+            if copy_op:
+                mem_eff_attention_op = ops.mem_eff_attention(
+                    **mem_eff_attention_op._get_op_attributes()
+                )
+            Y = mem_eff_attention_op(Q, K, V)
+            Y._attrs["is_output"] = True
+            Y._attrs["name"] = "output"
 
-        if rebuild:
-            target = detect_target()
-            module = compile_model(Y, target, "./tmp", test_name)
+            if rebuild:
+                target = detect_target()
+                module = compile_model(Y, target, "./tmp", test_name)
+            else:
+                module = Model(os.path.join("./tmp", test_name, "test.so"))
+
+            q = torch.permute(q, (0, 2, 1, 3))
+            k = torch.permute(k, (0, 2, 1, 3))
+            v = torch.permute(v, (0, 2, 1, 3))
+
+            inputs = {
+                "q": q.to(torch_dtype).contiguous(),
+                "k": k.to(torch_dtype).contiguous(),
+                "v": v.to(torch_dtype).contiguous(),
+            }
+            y = torch.empty(
+                [batch_size, seqlen, num_heads, head_size_v],
+                dtype=torch_dtype,
+                device="cuda",
+            )
+            module.run_with_tensors(inputs, [y])
+
+            if benchmark_ait:
+                # Warm up.
+                for _ in range(5):
+                    module.run_with_tensors(inputs, [y])
+                # Benchmark AIT
+                time_per_iter_ms, time_std, _ = module.benchmark_with_tensors(
+                    inputs,
+                    [y],
+                    count=100,
+                )
+                _LOGGER.info(f"benchmark cross-attn time: {time_per_iter_ms}")
+
+            torch.testing.assert_close(y, y_pt.to(torch_dtype), atol=atol, rtol=rtol)
+
+    @parameterized.expand(
+        filter_test_cases_by_params(
+            {
+                TestEnv.CUDA_SM80: [("float16"), ("float32"), ("bfloat16")],
+            }
+        ),
+        skip_on_empty=True,
+    )
+    def test_cross_attention(self, dtype):
+        if dtype == "bfloat16":
+            atol = 1e-2
+            rtol = 1e-2
         else:
-            module = Model(os.path.join("./tmp", test_name, "test.so"))
+            atol = 1e-3
+            rtol = 1e-3
 
-        q = torch.permute(q, (0, 2, 1, 3))
-        k = torch.permute(k, (0, 2, 1, 3))
-        v = torch.permute(v, (0, 2, 1, 3))
-
-        inputs = {
-            "q": q.detach().to(torch_dtype).cuda().contiguous(),
-            "k": k.detach().to(torch_dtype).cuda().contiguous(),
-            "v": v.detach().to(torch_dtype).cuda().contiguous(),
-        }
-        y = torch.empty(
-            [batch_size, seqlen, num_heads, head_size_v],
-            dtype=torch_dtype,
-            device="cuda",
-        )
-        module.run_with_tensors(inputs, [y])
-
-        if benchmark_ait:
-            # Warm up.
-            for _ in range(5):
-                module.run_with_tensors(inputs, [y])
-            # Benchmark AIT
-            time_per_iter_ms, time_std, _ = module.benchmark_with_tensors(
-                inputs,
-                [y],
-                count=100,
-            )
-            _LOGGER.info(f"benchmark cross-attn time: {time_per_iter_ms}")
-
-        torch.testing.assert_close(y, y_pt.to(torch_dtype), atol=atol, rtol=rtol)
-
-    def test_cross_attention_fp16_sm80(self):
         self._test_cross_attention(
-            test_name="cross_attention_fp16",
-            dtype="float16",
+            test_name=f"cross_attention_{dtype}",
+            dtype=dtype,
+            atol=atol,
+            rtol=rtol,
         )
         self._test_cross_attention(
             seqlen=1024,
             seqlen_kv=768,
             head_size=64,
             head_size_v=64,
-            test_name="cross_attention2_fp16",
-            dtype="float16",
+            test_name=f"cross_attention2_{dtype}",
+            dtype=dtype,
+            atol=atol,
+            rtol=rtol,
         )
-
-    def test_cross_attention_fp32_sm80(self):
-        self._test_cross_attention(
-            test_name="cross_attention_fp32",
-            dtype="float32",
-        )
-        self._test_cross_attention(
-            seqlen=1024,
-            seqlen_kv=768,
-            head_size=64,
-            head_size_v=64,
-            test_name="cross_attention2_fp32",
-            dtype="float32",
-        )
-
-    def test_cross_attention_bf16(self):
-        self._test_cross_attention(
-            test_name="cross_attention_bf16",
-            dtype="bfloat16",
-            atol=1e-2,
-            rtol=1e-2,
-        )
-        self._test_cross_attention(
-            seqlen=1024,
-            seqlen_kv=768,
-            head_size=64,
-            head_size_v=64,
-            test_name="cross_attention2_bf16",
-            dtype="bfloat16",
-            atol=1e-2,
-            rtol=1e-2,
-        )
-
-
-filter_test_cases_by_test_env(AttentionTestCase)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Modify `mem_eff_attention` op to handle variable sequence lengths: each element in the batch can specify different source and target sequence lengths.
The backend code is mainly based on [fused_multihead_attention_variable_seqlen.cu](https://github.com/NVIDIA/cutlass/blob/209faf7b94ce4ba573d27389fb643962e75d0581/examples/41_fused_multi_head_attention/fused_multihead_attention_variable_seqlen.cu) example in CUTLASS repo, as the fixed-lenth backend code was based on [fused_multihead_attention_fixed_seqlen.cu](https://github.com/NVIDIA/cutlass/blob/209faf7b94ce4ba573d27389fb643962e75d0581/examples/41_fused_multi_head_attention/fused_multihead_attention_fixed_seqlen.cu).

Currently the source and target sequence lengths are passed into the op as tensors `lengths_kv` and `lengths_q`, each of containing `batch_size` elements. If both are `None`, the old fixed-length backend is used.

In the future we might consider passing variable-length inputs Q, K, V as jagged tensors, instead of specifying lengths by separate tensors.

Differential Revision: D44027012

