### PR TITLE
propagate graph optimization setting from lowering context to model compilation

### DIFF
--- a/fx2ait/fx2ait/fx2ait.py
+++ b/fx2ait/fx2ait/fx2ait.py
@@ -66,6 +66,7 @@ class AITInterpreter(torch.fx.Interpreter):
         load_ait_dir: Optional[str] = None,
         remote_cache_file_path: Optional[str] = None,
         save_remote_cache: Optional[bool] = False,
+        do_optimize_graph: bool = True,
     ):
         """
         Args:
@@ -122,6 +123,7 @@ class AITInterpreter(torch.fx.Interpreter):
         self.dump_ait_dir = dump_ait_dir
         self.keep_constants = keep_constants
         self.load_ait_dir = load_ait_dir
+        self.do_optimize_graph = do_optimize_graph
 
     def _create_target(self):
         """Detect GPU target"""
@@ -208,6 +210,7 @@ class AITInterpreter(torch.fx.Interpreter):
             "dynamic_profiling_strategy": self.dynamic_profile_strategy,
             "dll_name": self.dll_name,
             "profile_dir": profile_dir,
+            "do_optimize_graph": self.do_optimize_graph,
         }
         if self.dump_ait_dir:
             dump_ait_path = os.path.join(self.dump_ait_dir, self.name + ".py")

--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -156,6 +156,7 @@ def compile_model(
     constants: Optional[Dict[str, TorchTensor]] = None,
     allocator_kind: Optional[AITemplateAllocatorKind] = None,
     debug_settings: AITDebugSettings = _DEBUG_SETTINGS,
+    do_optimize_graph: bool = True,
 ) -> Model:
     """Compiles a model and generates a .so file.
 
@@ -236,7 +237,9 @@ def compile_model(
             )
 
             start_t = datetime.now()
-            graph = compiler.transform.optimize_graph(graph, test_dir)
+            graph = compiler.transform.optimize_graph(
+                graph, test_dir, optimize=do_optimize_graph
+            )
             graph_utils.dump_graph_debug_str_to_file(graph, test_dir, "optimize_graph")
             _LOGGER.info(f"optimized graph elapsed time: {elapsed_dt_sec(start_t)}")
 

--- a/python/aitemplate/compiler/transform/optimize_graph.py
+++ b/python/aitemplate/compiler/transform/optimize_graph.py
@@ -120,6 +120,9 @@ def optimize_graph(
         funcs = [
             process_singleton_elementwise,
             apply_padding,
+            split_large_slice_scatter_ops,
+            split_large_concat_ops,
+            split_large_split_ops,
         ]
 
     for i, func in enumerate(funcs):


### PR DESCRIPTION
Summary: it also turns out we need to split large memory ops to make the model compilable (otherwise cuda limit for stack args is exceeded)

Differential Revision: D44322911

