### PR TITLE
Hotfix: Prevent race conditions in unit tests by locking the build directory.

### DIFF
--- a/python/aitemplate/compiler/__init__.py
+++ b/python/aitemplate/compiler/__init__.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 #
 from aitemplate.compiler import base, dtype, ops, tensor_accessor, transform
-from aitemplate.compiler.compiler import compile_model
+from aitemplate.compiler.compiler import compile_model, safe_compile_model
 from aitemplate.compiler.model import AIT_DEFAULT_NUM_RUNTIMES, AITData, Model
 
 __all__ = [
@@ -25,6 +25,7 @@ __all__ = [
     "tensor_accessor",
     "transform",
     "compile_model",
+    "safe_compile_model",
     "Model",
     "AITData",
     "AIT_DEFAULT_NUM_RUNTIMES",

--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -15,12 +15,14 @@
 """
 build a test module from a tensor
 """
+import inspect
 import logging
 import os
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
 from aitemplate import backend, compiler
+from aitemplate.backend.target import Target
 
 from aitemplate.compiler.base import (
     DynamicProfileStrategy,
@@ -28,6 +30,7 @@ from aitemplate.compiler.base import (
     JaggedIntVar,
     Tensor,
 )
+from aitemplate.compiler.lockfile import FileLock
 
 from aitemplate.compiler.model import (
     AIT_DEFAULT_NUM_RUNTIMES,
@@ -331,3 +334,86 @@ def compile_model(
     )
     module.debug_sorted_graph = graph
     return module
+
+
+def safe_compile_model(
+    tensor: Union[Tensor, List[Tensor]],
+    target: backend.target.Target,
+    workdir: str,
+    test_name: str,
+    *args,
+    lock_timeout_seconds=360.0,
+    write_log_file=True,
+    **kwargs,
+) -> Model:
+    """
+    Compile a model and generate a .so file. This function is safe to use when multiple processes are
+    potentially calling compile_model() with the same build directory. It uses a cooperative file
+    locking mechanism to ensure that only a single process accesses the build directory concurrently.
+
+    Parameters and return value are identical to compile_model() but it adds a few optional keyword
+    Parameters:
+
+    Additional Keyword Parameters
+    ----------
+    lock_timeout_seconds : Union[Tensor, List[Tensor]]
+        An output Tensor, or a list of output Tensors.
+        The compiled module will preserve the ordering of the outputs in its
+        internal ordering.
+    write_log_file: Whether to write a log file to the build directory, which allows to diagnose
+    prevented race conditions on the build directory.
+
+    """
+    test_name = test_name.replace(",", "_")
+    test_dir = os.path.join(workdir, test_name)
+
+    def get_caller_info():
+        try:
+            frame = inspect.currentframe().f_back.f_back
+            filename = inspect.getframeinfo(frame).filename
+            basename = os.path.basename(filename)
+            lineno = inspect.getframeinfo(frame).lineno
+            caller = f"source line: {basename}:{lineno}"
+            try:
+                # Obtain additional caller info, in case
+                # this is running inside a unittest.TestCase
+                import unittest
+
+                maybe_test_self = frame.f_locals.get("self", None)
+                maybe_target = frame.f_locals.get("target", None)
+                if isinstance(maybe_test_self, unittest.TestCase):
+                    caller += f" test_id='{maybe_test_self.id()}'"
+                if isinstance(maybe_target, Target):
+                    caller += f" target='{str(maybe_target.__class__.__name__)}'"
+            except BaseException:
+                pass
+            return caller
+        except AttributeError:
+            return "<unknown>"
+
+    os.makedirs(test_dir, exist_ok=True)
+    log_str = f"safe_compile_model called with build directory='{test_dir}'. PID: {os.getpid()}. Caller info: {get_caller_info()}"
+    _LOGGER.info(log_str)
+    if write_log_file:
+        with open(os.path.join(test_dir, ".safe_compile_model.log"), "a") as log:
+            print(log_str, file=log)
+            log.flush()
+
+    def lock_contention_callback():
+        contention_msg = f"Race condition prevented by FileLock in safe_compile_model. Waiting on lock release. (timeout={lock_timeout_seconds}). Original log message: {log_str}."
+        _LOGGER.warn(contention_msg)
+        if write_log_file:
+            with open(os.path.join(test_dir, ".safe_compile_model.log"), "a") as log:
+                print(contention_msg, file=log)
+                log.flush()
+
+    # This lock should prevent race conditions from multiple
+    # processes building in the same directory. This can otherwise
+    # lead to hard to diagnose errors during parallel unit tests.
+    with FileLock(
+        os.path.join(test_dir, ".safe_compile_model.lock"),
+        timeout=lock_timeout_seconds,
+        retry_interval=0.5,
+        lock_contention_callback=lock_contention_callback,
+    ):
+        return compile_model(tensor, target, workdir, test_name, *args, **kwargs)

--- a/python/aitemplate/compiler/lockfile.py
+++ b/python/aitemplate/compiler/lockfile.py
@@ -1,0 +1,104 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import fcntl
+import os
+import time
+from typing import Callable, Optional
+
+
+class FileLock:
+    def __init__(
+        self,
+        path,
+        timeout=3600.0,
+        retry_interval=0.2,
+        lock_contention_callback: Optional[Callable] = None,
+    ):
+        """
+        File locking context manager. Acts like an inter-process mutex
+        on a given file. The lock will be released when the context manager
+        exits. It has a timeout parameter, which triggers a TimeoutError
+        on expiry in order to prevent infinite loops or deadlocks.
+
+        Implementation note:
+            Attempts to open the given file for writing, and
+            acquires an exclusive file lock on success. If the file cannot be opened
+            or the lock cannot be acquired, it retries after retry_interval
+            seconds until success or a timeout occurs.
+
+            Uses fcntl.flock(self.lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            to acquire the file lock.
+
+            This is an OS-level cooperative lock, which will be automatically released on process
+            termination by the OS, if still unreleast. Cooperative means, it is not enforced.
+            It is still possible to do anything with the directory and lock file by
+            processes which do not try to acquire the same lock.
+
+        Usage:
+
+            with FileLock('/path/to/file.lock', timeout=10):
+                ...
+
+        Args:
+            path (str ): Path to lockfile. Will be created as an empty file
+            if it does not exist. Will not be deleted on exit.
+            timeout (int, optional): Timeout in seconds. Defaults to 3600.
+            retry_interval (float, optional): Retry interval in seconds. Defaults to 0.2.
+            lock_contention_callback(Callable,optional): A callback that will be invoked without arguments
+                                      in the case that a lock cannot be acquired on first attempt.
+                                      May be used for logging purposes.
+        """
+        self.path = path
+        self.timeout = timeout
+        self.lock_file = None
+        self.retry_interval = retry_interval
+        self.lock_contention_callback = lock_contention_callback
+
+    def __enter__(self):
+        start_time = time.monotonic()
+        attempts = 0
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        while True:
+            try:
+                self.lock_file = open(self.path, "w")
+                fcntl.flock(self.lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return self
+            except OSError:
+                if self.lock_file is not None:
+                    self.lock_file.close()
+                    self.lock_file = None
+                if attempts == 0 and self.lock_contention_callback is not None:
+                    lock_contention_callback = self.lock_contention_callback
+                    lock_contention_callback()
+                attempts += 1
+                if self.timeout is not None and (
+                    time.monotonic() + self.retry_interval - start_time > self.timeout
+                ):
+                    raise TimeoutError(
+                        f"Timeout waiting for lock on {self.path}"
+                    ) from None
+                time.sleep(self.retry_interval)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            # This is an OS-level cooperative lock, which will be automatically released on process
+            # termination by the OS, if still unreleast. Cooperative means, it is not enforced.
+            # It is still possible to do anything with the directory and lock file by
+            # processes which do not try to acquire the same lock.
+            fcntl.flock(self.lock_file, fcntl.LOCK_UN)
+        finally:
+            self.lock_file.close()
+            self.lock_file = None
+        return False

--- a/tests/unittest/ops/test_activation.py
+++ b/tests/unittest/ops/test_activation.py
@@ -19,7 +19,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model as compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor


### PR DESCRIPTION
Summary:
During recent CI runs, strange test failures unrelated to the diff being under test were encountered.

 It turned out that these were also happening on the main branch, possibly due to changes in how tests were executed in parallel by the Meta internal test runner.

Under further investigation, it could be confirmed that race conditions were happening, where multiple unit test processes were modifying the same AIT build directories.

This hotfix addresses this issue by introducing a scoped file lock with timeout to prevent concurrent code generation within the same build directory.

Note:

While this resolves the issue for now, in the long term it might be a good idea to enforce that unit tests do not reuse build directories and fail if the build directory already exists. This would have been too intrusive to enforce throughout the codebase, and would have broken too many existing tests and workflows, though.

Differential Revision: D44374161

