### PR TITLE
Resurrect gemm_ / bmm_softmax

### DIFF
--- a/python/aitemplate/compiler/ops/gemm_epilogue_vistor/gemm_rcr_bias_softmax.py
+++ b/python/aitemplate/compiler/ops/gemm_epilogue_vistor/gemm_rcr_bias_softmax.py
@@ -15,7 +15,7 @@
 """
 Operator definition for gemm_rcr_bias_softmax.
 """
-from aitemplate.compiler.base import _create_host_zero_tensor, Tensor
+from aitemplate.compiler.base import Tensor
 from aitemplate.compiler.ops.gemm_epilogue_vistor.gemm_rcr_softmax import (
     gemm_rcr_softmax,
 )
@@ -59,20 +59,13 @@ class gemm_rcr_bias_softmax(gemm_rcr_softmax):
         output_shape = self._infer_shapes(a, b, bias)
         self._extract_epilogue_alignment(output_shape)
 
-        temp_d = _create_host_zero_tensor(output_shape, dst_ops={self})
-        temp_n = _create_host_zero_tensor(
-            [output_shape[0], 1], dtype="float32", dst_ops={self}
-        )
-
-        self._attrs["inputs"].append(temp_d)
-        self._attrs["inputs"].append(temp_n)
         self._attrs["input_accessors"] = [
             TensorAccessor(tensor) for tensor in self._attrs["inputs"]
         ]
 
         self._set_depth()
 
-        output = Tensor(output_shape, src_ops={self})
+        output = Tensor(output_shape, src_ops={self}, dtype=a._attrs["dtype"])
         self._attrs["outputs"] = [output]
         self._attrs["output_accessors"] = [TensorAccessor(output)]
         return output

--- a/tests/unittest/ops/test_gemm_softmax.py
+++ b/tests/unittest/ops/test_gemm_softmax.py
@@ -12,33 +12,33 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-import logging
-import os
 import unittest
 
-import numpy as np
 import torch
-from aitemplate.compiler import compile_model, Model, ops
+from aitemplate.compiler import compile_model, ops
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
+    filter_test_cases_by_test_env,
     get_random_torch_tensor,
     get_torch_empty_tensor,
 )
 
 
-_LOGGER = logging.getLogger(__name__)
-
-
-# @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
-@unittest.skip("GEMM + Softmax is disabled for now")
+@unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
 class GEMMSoftmaxTestCase(unittest.TestCase):
-    def _test_gemm_rcr_softmax(self, M=16, K=64, N=24, rebuild=True, dtype="float16"):
-        target = detect_target()
-        if type(target).__name__ == "FBCUDA":
-            _LOGGER.warning("Skip this test for special profiling requirement")
-            return
+    @classmethod
+    def setUpClass(cls) -> None:
+        torch.manual_seed(0)
 
+    def _test_gemm_rcr_softmax(
+        self,
+        M=16,
+        K=64,
+        N=24,
+        dtype="float16",
+        test_name="gemm_rcr_softmax",
+    ):
         X = Tensor(shape=[M, K], dtype=dtype, name="input_0", is_input=True)
         W = Tensor(shape=[N, K], dtype=dtype, name="input_1", is_input=True)
         OP = ops.gemm_rcr_softmax()
@@ -46,35 +46,65 @@ class GEMMSoftmaxTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        X_pt = get_random_torch_tensor([M, K], dtype)
-        W_pt = get_random_torch_tensor([N, K], dtype)
-        Y_pt = torch.nn.functional.linear(X_pt, W_pt)
-        Y_pt = torch.softmax(Y_pt, dim=1)
-        Y_np = Y_pt.cpu().numpy()
+        x_pt = get_random_torch_tensor([M, K], dtype)
+        w_pt = get_random_torch_tensor([N, K], dtype)
+        y_pt = torch.nn.functional.linear(x_pt, w_pt)
+        y_pt = torch.softmax(y_pt, dim=1)
 
-        test_name = f"gemm_softmax_{dtype}"
-        if rebuild:
-            target = detect_target()
-            module = compile_model(Y, target, "./tmp", test_name)
-        else:
-            module = Model(os.path.join("./tmp", test_name, "test.so"))
-        inputs = {"input_0": X_pt, "input_1": W_pt}
+        module = compile_model(Y, detect_target(), "./tmp", test_name)
+
+        inputs = {"input_0": x_pt, "input_1": w_pt}
         y = get_torch_empty_tensor([M, N], dtype)
         module.run_with_tensors(inputs, [y])
-        y_ait_np = y.cpu().numpy()
-        np.testing.assert_allclose(Y_np, y_ait_np, atol=1e-1, rtol=1e-1)
-        np.testing.assert_allclose(
-            np.argmax(Y_np, axis=1),
-            np.argmax(y_ait_np, axis=1),
+
+        torch.testing.assert_close(y, y_pt, atol=1e-2, rtol=1e-2)
+
+        torch.testing.assert_close(
+            torch.argmax(y, axis=1),
+            torch.argmax(y_pt, axis=1),
             atol=1e-1,
             rtol=1e-1,
         )
 
-    def test_gemm_softmax(self):
-        self._test_gemm_rcr_softmax()
+    def test_gemm_rcr_softmax_float16(self):
+        self._test_gemm_rcr_softmax(
+            M=16,
+            K=64,
+            N=24,
+            dtype="float16",
+            test_name="gemm_rcr_softmax_fp16_1",
+        )
 
-    def test_gemm_softmax_float(self):
-        self._test_gemm_rcr_softmax(dtype="float")
+        if not detect_target().use_dummy_profiling_results():
+            # dummy workspace size (10240 bytes) is insufficient for
+            # these tests: run them only locally where profiler is
+            # executed and detects the necessary workspace size
+            self._test_gemm_rcr_softmax(
+                M=1024,
+                K=512,
+                N=4096,
+                dtype="float16",
+                test_name="gemm_rcr_softmax_fp16_2",
+            )
+            self._test_gemm_rcr_softmax(
+                M=2048,
+                K=1024,
+                N=4096,
+                dtype="float16",
+                test_name="gemm_rcr_softmax_fp16_3",
+            )
+
+    def test_gemm_rcr_softmax_float32_sm80(self):
+        self._test_gemm_rcr_softmax(
+            M=16,
+            K=64,
+            N=24,
+            dtype="float32",
+            test_name="gemm_rcr_softmax_fp32_1",
+        )
+
+
+filter_test_cases_by_test_env(GEMMSoftmaxTestCase)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
The `gemm_` / `bmm_softmax` ops are broken for ~10 months, with the corresponding tests disabled, due to an inconsistency with the CUTLASS API update in 2.10. As a result, the major changes in the GEMM back-end did not cover these ops.

In this diff, the following `softmax` ops are resurrected:

- `gemm_rcr_softmax`
- `gemm_rcr_bias_softmax`
- `bmm_rcr_softmax`

More specifically, the CUTLASS API inconsistency is resolved, the ops' GEMM back-end code is modernized to be compatible with the outer GEMM ecosystem, the unit tests are made functional again. Importantly, the diff introduces minimal changes necessary to make the above `softmax` ops functional again. Further improvements (some listed below) are *not introduced* here.

What is *done* in this diff (based on terrychenism's [unpublished branch](https://github.com/fairinternal/AITemplate/compare/main...terrychenism:AITemplate:softmax_update) from 8 months ago):

- Update the internal `GemmSoftmaxUnversal` CUTLASS-based operator to be consistent with the 3.0 APIs.
- Fix the bug in `GemmSoftmaxUnversal` operator (also present in the upstream `GemmSoftmax`).
    - To allow SMEM > `(48 << 10)` bytes required by some of the generated op instances.
- Use op workspace instead of *all* temporary inputs.
- Generalize `dtype` instead of the hard-coded `half`.
- Combine profilers into a single file, as required by the outer `gemm_universal` code.
- Remove `split_k` support from the codegen, as the CUTLASS op uses `kBatched` mode hard-coded.

What is *not done* in this diff (hence, should probably be done in the future):

- Performance tuning (e.g., based on tweaking the `ApplyShape` as suggested [here](https://github.com/NVIDIA/cutlass/blob/master/examples/35_gemm_softmax/gemm_softmax.cu#L221-L224)).
- Use upstream CUTLASS [`GemmSoftmax`](https://github.com/NVIDIA/cutlass/blob/master/examples/35_gemm_softmax/gemm_with_softmax.h#L317) operator instead of the internal `GemmSoftmaxUniversal`.
    - Due to the SMEM bug. Will submit a PR to `nvidia/cutlass` soon, can switch when merged.
- Support arbitrary number of `a` dimensions instead of M in `gemm_` ops.
- Support input TensorAccessors (output TAs seem to be supported).
- Other things that are possibly missed.

Differential Revision: D44406815

