### PR TITLE
Accept scalar shape in full op

### DIFF
--- a/python/aitemplate/compiler/ops/tensor/full.py
+++ b/python/aitemplate/compiler/ops/tensor/full.py
@@ -26,8 +26,8 @@ class full(Operator):
     with the specified `fill_value` (float scalar).
 
     Args:
-        shape (List[IntVar]): the shape of the output Tensor.
-        fill_Value (float): the value to fill the output Tensor with.
+        shape (int or IntVar or List[IntVar]): the shape of the output Tensor.
+        fill_value (int or float): the value to fill the output Tensor with.
         dtype (str): the dtype of the output Tensor.
 
     Returns:
@@ -46,6 +46,16 @@ class full(Operator):
         fill_value: float,
         dtype: str = "float16",
     ) -> Tensor:
+        if isinstance(shape, (int, IntVar)):
+            shape = [shape]
+        if not isinstance(shape, (list, tuple)):
+            raise TypeError(f"shape must be List[IntVar], but got {shape}.")
+        shape = list(shape)
+
+        if not isinstance(fill_value, (int, float)):
+            raise TypeError(f"fill_value must be a scalar, but got {fill_value}.")
+        fill_value = float(fill_value)
+
         self._attrs["inputs"] = []
         self._attrs["fill_value"] = fill_value
 

--- a/tests/unittest/ops/test_full.py
+++ b/tests/unittest/ops/test_full.py
@@ -36,15 +36,18 @@ class TestFull(unittest.TestCase):
         dtype="float16",
         test_name="full",
     ) -> None:
+        Y = ops.full()(shape, fill_value, dtype)
+        Y._attrs["name"] = "Y"
+
+        if not isinstance(shape, list):
+            shape = [shape]
+
         X = Tensor(
             shape=shape,
             name="X",
             dtype=dtype,
             is_input=True,
         )
-
-        Y = ops.full()(X.shape(), fill_value, dtype)
-        Y._attrs["name"] = "Y"
 
         Z = ops.elementwise(FuncEnum.ADD)(X, Y)
         Z._attrs["name"] = "Z"
@@ -73,8 +76,10 @@ class TestFull(unittest.TestCase):
             param(1, [1], 1, "float16"),
             param(2, [10, 20, 30], 3.14, "float16"),
             param(3, [IntVar([10, 20]), 30], 0, "float16"),
-            param(4, [20, 30], 2.71, "float32"),
-            param(5, [IntVar([1, 128]), 10], -1.23, "float32"),
+            param(4, 123, -5, "float16"),
+            param(5, [20, 30], 2.71, "float32"),
+            param(6, [IntVar([1, 128]), 10], -1.23, "float32"),
+            param(7, IntVar([1, 128]), 1234, "float32"),
         ]
     )
     def test_full(self, i, shape, fill_value, dtype):


### PR DESCRIPTION
Summary: Full op's front-end was missing validation and some flexibility around the arguments. E.g., `torch.Tensor.new_ones` happens to accept int as a size, and so do we now.

Reviewed By: tissue3

Differential Revision: D44351353

