### PR TITLE
Allow file name without dir to dump ait_to_py

### DIFF
--- a/docs/static/ait_model.html
+++ b/docs/static/ait_model.html
@@ -661,7 +661,7 @@ input[type=submit] {
           /*make the matching letters bold:*/
           b.innerHTML = "<strong>" + arr[i].substr(0, val.length) + "</strong>";
           b.innerHTML += arr[i].substr(val.length);
-          /*insert a input field that will hold the current array item's value:*/
+          /*insert an input field that will hold the current array item's value:*/
           b.innerHTML += "<input type='hidden' value='" + arr[i] + "'>";
           /*execute a function when someone clicks on the item value (DIV element):*/
               b.addEventListener("click", function(e) {

--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -203,7 +203,8 @@ def compile_model(
     # arguments (even if we put quotes around it)!!
     test_name = test_name.replace(",", "_")
     test_dir = os.path.join(workdir, test_name)
-    profile_dir = workdir if profile_dir is None else profile_dir
+    if profile_dir is None:
+        profile_dir = workdir
 
     if debug_settings.dump_ait_to_py:
         dump_program(tensor, debug_settings.dump_ait_to_py)

--- a/python/aitemplate/utils/serialization/ait_program.py
+++ b/python/aitemplate/utils/serialization/ait_program.py
@@ -86,6 +86,6 @@ class AITBasicProgram:
     def model(self) -> Union[Tensor, Tuple[Tensor]]:
         """
         This function defines the AIT program.
-        Returns a output tensor, or a tuple of output tensors.
+        Returns an output tensor, or a tuple of output tensors.
         """
         pass

--- a/python/aitemplate/utils/serialization/serdes_code.py
+++ b/python/aitemplate/utils/serialization/serdes_code.py
@@ -360,7 +360,9 @@ def dump_program(
     )
 
     if file_path != "":
-        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        dirs = os.path.dirname(file_path)
+        if dirs != "":
+            os.makedirs(dirs, exist_ok=True)
         with open(file_path, "w") as f:
             f.write(program)
 

--- a/python/aitemplate/utils/visualization/web_template.py
+++ b/python/aitemplate/utils/visualization/web_template.py
@@ -162,7 +162,7 @@ input[type=submit] {
           /*make the matching letters bold:*/
           b.innerHTML = "<strong>" + arr[i].substr(0, val.length) + "</strong>";
           b.innerHTML += arr[i].substr(val.length);
-          /*insert a input field that will hold the current array item's value:*/
+          /*insert an input field that will hold the current array item's value:*/
           b.innerHTML += "<input type='hidden' value='" + arr[i] + "'>";
           /*execute a function when someone clicks on the item value (DIV element):*/
               b.addEventListener("click", function(e) {


### PR DESCRIPTION
`AITDebugSettings` allow to specify py file to which generated `AITProgram` will be dumped.
Currently it expects at least one dir before the file name.
This PR allows to use file name without dir.
e.g.
```
debug_settings = AITDebugSettings()
debug_settings.dump_ait_to_py = "ait_prog.py"

m = compiler.compile_model(...,
    debug_settings=debug_settings,
)
```
