### PR TITLE
Refactor gemm_rcr_bias inputs validation

### DIFF
--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_common.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_common.py
@@ -221,7 +221,6 @@ class gemm(Operator):
 
         dtype = self._attrs["inputs"][0].dtype()
         self._attrs["epilogue_alignment"] = alignment.find_max_alignment(shape, dtype)
-        return
 
     def _infer_shapes(self, a: Tensor, b: Tensor):
         raise NotImplementedError("_infer_shapes() is not implemented!")
@@ -409,7 +408,7 @@ class gemm(Operator):
         entry for this gemm instance, we update this gemm op's
         relevant attributes with the cached result and return False.
         """
-        # We are forced to use the cache so we skip building profilers.
+        # We are forced to use the cache, so we skip building profilers.
         if environ.force_profiler_cache():
             return False
         target = backend.target.Target.current()

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias.py
@@ -15,6 +15,8 @@
 """
 GEMM Specialization: GEMM_RCR(A, B) + Bias
 """
+from typing import List
+
 from aitemplate.compiler.base import IntImm, Tensor
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr
 from aitemplate.compiler.tensor_accessor import TensorAccessor
@@ -40,48 +42,22 @@ class gemm_rcr_bias(gemm_rcr):
         super().__init__()
         self._attrs["op"] = "gemm_rcr_bias"
 
-    @staticmethod
-    def is_valid_inputs(X: Tensor, W: Tensor, bias: Tensor):
-        msg = ""
-
+    def _sanity_check_extra_inputs(self, output_shape: List):
+        bias = self._attrs["inputs"][2]
         bias_shapes = bias._attrs["shape"]
         if len(bias_shapes) != 1:
-            msg = f"Bias should be 1D vector! Current bias shape: {bias_shapes}"
-            return False, msg
-
+            raise RuntimeError(
+                f"Bias should be 1D vector! Current bias shape: {bias_shapes}"
+            )
         bias_shape = bias_shapes[0]
         if not isinstance(bias_shape, IntImm):
-            msg = f"Bias should be fixed 1D vector! Current bias shape: {bias_shape}"
-            return False, msg
-
-        outshape = gemm_rcr()._infer_shapes(X, W)
-        if outshape[-1] != bias_shape:
-            msg = f"GEMM/Bias shape doesn't match! Gemm shape: {outshape}, bias shape: {bias_shape}"
-            return False, msg
-
-        return True, msg
-
-    def _infer_shapes(self, a: Tensor, b: Tensor, bias: Tensor):
-        """Infers output shapes for gemm_rcr_bas.
-
-        Parameters
-        ----------
-        a : Tensor
-            Input tensor A.
-        b : Tensor
-            Input tensor B.
-        bias : Tensor
-            Input tensor bias. Must be a 1D vector.
-
-        Returns
-        -------
-        List[IntVar]
-            Output tensor shape.
-        """
-        is_valid_inputs, msg = self.is_valid_inputs(a, b, bias)
-        if not is_valid_inputs:
-            raise RuntimeError(msg)
-        return super()._infer_shapes(a, b)
+            raise RuntimeError(
+                f"Bias should be fixed 1D vector! Current bias shape: {bias_shape}"
+            )
+        if output_shape[-1] != bias_shape:
+            raise RuntimeError(
+                f"GEMM/Bias shape doesn't match! Gemm shape: {output_shape}, bias shape: {bias_shape}"
+            )
 
     def __call__(self, a: Tensor, b: Tensor, bias: Tensor) -> Tensor:
         a, b = self._align_ab(a, b)
@@ -91,7 +67,8 @@ class gemm_rcr_bias(gemm_rcr):
         ]
         self._set_depth()
         self._sanity_check(a, b)
-        output_shape = self._infer_shapes(a, b, bias)
+        output_shape = self._infer_shapes(a, b)
+        self._sanity_check_extra_inputs(output_shape)
         self._extract_epilogue_alignment(output_shape)
         output = Tensor(output_shape, src_ops={self}, dtype=a.dtype())
         self._attrs["outputs"] = [output]

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_broadcast.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_broadcast.py
@@ -16,6 +16,7 @@
 gemm_rcr_bias with 2 extra sources.
 BinaryOp2(BinaryOp1(UnaryOp(TensorOp(X) + bias), residual1), residual2)
 """
+from typing import List
 
 from aitemplate.compiler.base import Tensor
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr_bias
@@ -29,30 +30,15 @@ class gemm_rcr_bias_broadcast(gemm_rcr_bias):
         super().__init__()
         self._attrs["epilogue"] = "LinearCombinationResidualBlock"
 
-    @staticmethod
-    def is_valid_inputs(*inputs):
-        msg = ""
-        if len(inputs) < 3:
-            msg = "input for gemm_rcr_bias_broadcast should be at least 3, got {} instead.".format(
-                len(inputs)
-            )
-            return False, msg
-
-        gemm_rcr_bias_valid, msg = gemm_rcr_bias.is_valid_inputs(
-            inputs[0], inputs[1], inputs[2]
-        )
-        if not gemm_rcr_bias_valid:
-            return False, msg
-
-        if len(inputs) > 3:
-            base_shape = gemm_rcr_bias()._infer_shapes(inputs[0], inputs[1], inputs[2])
-            for d in inputs[3:]:
-                d_shape = d.shape()
-                if d_shape != base_shape:
-                    msg = "Additional elementwise shape {d_shape} doesn't match gemm_bias' shape {base_shape}"
-                    return False, msg
-
-        return True, msg
+    def _sanity_check_extra_inputs(self, output_shape: List):
+        super()._sanity_check_extra_inputs(output_shape)
+        inputs = self._attrs["inputs"]
+        for d in inputs[3:]:
+            d_shape = d.shape()
+            if d_shape != output_shape:
+                raise RuntimeError(
+                    f"Additional elementwise shape {d_shape} doesn't match gemm_rcr_bias' shape {output_shape}"
+                )
 
     def __call__(
         self, a: Tensor, b: Tensor, bias: Tensor, d0: Tensor, d1: Tensor = None
@@ -66,7 +52,8 @@ class gemm_rcr_bias_broadcast(gemm_rcr_bias):
         ]
         self._set_depth()
         self._sanity_check(a, b)
-        output_shape = self._infer_shapes(a, b, bias)
+        output_shape = self._infer_shapes(a, b)
+        self._sanity_check_extra_inputs(output_shape)
         self._extract_epilogue_alignment(output_shape)
         output = Tensor(output_shape, src_ops={self}, dtype=a.dtype())
         self._attrs["outputs"] = [output]

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_permute.py
@@ -51,7 +51,8 @@ class gemm_rcr_bias_permute(gemm_rcr_bias):
         ]
         self._set_depth()
         self._sanity_check(a, b)
-        output_shape = self._infer_shapes(a, b, bias)
+        output_shape = self._infer_shapes(a, b)
+        self._sanity_check_extra_inputs(output_shape)
 
         output = Tensor(output_shape, src_ops={self}, dtype=a.dtype())
         self._attrs["outputs"] = [output]

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rrr_bias_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rrr_bias_permute.py
@@ -45,7 +45,8 @@ class gemm_rrr_bias_permute(gemm_rrr_bias):
         ]
         self._set_depth()
         self._sanity_check(a, b)
-        output_shape = self._infer_shapes(a, b, bias)
+        output_shape = self._infer_shapes(a, b)
+        self._sanity_check_extra_inputs(output_shape)
 
         output = Tensor(output_shape, src_ops={self}, dtype=a.dtype())
         self._attrs["outputs"] = [output]


### PR DESCRIPTION
I noticed that `gemm_rcr_bias` and `gemm_rrr_bias` have static methods `is_valid_inputs`. 
Inside `is_valid_inputs` they  create new instance of their own super class just to call `_infer_shape()` method!
What is more - `is_valid_inputs` is used inside `this._infer_shape()` method which calls `super()._infer_shape()` too.
So, `super()._infer_shape()` is called twice.

This PR makes the following improvements: 
- avoid unnecessary short-living super class instance creation.
- do not call `super()._infer_shape()` two times.
- currently we call `_sanity_check(a,b)` before `infer_shape()`. In a similar way this PR calls `_sanity_check_extra_inputs()` after `infer_shape()` for extra inputs (such as bias, d0, d1). `_sanity_check_extra_inputs()` requires `output_shape`. This is why it is called after  `infer_shape()`
- OO approach allowed to shrink the code 2 times

Class responsibilities: 
```
gemm class:
    def _sanity_check(self, a: Tensor, b: Tensor)
        # checks a, b inputs

gemm_rcr class:
    def _infer_shapes(self, a: Tensor, b: Tensor)
        # infers output shape based on a and b inputs

gemm_rcr_bias class:
    def _sanity_check_extra_inputs(self, output_shape: List):
        # checks bias input

gemm_rcr_bias_broadcast class:
    def _sanity_check_extra_inputs(self, output_shape: List):
        super._sanity_check_extra_inputs(output_shape)
        # calls super._sanity_check_extra_input (to check bias) and in addition to it checks d0, d1 inputs
 ```

`gemm_rrr_bias` class family was refactored in a similar way as `gemm_rcr_bias`.