### PR TITLE
fixed how we fetch leading_a_dim and leading_b_dim for bmm ops

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_universal/common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/common.py
@@ -1093,11 +1093,12 @@ def gen_local_dim_defs(func_attrs, indent="  "):
             # skip dynamic dims
             if isinstance(dim, IntImm):
                 input_shape = func_attrs["inputs"][input_idx]._attrs["shape"]
-                name = input_shape[idx]._attrs["name"]
-                if name in dims:
-                    assert dims[name] == dim.value(), "bmm inputs shape mismatch"
-                else:
-                    dims[name] = dim.value()
+                if idx < len(input_shape):
+                    name = input_shape[idx]._attrs["name"]
+                    if name in dims:
+                        assert dims[name] == dim.value(), "bmm inputs shape mismatch"
+                    else:
+                        dims[name] = dim.value()
     return DIM_DEFS_TEMPLATE.render(dims=dims, indent=indent)
 
 

--- a/tests/unittest/compiler/test_slice_gemm_fusion.py
+++ b/tests/unittest/compiler/test_slice_gemm_fusion.py
@@ -348,7 +348,6 @@ class SliceGemmFusionTestCase(unittest.TestCase):
         no_fusion=False,
         dtype="float16",
     ):
-
         X = Tensor(
             shape=slice_input_shape,
             dtype=dtype,
@@ -826,7 +825,6 @@ class SliceGemmFusionTestCase(unittest.TestCase):
             slice_start_indices=(0, 8),
             slice_end_indices=(None, 16),
             test_name="slice_gemm_rcr_fusion_a_2_float",
-            no_fusion=True,
             dtype="float",
         )
         self._test_slice_gemm_rcr_bias_add(


### PR DESCRIPTION
This PR fixed the incorrect uses of bmm's methods _get_a_leading_dim and _get_b_leading_dim