### PR TITLE
Reorganize skipped tests

### DIFF
--- a/tests/unittest/compiler/test_split_bmm_softmax_bmm.py
+++ b/tests/unittest/compiler/test_split_bmm_softmax_bmm.py
@@ -24,13 +24,13 @@ from aitemplate.compiler import compile_model, ops
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
+    filter_test_cases_by_test_env,
     get_random_torch_tensor,
     get_torch_empty_tensor,
 )
 from aitemplate.utils import graph_utils, shape_utils
 
 
-@unittest.skipIf(detect_target().name() == "cuda", "Only supported by ROCM.")
 class SplitBMMTestCase(unittest.TestCase):
     def _test_split_reshape_bmm_permute(
         self, bs, nheads, seq_len, hidden_size, test_name, dtype="float16"
@@ -82,13 +82,16 @@ class SplitBMMTestCase(unittest.TestCase):
             module.run_with_tensors([x_pt], [y])
             self.assertTrue(torch.allclose(y_pt, y, atol=1e-1, rtol=1e-1))
 
-    def test_split_reshape_bmm_permute(self):
+    def test_split_reshape_bmm_permute_rocm(self):
         self._test_split_reshape_bmm_permute(
             bs=[1], nheads=12, seq_len=256, hidden_size=768, test_name="static"
         )
         self._test_split_reshape_bmm_permute(
             bs=[16], nheads=12, seq_len=256, hidden_size=768, test_name="static"
         )
+
+
+filter_test_cases_by_test_env(SplitBMMTestCase)
 
 
 if __name__ == "__main__":

--- a/tests/unittest/compiler/test_transform_special_op.py
+++ b/tests/unittest/compiler/test_transform_special_op.py
@@ -266,7 +266,6 @@ class BmmRcrN1TestCase(unittest.TestCase):
         self.assertEqual(src_op._attrs["op"], "bmm_rcr")
 
 
-@unittest.skip("enable it when ck fix")
 class OneByOneConvTestCase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -376,38 +375,41 @@ class OneByOneConvTestCase(unittest.TestCase):
                     Y_pt, Y_ait.permute(0, 3, 1, 2), atol=1e-1, rtol=1e-1
                 )
 
-    def test_1x1_conv_no_bias(self):
-        self._test_simple_1x1_conv(batch=1, CO=256, HH=3, WW=4, CI=2)
-        self._test_simple_1x1_conv(
-            batch=3, CO=100, HH=200, WW=4, CI=2, activation="relu"
-        )
-        self._test_simple_1x1_conv(
-            batch=2, CO=128, HH=10, WW=42, CI=3, activation="sigmoid"
-        )
-        self._test_simple_1x1_conv(batch=5, CO=256, HH=15, WW=5, CI=13)
-        self._test_simple_1x1_conv(batch=(1, 10), CO=128, HH=2, WW=2, CI=10)
+    # !!! SKIPPED TESTS BELOW !!!
+    # TODO: enable the tests when ck is fixed
 
-    def test_1x1_conv_with_bias(self):
-        self._test_simple_1x1_conv(batch=1, CO=256, HH=3, WW=4, CI=2, with_bias=True)
-        self._test_simple_1x1_conv(
-            batch=3,
-            CO=100,
-            HH=200,
-            WW=4,
-            CI=2,
-            activation="relu",
-            with_bias=True,
-        )
-        self._test_simple_1x1_conv(
-            batch=2, CO=128, HH=10, WW=42, CI=3, activation="sigmoid", with_bias=True
-        )
-        self._test_simple_1x1_conv(
-            batch=2, CO=64, HH=10, WW=42, CI=3, activation="hardswish", with_bias=True
-        )
-        self._test_simple_1x1_conv(batch=5, CO=256, HH=15, WW=5, CI=13, with_bias=True)
-        self._test_simple_1x1_conv(
-            batch=(1, 10), CO=128, HH=2, WW=2, CI=10, with_bias=True
-        )
+    # def test_1x1_conv_no_bias(self):
+    #     self._test_simple_1x1_conv(batch=1, CO=256, HH=3, WW=4, CI=2)
+    #     self._test_simple_1x1_conv(
+    #         batch=3, CO=100, HH=200, WW=4, CI=2, activation="relu"
+    #     )
+    #     self._test_simple_1x1_conv(
+    #         batch=2, CO=128, HH=10, WW=42, CI=3, activation="sigmoid"
+    #     )
+    #     self._test_simple_1x1_conv(batch=5, CO=256, HH=15, WW=5, CI=13)
+    #     self._test_simple_1x1_conv(batch=(1, 10), CO=128, HH=2, WW=2, CI=10)
+
+    # def test_1x1_conv_with_bias(self):
+    #     self._test_simple_1x1_conv(batch=1, CO=256, HH=3, WW=4, CI=2, with_bias=True)
+    #     self._test_simple_1x1_conv(
+    #         batch=3,
+    #         CO=100,
+    #         HH=200,
+    #         WW=4,
+    #         CI=2,
+    #         activation="relu",
+    #         with_bias=True,
+    #     )
+    #     self._test_simple_1x1_conv(
+    #         batch=2, CO=128, HH=10, WW=42, CI=3, activation="sigmoid", with_bias=True
+    #     )
+    #     self._test_simple_1x1_conv(
+    #         batch=2, CO=64, HH=10, WW=42, CI=3, activation="hardswish", with_bias=True
+    #     )
+    #     self._test_simple_1x1_conv(batch=5, CO=256, HH=15, WW=5, CI=13, with_bias=True)
+    #     self._test_simple_1x1_conv(
+    #         batch=(1, 10), CO=128, HH=2, WW=2, CI=10, with_bias=True
+    #     )
 
 
 if __name__ == "__main__":

--- a/tests/unittest/ops/test_bmm_softmax_bmm.py
+++ b/tests/unittest/ops/test_bmm_softmax_bmm.py
@@ -24,6 +24,7 @@ import torch
 from aitemplate.compiler import compile_model, ops
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
+from aitemplate.testing.test_utils import filter_test_cases_by_test_env
 from aitemplate.utils import shape_utils
 
 
@@ -37,7 +38,6 @@ def build_causal_attention_mask(bsz, seq_len, dtype):
     return mask
 
 
-@unittest.skipIf(detect_target().name() == "cuda", "Only supported by ROCM.")
 class BMMSoftmaxBMMTestCase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(BMMSoftmaxBMMTestCase, self).__init__(*args, **kwargs)
@@ -172,7 +172,7 @@ class BMMSoftmaxBMMTestCase(unittest.TestCase):
             else:
                 self.assertTrue(torch.allclose(Y2_pt, y, atol=1e-1, rtol=1e-1))
 
-    def test_rcr(self):
+    def test_rcr_rocm(self):
         # FIXME: re-enable it after we fix the missing parameter for bmm_softmax_bmm
         # self._test_b2b([16], [576], N=576, K=64, D=64, test_name="static")
         self._test_bmm_permute([24], [256], N=256, K=64, D=64, test_name="static")
@@ -204,6 +204,9 @@ class BMMSoftmaxBMMTestCase(unittest.TestCase):
             test_name="static_copy_op",
             copy_op=True,
         )
+
+
+filter_test_cases_by_test_env(BMMSoftmaxBMMTestCase)
 
 
 if __name__ == "__main__":

--- a/tests/unittest/ops/test_conv3d.py
+++ b/tests/unittest/ops/test_conv3d.py
@@ -22,7 +22,11 @@ from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
 
 
-@unittest.skipIf(detect_target()._arch == "75", "Conv3d not supported on sm75.")
+@unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+@unittest.skipIf(
+    detect_target().name() == "cuda" and int(detect_target()._arch) < 80,
+    "Not supported by CUDA < SM80.",
+)
 class Conv3dTestCase(unittest.TestCase):
     def test_conv3d_bias_padding(
         self,
@@ -248,39 +252,37 @@ class Conv3dTestCase(unittest.TestCase):
             dtype="float16",
         )
 
-    @unittest.skip("no fp32 kernels are available for conv3d")
-    @unittest.skipIf(detect_target().name() == "rocm", "fp32 not supported in ROCm")
-    @unittest.skipIf(
-        detect_target().name() == "cuda" and int(detect_target()._arch) < 80,
-        "Not supported by CUDA < SM80.",
-    )
-    def test_fp32(self):
-        self._test_conv3d(
-            4,
-            224,
-            224,
-            8,
-            96,
-            3,
-            5,
-            5,
-            stride=(2, 4, 4),
-            pad=(1, 2, 2),
-            test_name="conv3d_fp32_1",
-            dtype="float32",
-        )
-        self._test_conv3d(
-            56,
-            56,
-            56,
-            64,
-            256,
-            1,
-            1,
-            1,
-            test_name="conv3d_fp32_2",
-            dtype="float32",
-        )
+    # !!! SKIPPED TESTS BELOW !!!
+    # CUTLASS generator doesn't provide conv3d ops for fp32
+    # TODO: enable the tests after the issue is resolved
+
+    # def test_fp32(self):
+    #     self._test_conv3d(
+    #         4,
+    #         224,
+    #         224,
+    #         8,
+    #         96,
+    #         3,
+    #         5,
+    #         5,
+    #         stride=(2, 4, 4),
+    #         pad=(1, 2, 2),
+    #         test_name="conv3d_fp32_1",
+    #         dtype="float32",
+    #     )
+    #     self._test_conv3d(
+    #         56,
+    #         56,
+    #         56,
+    #         64,
+    #         256,
+    #         1,
+    #         1,
+    #         1,
+    #         test_name="conv3d_fp32_2",
+    #         dtype="float32",
+    #     )
 
 
 if __name__ == "__main__":

--- a/tests/unittest/ops/test_efficient_nms.py
+++ b/tests/unittest/ops/test_efficient_nms.py
@@ -322,36 +322,38 @@ class nmsTestCase(unittest.TestCase):
             dtype="float32",
         )
 
-    @unittest.skip("manually enable it for benchmarking")
-    def test_nms_benchmark_shapes(self):
-        self._test_nms(
-            N=3350,
-            preNmsTop=2000,
-            nmsMaxOut=100,
-            iouThreshold=0.5,
-            minBoxSize=0,
-            batch_size=16,
-            num_classes=1,
-            rand_box=True,
-            test_name="nms_fcos_shape",
-            benchmark_shapes=True,
-        )
+    # !!! SKIPPED TESTS BELOW !!!
+    # manually enable for benchmarking
 
-        for bz in (1, 4, 16):
-            for N in (6000, 12000, 20000, 60000):
-                for maxout in (100, 300, 1000):
-                    self._test_nms(
-                        N=N,
-                        preNmsTop=6000,
-                        nmsMaxOut=maxout,
-                        iouThreshold=0.5,
-                        minBoxSize=0,
-                        batch_size=bz,
-                        num_classes=1,
-                        rand_box=True,
-                        test_name="nms_" + str(bz) + "_" + str(N) + "_" + str(maxout),
-                        benchmark_shapes=True,
-                    )
+    # def test_nms_benchmark_shapes(self):
+    #     self._test_nms(
+    #         N=3350,
+    #         preNmsTop=2000,
+    #         nmsMaxOut=100,
+    #         iouThreshold=0.5,
+    #         minBoxSize=0,
+    #         batch_size=16,
+    #         num_classes=1,
+    #         rand_box=True,
+    #         test_name="nms_fcos_shape",
+    #         benchmark_shapes=True,
+    #     )
+
+    #     for bz in (1, 4, 16):
+    #         for N in (6000, 12000, 20000, 60000):
+    #             for maxout in (100, 300, 1000):
+    #                 self._test_nms(
+    #                     N=N,
+    #                     preNmsTop=6000,
+    #                     nmsMaxOut=maxout,
+    #                     iouThreshold=0.5,
+    #                     minBoxSize=0,
+    #                     batch_size=bz,
+    #                     num_classes=1,
+    #                     rand_box=True,
+    #                     test_name="nms_" + str(bz) + "_" + str(N) + "_" + str(maxout),
+    #                     benchmark_shapes=True,
+    #                 )
 
 
 if __name__ == "__main__":

--- a/tests/unittest/ops/test_perm021fc_ccr_bias_perm021.py
+++ b/tests/unittest/ops/test_perm021fc_ccr_bias_perm021.py
@@ -25,12 +25,18 @@ import torch
 from aitemplate.compiler import compile_model, ops
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
-from aitemplate.testing.test_utils import get_random_torch_tensor
+from aitemplate.testing.test_utils import (
+    filter_test_cases_by_test_env,
+    get_random_torch_tensor,
+)
 
 
-@unittest.skip("Re-enable after cutlass fix")
-# @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+@unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
 class Perm021FCCCRBiasPerm021TestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        torch.manual_seed(0)
+
     def _test_perm021fc_ccr_bias_perm021(
         self,
         test_name="perm021fc_ccr_bias_perm021",
@@ -83,35 +89,31 @@ class Perm021FCCCRBiasPerm021TestCase(unittest.TestCase):
 
         self.assertTrue(torch.allclose(Y_pt, y, atol=1e-1, rtol=1e-1))
 
-    def test_perm021fc_ccr_bias_perm021_fp16(self):
-        self._test_perm021fc_ccr_bias_perm021(
-            test_name="perm021fc_ccr_bias_perm021_fp16",
-            dtype="float16",
-        )
+    # !!! SKIPPED TESTS BELOW !!!
+    # Permute3DBMM_021 layout not currently present in CUTLASS
+    # TODO: enable the tests after this layout becomes available
 
-    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
-    @unittest.skipIf(
-        int(detect_target()._arch) < 80,
-        f"fp32 BMM not supported in {detect_target()._arch}",
-    )
-    def test_perm021fc_ccr_bias_perm021_fp32(self):
-        self._test_perm021fc_ccr_bias_perm021(
-            test_name="perm021fc_ccr_bias_perm021_fp32",
-            dtype="float32",
-        )
+    # def test_perm021fc_ccr_bias_perm021_fp16(self):
+    #     self._test_perm021fc_ccr_bias_perm021(
+    #         test_name="perm021fc_ccr_bias_perm021_fp16",
+    #         dtype="float16",
+    #     )
 
-    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
-    @unittest.skipIf(
-        int(detect_target()._arch) < 80,
-        f"bf16 BMM not supported in {detect_target()._arch}",
-    )
-    def test_perm021fc_ccr_bias_perm021_bf16(self):
-        self._test_perm021fc_ccr_bias_perm021(
-            test_name="perm021fc_ccr_bias_perm021_bf16",
-            dtype="bfloat16",
-        )
+    # def test_perm021fc_ccr_bias_perm021_fp32_sm80(self):
+    #     self._test_perm021fc_ccr_bias_perm021(
+    #         test_name="perm021fc_ccr_bias_perm021_fp32",
+    #         dtype="float32",
+    #     )
+
+    # def test_perm021fc_ccr_bias_perm021_bf16_sm80(self):
+    #     self._test_perm021fc_ccr_bias_perm021(
+    #         test_name="perm021fc_ccr_bias_perm021_bf16",
+    #         dtype="bfloat16",
+    #     )
+
+
+filter_test_cases_by_test_env(Perm021FCCCRBiasPerm021TestCase)
 
 
 if __name__ == "__main__":
-    torch.manual_seed(0)
     unittest.main()


### PR DESCRIPTION
Summary:
A few tests are currently being skipped (with `unittest.skip`) which causes issues in the internal CI. In this diff, those tests are reorganized to avoid skipping them. More specifically:

- `test_bmm_softmax_bmm`: supported on ROCM only: split with `filter_test_cases_by_test_env`.
- `test_split_bmm_softmax_bmm`: supported on ROCM only: split with `filter_test_cases_by_test_env`.
- `test_conv3d`: fp32 op instances aren't generated by CUTLASS: commented out.
- `test_perm021fc_ccr_bias_perm021`: necessary CUTLAS permute layout not available: commented out.
- `test_transform_special_op`: ROCM-based tests have issue in CK; commented out.
- `test_efficient_nms`: benchmark function is supposed to be enabled manually; disabled with `_` prefix.

Differential Revision: D44416401

