### PR TITLE
Use absolute imports in aitemplate pkg

### DIFF
--- a/python/aitemplate/backend/cuda/b2b_bmm/__init__.py
+++ b/python/aitemplate/backend/cuda/b2b_bmm/__init__.py
@@ -18,4 +18,4 @@
 b2b bmm module init
 """
 
-from . import classic_b2b_bmm
+from aitemplate.backend.cuda.b2b_bmm import classic_b2b_bmm

--- a/python/aitemplate/compiler/ops/gemm_universal/bmm_xxx.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/bmm_xxx.py
@@ -13,9 +13,9 @@
 #  limitations under the License.
 #
 
-from ...base import Tensor
-from . import gemm_common as common
-from .bmm import bmm
+from aitemplate.compiler.base import Tensor
+from aitemplate.compiler.ops.gemm_universal import gemm_common as common
+from aitemplate.compiler.ops.gemm_universal.bmm import bmm
 
 
 class bmm_xxx(bmm):

--- a/python/aitemplate/compiler/ops/gemm_universal/bmm_xxx_add.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/bmm_xxx_add.py
@@ -14,11 +14,11 @@
 #
 
 
-from aitemplate.compiler.tensor_accessor import TensorAccessor
-
-from ...base import Tensor
-from .bmm import is_valid_inputs as bmm_is_valid_inputs
-from .bmm_xxx import (
+from aitemplate.compiler.base import Tensor
+from aitemplate.compiler.ops.gemm_universal.bmm import (
+    is_valid_inputs as bmm_is_valid_inputs,
+)
+from aitemplate.compiler.ops.gemm_universal.bmm_xxx import (
     bmm_ccc,
     bmm_ccr,
     bmm_crc,
@@ -29,6 +29,7 @@ from .bmm_xxx import (
     bmm_rrr,
     bmm_xxx,
 )
+from aitemplate.compiler.tensor_accessor import TensorAccessor
 
 
 class bmm_xxx_add(bmm_xxx):

--- a/python/aitemplate/compiler/ops/gemm_universal/group_gemm_rcr.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/group_gemm_rcr.py
@@ -166,7 +166,7 @@ class group_gemm_rcr(common.gemm):
             offset += output_tensor._attrs["shape"][output_stride_dim]._attrs["values"][
                 0
             ]
-            from ...transform import transform_utils
+            from aitemplate.compiler.transform import transform_utils
 
             transform_utils.remove_tensor_from_sorted_graph(output_tensor)
         return cat_output

--- a/python/aitemplate/compiler/ops/tensor/slice_reshape_scatter.py
+++ b/python/aitemplate/compiler/ops/tensor/slice_reshape_scatter.py
@@ -80,7 +80,7 @@ class slice_reshape_scatter(Operator):
         )
 
     def _update_inputs_outputs(self, cat_op, reshape_op, cat_op_2):
-        from ...transform import transform_utils
+        from aitemplate.compiler.transform import transform_utils
 
         idx = -1
         for i, input_tensor in enumerate(cat_op_2._attrs["inputs"]):

--- a/python/aitemplate/compiler/transform/fuse_conv_elementwise.py
+++ b/python/aitemplate/compiler/transform/fuse_conv_elementwise.py
@@ -61,7 +61,7 @@ def fuse_conv_elementwise(sorted_graph: List[Tensor], _: str) -> List[Tensor]:
     for func in funcs:
         sorted_graph = func(sorted_graph)
 
-    from ...backend.target import Target
+    from aitemplate.backend.target import Target
 
     if Target.current().name() == "cuda":
         funcs = [

--- a/python/aitemplate/compiler/transform/fuse_group_ops.py
+++ b/python/aitemplate/compiler/transform/fuse_group_ops.py
@@ -753,7 +753,7 @@ def fuse_group_ops(sorted_graph: List[Tensor], workdir: str = None) -> List[Tens
     """
     # gemms need to be fused first
     # TODO: enable after adding heuristics and fixing dynamic shapes
-    from ...backend.target import Target
+    from aitemplate.backend.target import Target
 
     if Target.current().name() == "cuda":
         if "fuse_group_gemm" in Target.current()._kwargs:

--- a/python/aitemplate/compiler/transform/fuse_split.py
+++ b/python/aitemplate/compiler/transform/fuse_split.py
@@ -138,7 +138,7 @@ def _fuse_split_and_group_gemm(  # noqa: C901
 
 
 def _is_supported_op(op_type: str):
-    from ...backend.target import Target
+    from aitemplate.backend.target import Target
 
     if Target.current().name() == "rocm":
         return op_type == "bmm_softmax_bmm_permute"

--- a/python/aitemplate/compiler/transform/transform_permute_to_reshape.py
+++ b/python/aitemplate/compiler/transform/transform_permute_to_reshape.py
@@ -17,11 +17,12 @@ Transform permute to reshape wherever applicable.
 """
 from typing import List
 
-from ...utils import graph_utils
-from ..base import IntImm, Operator, Tensor
-from ..ops import reshape
-from . import transform_utils
-from .toposort import toposort
+from aitemplate.compiler.base import IntImm, Operator, Tensor
+from aitemplate.compiler.ops import reshape
+from aitemplate.compiler.transform import transform_utils
+from aitemplate.compiler.transform.toposort import toposort
+
+from aitemplate.utils import graph_utils
 
 
 def _check_permute_to_reshape(op: Operator) -> bool:

--- a/python/aitemplate/compiler/transform/transform_special_ops.py
+++ b/python/aitemplate/compiler/transform/transform_special_ops.py
@@ -292,7 +292,7 @@ def transform_special_ops(
         _transform_1x1_conv_gemm_rcr,
     ]
 
-    from ...backend.target import Target
+    from aitemplate.backend.target import Target
 
     if "transform_conv_to_gemm" in Target.current()._kwargs:
         if Target.current()._kwargs["transform_conv_to_gemm"]:

--- a/python/aitemplate/compiler/transform/transform_strided_op_and_view_op.py
+++ b/python/aitemplate/compiler/transform/transform_strided_op_and_view_op.py
@@ -29,7 +29,7 @@ _VIEW_OPS = {"reshape", "flatten", "squeeze", "unsqueeze"}
 
 
 def _is_supported_strided_op(op: Operator) -> bool:
-    from ...backend.target import Target
+    from aitemplate.backend.target import Target
 
     op_kind = op._attrs["op"]
     if Target.current().name() == "rocm":


### PR DESCRIPTION
Couple weeks ago it was decided to use absolute imports in aitemplate package. - [PR354](https://github.com/facebookincubator/AITemplate/pull/354)

This PR fixes recently added files to use absolute imports too.