### PR TITLE
Support simple variable_seq_length in FMHA_style_b2b_bmm

### DIFF
--- a/python/aitemplate/backend/cuda/b2b_bmm/__init__.py
+++ b/python/aitemplate/backend/cuda/b2b_bmm/__init__.py
@@ -18,4 +18,8 @@
 b2b bmm module init
 """
 
-from aitemplate.backend.cuda.b2b_bmm import classic_b2b_bmm, fmha_style_b2b_bmm
+from aitemplate.backend.cuda.b2b_bmm import (
+    classic_b2b_bmm,
+    fmha_style_b2b_bmm,
+    grouped_fmha_style_b2b_bmm,
+)

--- a/python/aitemplate/backend/cuda/b2b_bmm/grouped_fmha_style_b2b_bmm.py
+++ b/python/aitemplate/backend/cuda/b2b_bmm/grouped_fmha_style_b2b_bmm.py
@@ -1,0 +1,180 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+grouped_fmha_style_b2b_bmm kernel codegen for CUDA.
+"""
+from typing import Any, Dict
+
+import jinja2
+
+from aitemplate.backend.backend_spec import CUDASpec
+from aitemplate.backend.cuda.b2b_bmm import fmha_style_b2b_bmm
+from aitemplate.backend.target import Target
+from aitemplate.compiler.base import IntImm
+
+from ... import registry
+
+# pylint: disable=C0301
+
+FUNC_SIGNATURE = jinja2.Template(
+    """
+void {{func_name}}(
+  void* output,
+  void* query,
+  void* key,
+  void* value,
+  void* bias,
+  void* accum_ptr,
+  int64_t batch_size,
+  int64_t max_seq_length,
+  const void* offset,
+  cudaStream_t stream)
+    """
+)
+
+FUNC_DECL = jinja2.Template(
+    """
+{{func_signature}};
+    """
+)
+
+FUNC_CALL_TEMPLATE = jinja2.Template(
+    """
+{{indent}}{{func_name}}(
+{{indent}}    {{output}},
+{{indent}}    {{query}}, {{key}}, {{value}}, {{bias}},
+{{indent}}    {{accum_ptr}},
+{{indent}}    {{batch_size}},
+{{indent}}    {{max_seq_length}},
+{{indent}}    {{offset}},
+{{indent}}    stream
+{{indent}});
+    """
+)
+
+
+@registry.reg("cuda.grouped_fmha_style_b2b_bmm.gen_function")
+def grouped_fmha_style_b2b_bmm_gen_function(func_attrs: Dict[str, Any]) -> str:
+    """the function for generating attention kernel"""
+    q, k, v = func_attrs["inputs"][0:3]
+
+    bias_broadcast = [False] * 4
+    if len(func_attrs["inputs"]) > 3:
+        bias = func_attrs["inputs"][3]
+        bias_broadcast = [var == IntImm(1) for var in bias.shape()]
+
+    jagged_dim = q._attrs["shape"][0]
+    head_dim = q._attrs["shape"][2]
+    head_dim_value = v._attrs["shape"][2]
+    if not isinstance(head_dim, IntImm) or not isinstance(head_dim_value, IntImm):
+        raise RuntimeError(
+            f"head_dim and head_dim_value must be static dims. {func_attrs['name']=}, {head_dim=}, {head_dim_value=}"
+        )
+    backend_spec = CUDASpec()
+    elem_input_type = backend_spec.dtype_to_lib_type(
+        func_attrs["inputs"][0]._attrs["dtype"]
+    )
+    elem_output_type = backend_spec.dtype_to_lib_type(
+        func_attrs["outputs"][0]._attrs["dtype"]
+    )
+    elem_accum_type = elem_input_type
+    if (
+        elem_input_type == "cutlass::half_t"
+        and "use_fp16_acc" in Target.current()._kwargs
+        and not Target.current()._kwargs["use_fp16_acc"]
+    ):
+        elem_accum_type = "float"
+
+    import cutlass_lib
+
+    activation_functor = cutlass_lib.library.EpilogueMathTag[
+        cutlass_lib.library.EpilogueMathName[func_attrs["epilogue_math_name"]]
+    ]
+    return fmha_style_b2b_bmm.FUNC_TEMPLATE.render(
+        func_name=func_attrs["name"],
+        func_signature=FUNC_SIGNATURE.render(func_name=func_attrs["name"]),
+        elem_input_type=elem_input_type,
+        elem_output_type=elem_output_type,
+        elem_accum_type=elem_accum_type,
+        offset_t=jagged_dim.offsets_type(),
+        seq_length="max_seq_length",
+        seq_length_kv="max_seq_length",
+        head_dim=str(head_dim.value()),
+        head_dim_value=str(head_dim_value.value()),
+        causal_type=fmha_style_b2b_bmm.causal_type_to_kernel_str(
+            func_attrs["causal_type"]
+        ),
+        num_heads=str(func_attrs["num_heads"]),
+        alpha0=str(func_attrs["alpha0"]),
+        alpha1=str(func_attrs["alpha1"]),
+        alpha1_divide_by_seq_len="true"
+        if func_attrs["alpha1_divide_by_seq_len"]
+        else "false",
+        activation_functor=activation_functor,
+        bias_broadcast=bias_broadcast,
+        offset_ptr="offset",
+    )
+
+
+@registry.reg("cuda.grouped_fmha_style_b2b_bmm.func_decl")
+def grouped_fmha_style_b2b_bmm_gen_function_decl(func_attrs: Dict[str, Any]):
+    return FUNC_DECL.render(
+        func_signature=FUNC_SIGNATURE.render(func_name=func_attrs["name"]).strip()
+    )
+
+
+@registry.reg("cuda.grouped_fmha_style_b2b_bmm.func_call")
+def grouped_fmha_style_b2b_bmm_gen_function_call(func_attrs, indent="  "):
+    """the function for generating a function call for attention"""
+    assert len(func_attrs["outputs"]) == 1
+    assert len(func_attrs["inputs"]) in (3, 4)
+
+    output_name = func_attrs["outputs"][0]._attrs["name"]
+    q_name = func_attrs["inputs"][0]._attrs["name"]
+    k_name = func_attrs["inputs"][1]._attrs["name"]
+    v_name = func_attrs["inputs"][2]._attrs["name"]
+
+    bias_name = "nullptr"
+    if len(func_attrs["inputs"]) == 4:
+        bias_name = func_attrs["inputs"][3]._attrs["name"]
+
+    jagged_intvar = func_attrs["inputs"][0]._attrs["shape"][0]
+    batch_size = jagged_intvar.batch_dim()._attrs["name"]
+    if len(jagged_intvar.jagged_dims()) != 1:
+        raise RuntimeError(
+            "Only support 1 jagged dim in grouped_fmha_style_b2b_bmm for now! "
+            f"Current jagged intvar: {jagged_intvar}"
+        )
+    max_seq_length_dim = jagged_intvar.jagged_dims()[0].max_value()
+    max_seq_length = (
+        str(max_seq_length_dim.value())
+        if isinstance(max_seq_length_dim, IntImm)
+        else max_seq_length_dim._attrs["name"]
+    )
+    offset = f"{jagged_intvar.offsets_var_name()}.data[0]"
+
+    return FUNC_CALL_TEMPLATE.render(
+        func_name=func_attrs["name"],
+        output=output_name,
+        query=q_name,
+        key=k_name,
+        value=v_name,
+        bias=bias_name,
+        accum_ptr="global_workspace_",
+        batch_size=batch_size,
+        max_seq_length=max_seq_length,
+        offset=offset,
+        indent=indent,
+    )

--- a/python/aitemplate/compiler/ops/b2b_bmm/__init__.py
+++ b/python/aitemplate/compiler/ops/b2b_bmm/__init__.py
@@ -19,3 +19,6 @@ B2B Bmm ops.
 
 from aitemplate.compiler.ops.b2b_bmm.classic_b2b_bmm import classic_b2b_bmm
 from aitemplate.compiler.ops.b2b_bmm.fmha_style_b2b_bmm import fmha_style_b2b_bmm
+from aitemplate.compiler.ops.b2b_bmm.grouped_fmha_style_b2b_bmm import (
+    grouped_fmha_style_b2b_bmm,
+)

--- a/python/aitemplate/compiler/ops/b2b_bmm/fmha_style_b2b_bmm.py
+++ b/python/aitemplate/compiler/ops/b2b_bmm/fmha_style_b2b_bmm.py
@@ -60,7 +60,7 @@ class fmha_style_b2b_bmm(b2b_bmm_base):
         self._attrs["workspace"] = 0
 
     def _infer_shapes(self):
-        """infer the output shape for classic_b2b_bmm."""
+        """infer the output shape for fmha_style_b2b_bmm."""
         q, k, v = self._attrs["inputs"][0:3]
         q_shape = q._attrs["shape"]
         k_shape = k._attrs["shape"]

--- a/python/aitemplate/compiler/ops/b2b_bmm/grouped_fmha_style_b2b_bmm.py
+++ b/python/aitemplate/compiler/ops/b2b_bmm/grouped_fmha_style_b2b_bmm.py
@@ -1,0 +1,181 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+"""
+Grouped back-to-back batched gemm fused kernel, implemented in FMHA style.
+Computes bmm(causal_masks(alpha1(activation(alpha0 * bmm(Q, K) [+ bias]))), V),
+
+where:
+Q: [B_M0, H, K0] (row_major),
+K: [B_N0, H, K0] (column_major),
+V: [B_N0, H, N1] (row_major),
+bias: [B, H, M0, N0] (row_major). Bias can be omitted.
+B_M0, B_N0 are jagged dims.
+Layouts are fixed for now.
+
+causal_masks have 3 types:
+NO_CAUSAL: no causal masks
+UPPER_RIGHT_EMPTY: the upper right triangular part of the matrix is 0
+LOWER_LEFT_EMPTY: the bottom left triangular part of the matrix is 0
+When causal_masks is enabled, M0 must be equal to N0.
+
+Internally this implementation stores the results of Q@K in shared memory.
+It supports larger N0 / N1 compared to the classic_b2b_bmm implementation.
+"""
+
+from aitemplate.compiler.base import IntImm
+from aitemplate.compiler.ops.b2b_bmm.fmha_style_b2b_bmm import (
+    CausalType,
+    fmha_style_b2b_bmm,
+)
+from aitemplate.utils import shape_utils
+
+
+class grouped_fmha_style_b2b_bmm(fmha_style_b2b_bmm):
+    def __init__(
+        self,
+        causal_type: CausalType,
+        epilogue_math_name: str,
+        alpha0: float,
+        alpha1: float,
+        alpha1_divide_by_seq_len: bool,
+        num_heads: int,
+    ) -> None:
+        """Initialize grouped_fmha_style_b2b_bmm op."""
+        super().__init__(causal_type, epilogue_math_name, alpha0, alpha1, num_heads)
+        self._attrs["op"] = "grouped_fmha_style_b2b_bmm"
+        self._attrs["alpha1_divide_by_seq_len"] = alpha1_divide_by_seq_len
+
+    def _infer_shapes(self):
+        """infer the output shape for grouped_fmha_style_b2b_bmm."""
+        q, k, v = self._attrs["inputs"][0:3]
+        if not (q.is_jagged() and k.is_jagged() and v.is_jagged()):
+            raise RuntimeError(f"{q=}, {k=}, {v=} must be jagged!")
+        q_shape = q._attrs["shape"]
+        k_shape = k._attrs["shape"]
+        v_shape = v._attrs["shape"]
+        if len(q_shape) != len(k_shape) or len(q_shape) != len(v_shape):
+            raise RuntimeError(
+                f"QKV ranks must be the same! QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}."
+            )
+        if len(q_shape) != 3:
+            raise RuntimeError(
+                f"QKV must have rank == 3! Current rank: {len(q_shape)}, QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}."
+            )
+
+        if q_shape[0] != k_shape[0] or q_shape[0] != v_shape[0]:
+            raise RuntimeError(
+                f"QKV must have same jagged_dim (batch_size and seq_length)! QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}."
+            )
+
+        if len(q_shape[0].jagged_dims()) != 1:
+            raise RuntimeError(f"{len(q_shape[0].jagged_dims())=} must be 1!")
+
+        if q_shape[1] != k_shape[1] or q_shape[1] != v_shape[1]:
+            raise RuntimeError(
+                f"QKV must have same head size! QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}."
+            )
+        if q_shape[1] != IntImm(self._attrs["num_heads"]):
+            raise RuntimeError(
+                f"num_heads are not equal! {self._attrs['num_heads']=}, {q_shape[1]=}"
+            )
+        K0 = q_shape[2]
+        if K0 != k_shape[2]:
+            raise RuntimeError(
+                f"Q K shapes are not compatible! QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}."
+            )
+
+        head_size = IntImm(self._attrs["num_heads"])
+
+        output_shape = [q_shape[0], head_size, v_shape[2]]
+
+        if len(self._attrs["inputs"]) == 4:
+            batch_size = q_shape[0].batch_dim()
+            max_seq_length = q_shape[0].jagged_dims()[0].max_value()
+            bias = self._attrs["inputs"][3]
+            bias_shape = bias._attrs["shape"]
+            bias_expected_shape = [
+                batch_size,
+                head_size,
+                max_seq_length,
+                max_seq_length,
+            ]
+            bias_max_shape = shape_utils.get_broadcast_max_shape(
+                bias_shape, bias_expected_shape
+            )
+            if len(bias_shape) != 4:
+                raise RuntimeError(
+                    f"Expected bias rank 4. Current bias rank: {len(bias)}."
+                )
+            if not bias_max_shape[0]:
+                raise RuntimeError(
+                    f"bias shape is not compatible with Q K! "
+                    f"QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}, "
+                    f"bias shapes: {bias_shape=}, {bias_expected_shape=}."
+                )
+            if bias_shape[-1] != max_seq_length:
+                raise RuntimeError(
+                    f"Bias last dim is not broadcastable! Expected shape: {max_seq_length}, current bias shape: {bias_shape}"
+                )
+            # See comments below.
+            if not isinstance(q_shape[0].jagged_dims()[0].min_value(), IntImm):
+                raise RuntimeError(
+                    "Jagged dim' min value must be constant!"
+                    f"Current value: {q_shape[0].jagged_dims()=}"
+                )
+        else:
+            # Note: jagged_dims min / max values cannot be IntVar, as AIT lacks the feature to set
+            # "attributes" dynamically at runtime in general.
+            #
+            # Assuming the case: Q @ K @ V, Q / K / V are all dense tensor inputs.
+            # As a result, Q / K / V have total_length IntVar to represent the first dimension.
+            # Then there are make_jagged() ops which take Q / K / V as well as
+            # min_seq_len / max_seq_len IntVars as inputs.
+            # At runtime, Q / K / V are inputs passed to AIT runtime. However, since
+            # min_seq_len / max_seq_len is not bound to any input dimensions,
+            # there are no ways for AIT to infer these values. As a result, AIT compilation would
+            # fail.
+            #
+            # To support min_seq_len / max_seq_len IntVars, there must be a way dynamically set
+            # them at runtime.
+            #
+            # When bias is set, max_seq_len can be inferred from bias input.
+
+            if (not isinstance(q_shape[0].jagged_dims()[0].min_value(), IntImm)) or (
+                not isinstance(q_shape[0].jagged_dims()[0].max_value(), IntImm)
+            ):
+                raise RuntimeError(
+                    "Jagged dim' min / max values must be constant!"
+                    f"Current value: {q_shape[0].jagged_dims()=}"
+                )
+
+        return output_shape
+
+    def _get_op_attributes(self):
+        target_attrs = [
+            "causal_type",
+            "epilogue_math_name",
+            "alpha0",
+            "alpha1",
+            "alpha1_divide_by_seq_len",
+            "num_heads",
+        ]
+        attr = {}
+
+        for target_attr in target_attrs:
+            if target_attr in self._attrs:
+                attr[target_attr] = self._attrs[target_attr]
+
+        return attr

--- a/tests/unittest/ops/test_grouped_b2b_bmm.py
+++ b/tests/unittest/ops/test_grouped_b2b_bmm.py
@@ -1,0 +1,337 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Unittests for grouped b2b bmm Operators.
+"""
+import itertools
+import logging
+import unittest
+from typing import List, Tuple
+
+import torch
+
+from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler.base import IntVar, JaggedDim
+from aitemplate.compiler.ops.b2b_bmm.b2b_bmm_base import CausalType
+from aitemplate.frontend import Tensor
+from aitemplate.testing import detect_target
+from aitemplate.testing.test_utils import (
+    epilogue_math_name_to_torch_fn,
+    get_attn_mask_per_causal_type,
+)
+from aitemplate.utils import shape_utils
+from aitemplate.utils.torch_utils import string_to_torch_dtype
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@unittest.skipIf(
+    detect_target().name() == "cuda" and int(detect_target()._arch) < 80,
+    "Not supported by CUDA < SM80.",
+)
+class GroupedFMHAStyleB2bBmmTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch.manual_seed(0)
+
+    def _test_grouped_fmha_style_b2b_bmm(
+        self,
+        batch_sizes: Tuple[int, List[int]] = 1024,
+        max_seq_lens: Tuple[int, List[int]] = 256,
+        head_dim=128,
+        head_dim_value=256,
+        num_heads=1,
+        has_bias=False,
+        bias_broadcast=None,
+        epilogue_math_name="Identity",
+        causal_type=CausalType.NO_CAUSAL,
+        dtype="float16",
+        offsets_dtype="int32",
+        test_name="grouped_fmha_style_b2b_bmm",
+        alpha1_divide_by_seq_len=True,
+        copy_op=True,
+        atol=1e-3,
+        rtol=1e-3,
+        use_fp16_acc=False,
+    ):
+        # Initialize AIT fmha_style_b2b_bmm operator.
+        if isinstance(batch_sizes, int):
+            batch_sizes = [batch_sizes, batch_sizes]
+        if isinstance(max_seq_lens, int):
+            max_seq_lens = [max_seq_lens, max_seq_lens]
+        alpha0 = 1.0 / (head_dim**0.5)
+        batch_size_dim = IntVar(
+            values=[min(batch_sizes), max(batch_sizes)], name="batch_size"
+        )
+        max_seq_len_dim = shape_utils.gen_int_var_min_max(
+            max_seq_lens, name="max_seq_len"
+        )
+        jagged_dims = [JaggedDim(min_value=0, max_value=max_seq_len_dim)]
+        total_length_dim = IntVar(
+            values=[0, batch_size_dim.upper_bound() * max_seq_len_dim.upper_bound()],
+            name="total_length",
+        )
+        offsets_dim = IntVar(
+            values=[batch_size_dim.lower_bound() + 1, batch_size_dim.upper_bound() + 1],
+            name="offset_length",
+        )
+        Q_dense = Tensor(
+            shape=[total_length_dim, num_heads, head_dim],
+            dtype=dtype,
+            name="q",
+            is_input=True,
+        )
+        K_dense = Tensor(
+            shape=[total_length_dim, num_heads, head_dim],
+            dtype=dtype,
+            name="k",
+            is_input=True,
+        )
+        V_dense = Tensor(
+            shape=[total_length_dim, num_heads, head_dim_value],
+            dtype=dtype,
+            name="v",
+            is_input=True,
+        )
+        offsets = [
+            Tensor(
+                shape=[offsets_dim], name="offsets", dtype=offsets_dtype, is_input=True
+            )
+        ]
+        Q = ops.make_jagged(batch_dim=batch_size_dim, jagged_dims=jagged_dims)(
+            Q_dense, offsets
+        )
+        K = ops.make_jagged(batch_dim=batch_size_dim, jagged_dims=jagged_dims)(
+            K_dense, offsets
+        )
+        V = ops.make_jagged(batch_dim=batch_size_dim, jagged_dims=jagged_dims)(
+            V_dense, offsets
+        )
+        Bias = None
+        if has_bias:
+            shape = [batch_size_dim, num_heads, max_seq_len_dim, max_seq_len_dim]
+            if bias_broadcast:
+                for i, broadcast in enumerate(bias_broadcast):
+                    if broadcast:
+                        shape[i] = 1
+            Bias = Tensor(
+                shape=shape,
+                dtype=dtype,
+                name="bias",
+                is_input=True,
+            )
+        grouped_fmha_style_b2b_bmm_op = ops.grouped_fmha_style_b2b_bmm(
+            causal_type=causal_type,
+            alpha0=alpha0,
+            alpha1=1.0,
+            alpha1_divide_by_seq_len=alpha1_divide_by_seq_len,
+            epilogue_math_name=epilogue_math_name,
+            num_heads=num_heads,
+        )
+        if copy_op:
+            grouped_fmha_style_b2b_bmm_op = ops.grouped_fmha_style_b2b_bmm(
+                **grouped_fmha_style_b2b_bmm_op._get_op_attributes()
+            )
+        Y = grouped_fmha_style_b2b_bmm_op(Q, K, V, Bias)
+        Y._attrs["is_output"] = True
+        Y._attrs["name"] = "output"
+
+        target = detect_target(use_fp16_acc=use_fp16_acc)
+        torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = use_fp16_acc
+        module = compile_model(Y, target, "./tmp", test_name)
+
+        # Run tests.
+        torch_dtype = string_to_torch_dtype(dtype)
+        offsets_torch_dtype = string_to_torch_dtype(offsets_dtype)
+        for batch_size, max_seq_len in itertools.product(
+            sorted(set(batch_sizes)), sorted(set(max_seq_lens))
+        ):
+            # Initialize inputs
+            lengths = torch.randint(
+                1, max_seq_len, (batch_size + 1,), dtype=offsets_torch_dtype
+            )
+            lengths[0] = 0
+            offsets = torch.cumsum(lengths, dim=0).to(dtype=offsets_torch_dtype)
+            # print(f"{batch_size=}, {offsets=}")
+            total_length = offsets[-1]
+            offsets_pt = offsets.cuda()
+            q_pt = torch.rand(
+                (total_length, num_heads, head_dim), dtype=torch_dtype
+            ).cuda()
+            k_pt = torch.rand(
+                (total_length, num_heads, head_dim), dtype=torch_dtype
+            ).cuda()
+            v_pt = torch.rand(
+                (total_length, num_heads, head_dim_value), dtype=torch_dtype
+            ).cuda()
+            bias_shape = [batch_size, num_heads, max_seq_len, max_seq_len]
+            if bias_broadcast:
+                for i, broadcast in enumerate(bias_broadcast):
+                    if broadcast:
+                        bias_shape[i] = 1
+            bias_pt = torch.rand(bias_shape, dtype=torch_dtype).cuda()
+
+            # Run AIT.
+            inputs = {
+                "q": q_pt,
+                "k": k_pt,
+                "v": v_pt,
+                "offsets": offsets_pt,
+            }
+            if has_bias:
+                inputs["bias"] = bias_pt
+            y = torch.empty(
+                [total_length, num_heads, head_dim_value],
+                dtype=torch_dtype,
+                device="cuda",
+            )
+            module.run_with_tensors(inputs, [y])
+
+            # Run PT reference and verify results.
+            for row in range(batch_size):
+                start = offsets[row]
+                end = offsets[row + 1]
+                length = end - start
+                q_pt_row = q_pt[start:end, :, :]
+                k_pt_row = k_pt[start:end, :, :]
+                v_pt_row = v_pt[start:end, :, :]
+                attn = alpha0 * (
+                    q_pt_row.transpose(0, 1)
+                    @ k_pt_row.transpose(0, 1).transpose(-2, -1)
+                )
+                if has_bias:
+                    bias_row = (
+                        0 if (bias_broadcast is not None and bias_broadcast[0]) else row
+                    )
+                    bias_pt_row = bias_pt[
+                        bias_row : bias_row + 1, :, :length, :length
+                    ].squeeze(dim=0)
+                    attn = attn + bias_pt_row
+                attn = epilogue_math_name_to_torch_fn(epilogue_math_name)(attn)
+                if alpha1_divide_by_seq_len:
+                    attn /= max_seq_len
+                invalid_attn_mask = get_attn_mask_per_causal_type(
+                    length, length, causal_type, torch_dtype
+                )
+                attn = attn * invalid_attn_mask
+                output = (attn @ v_pt_row.transpose(0, 1)).transpose(0, 1)
+                y_pt_row = output.detach()
+                # print(
+                #     f"{batch_size=}, {row=}, {y[start:end, :, :]=}, {y_pt_row.to(torch_dtype)=}"
+                # )
+                torch.testing.assert_close(
+                    y[start:end, :, :], y_pt_row.to(torch_dtype), atol=atol, rtol=rtol
+                )
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_grouped_fmha_style_b2b_bmm_fp16(self):
+        self._test_grouped_fmha_style_b2b_bmm(
+            test_name="grouped_fmha_style_b2b_bmm_fp16_basic",
+            dtype="float16",
+            batch_sizes=1,
+        )
+        self._test_grouped_fmha_style_b2b_bmm(
+            test_name="grouped_fmha_style_b2b_bmm_fp16_dynamic_batch",
+            dtype="float16",
+            batch_sizes=[3, 8, 10],
+        )
+        self._test_grouped_fmha_style_b2b_bmm(
+            test_name="grouped_fmha_style_b2b_bmm_fp16_dynamic_batch_fp16_acc",
+            dtype="float16",
+            batch_sizes=[3, 8, 10],
+            use_fp16_acc=True,
+            # Need to use a larger threshold for fp16 accum, it seems that
+            # torch always generates the same result regardless of
+            # how allow_fp16_reduced_precision_reduction is set.
+            atol=1e-2,
+        )
+        self._test_grouped_fmha_style_b2b_bmm(
+            test_name="grouped_fmha_style_b2b_bmm_fp16_causal_upper_right_empty",
+            dtype="float16",
+            batch_sizes=2,
+            causal_type=CausalType.UPPER_RIGHT_EMPTY,
+        )
+        self._test_grouped_fmha_style_b2b_bmm(
+            test_name="grouped_fmha_style_b2b_bmm_fp16_causal_lower_left_empty",
+            dtype="float16",
+            batch_sizes=3,
+            causal_type=CausalType.LOWER_LEFT_EMPTY,
+        )
+        self._test_grouped_fmha_style_b2b_bmm(
+            test_name="grouped_fmha_style_b2b_bmm_fp16_bias",
+            dtype="float16",
+            batch_sizes=2,
+            has_bias=True,
+        )
+        self._test_grouped_fmha_style_b2b_bmm(
+            test_name="grouped_fmha_style_b2b_bmm_fp16_bias_broadcast",
+            dtype="float16",
+            batch_sizes=3,
+            has_bias=True,
+            bias_broadcast=[False, True, False, False],
+        )
+        self._test_grouped_fmha_style_b2b_bmm(
+            test_name="grouped_fmha_style_b2b_bmm_fp16_dynamic_seq_len",
+            dtype="float16",
+            max_seq_lens=[128, 256],
+            has_bias=True,
+            bias_broadcast=[False, True, False, False],
+        )
+        self._test_grouped_fmha_style_b2b_bmm(
+            test_name="grouped_fmha_style_b2b_bmm_fp16_sigmoid",
+            dtype="float16",
+            batch_sizes=[1, 4],
+            epilogue_math_name="Sigmoid",
+        )
+        self._test_grouped_fmha_style_b2b_bmm(
+            test_name="grouped_fmha_style_b2b_bmm_fp16_multi_head",
+            dtype="float16",
+            batch_sizes=[1, 4],
+            has_bias=True,
+            num_heads=2,
+            bias_broadcast=[True, True, True, False],
+        )
+        self._test_grouped_fmha_style_b2b_bmm(
+            test_name="grouped_fmha_style_b2b_bmm_fp16_complex",
+            dtype="float16",
+            offsets_dtype="int64",
+            batch_sizes=[3, 4],
+            epilogue_math_name="SiLu",
+            causal_type=CausalType.LOWER_LEFT_EMPTY,
+            has_bias=True,
+            bias_broadcast=[False, True, False, False],
+            num_heads=4,
+        )
+        self._test_grouped_fmha_style_b2b_bmm(
+            test_name="grouped_fmha_style_b2b_bmm_fp16_complex_fp16_acc",
+            dtype="float16",
+            batch_sizes=[1, 4, 10, 512, 1024],
+            epilogue_math_name="ReLu",
+            causal_type=CausalType.LOWER_LEFT_EMPTY,
+            has_bias=True,
+            bias_broadcast=[False, False, True, False],
+            num_heads=2,
+            use_fp16_acc=True,
+            max_seq_lens=1024,
+            # Need to use a larger threshold for fp16 accum, it seems that
+            # torch always generates the same result regardless of
+            # how allow_fp16_reduced_precision_reduction is set.
+            atol=1e-2,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
ATT, the block size / thread  size is still based on max_seq_length, but skip elements which are not within actual_seq_length.
It's not as optimal as the solution with group scheduling algorithm (especially when seq_lengths differ a lot for different examples in a batch), but it could help avoid jagged / padded conversion and should work fine when seq_lengths do not differ a lot.

Differential Revision: D44364087

