### PR TITLE
Introduce safe_compile_model with locking

### DIFF
--- a/python/aitemplate/compiler/__init__.py
+++ b/python/aitemplate/compiler/__init__.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 #
 from aitemplate.compiler import base, dtype, ops, tensor_accessor, transform
-from aitemplate.compiler.compiler import compile_model
+from aitemplate.compiler.compiler import compile_model, safe_compile_model
 from aitemplate.compiler.model import AIT_DEFAULT_NUM_RUNTIMES, AITData, Model
 
 __all__ = [
@@ -25,6 +25,7 @@ __all__ = [
     "tensor_accessor",
     "transform",
     "compile_model",
+    "safe_compile_model",
     "Model",
     "AITData",
     "AIT_DEFAULT_NUM_RUNTIMES",

--- a/python/aitemplate/compiler/lockfile.py
+++ b/python/aitemplate/compiler/lockfile.py
@@ -1,0 +1,96 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import fcntl
+import os
+import time
+from typing import Callable, Optional
+
+
+class FileLock:
+    def __init__(
+        self,
+        path,
+        timeout=3600.0,
+        retry_interval=0.2,
+        lock_contention_callback: Optional[Callable] = None,
+    ):
+        """
+        File locking context manager. Acts like an inter-process mutex
+        on a given file. The lock will be released when the context manager
+        exits. It has a timeout parameter, which triggers a TimeoutError
+        on expiry in order to prevent infinite loops or deadlocks.
+
+        Implementation note:
+            Attempts to open the given file for writing, and
+            acquires an exclusive file lock on success. If the file cannot be opened
+            or the lock cannot be acquired, it retries after retry_interval
+            seconds until success or a timeout occurs.
+
+            Uses fcntl.flock(self.lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            to acquire the file lock.
+
+        Usage:
+
+            with FileLock('/path/to/file.lock', timeout=10):
+                ...
+
+        Args:
+            path (str ): Path to lockfile. Will be created as an empty file
+            if it does not exist. Will not be deleted on exit.
+            timeout (int, optional): Timeout in seconds. Defaults to 3600.
+            retry_interval (float, optional): Retry interval in seconds. Defaults to 0.2.
+            lock_contention_callback(Callable,optional): A callback that will be invoked without arguments
+                                      in the case that a lock cannot be acquired on first attempt.
+                                      May be used for logging purposes.
+        """
+        self.path = path
+        self.timeout = timeout
+        self.lock_file = None
+        self.retry_interval = retry_interval
+        self.lock_contention_callback = lock_contention_callback
+
+    def __enter__(self):
+        start_time = time.monotonic()
+        attempts = 0
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        while True:
+            try:
+                self.lock_file = open(self.path, "w")
+                fcntl.flock(self.lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return self
+            except OSError:
+                if self.lock_file is not None:
+                    self.lock_file.close()
+                    self.lock_file = None
+                if attempts == 0 and self.lock_contention_callback is not None:
+                    lock_contention_callback = self.lock_contention_callback
+                    lock_contention_callback()
+                attempts += 1
+                if (
+                    self.timeout is not None
+                    and time.monotonic() - start_time >= self.timeout
+                ):
+                    raise TimeoutError(
+                        f"Timeout waiting for lock on {self.path}"
+                    ) from None
+                time.sleep(self.retry_interval)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            fcntl.flock(self.lock_file, fcntl.LOCK_UN)
+        finally:
+            self.lock_file.close()
+            self.lock_file = None
+        return False

--- a/tests/unittest/backend/test_cuda_graph.py
+++ b/tests/unittest/backend/test_cuda_graph.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm, IntVar
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
@@ -50,7 +50,7 @@ class CUDAGraphTestCase(unittest.TestCase):
 
         target = detect_target()
         test_name = "cuda_graph_multiple_runes"
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         run = 2
         repeat = 1

--- a/tests/unittest/backend/test_gen_standalone.py
+++ b/tests/unittest/backend/test_gen_standalone.py
@@ -20,7 +20,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
@@ -83,7 +83,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
         target = detect_target()
         debug_settings = AITDebugSettings(gen_standalone=True)
         dll_name = "test.so"
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",

--- a/tests/unittest/backend/test_model_api.py
+++ b/tests/unittest/backend/test_model_api.py
@@ -25,7 +25,7 @@ import numpy as np
 
 import torch
 
-from aitemplate.compiler import AIT_DEFAULT_NUM_RUNTIMES, compile_model, ops
+from aitemplate.compiler import AIT_DEFAULT_NUM_RUNTIMES, ops, safe_compile_model
 from aitemplate.compiler.base import (
     _ConstantTensorData,
     _create_host_zero_tensor,
@@ -73,7 +73,7 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(output, target, "./tmp", test_name)
+        module = safe_compile_model(output, target, "./tmp", test_name)
         in0_pt = torch.randn([1]).cuda().half()
         in1_pt = torch.randn([1]).cuda().half()
         output_pt = torch.mul(in0_pt, in1_pt)
@@ -91,7 +91,7 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(output, target, "./tmp", "test_set_unnamed_input")
+        module = safe_compile_model(output, target, "./tmp", "test_set_unnamed_input")
         in0_pt = torch.randn([1]).cuda().half()
         in1_pt = torch.randn([1]).cuda().half()
         output_pt = in0_pt - in1_pt
@@ -115,7 +115,7 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(output, target, "./tmp", name)
+        module = safe_compile_model(output, target, "./tmp", name)
         input_name_to_index = module.get_input_name_to_index_map()
         self.assertEqual(input_name_to_index, {"input_0": 0, "input_1": 1})
         output_name_to_index = module.get_output_name_to_index_map()
@@ -227,7 +227,9 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(output, target, "./tmp", "test_one_input_many_constants")
+        module = safe_compile_model(
+            output, target, "./tmp", "test_one_input_many_constants"
+        )
         in0_pt = torch.randn((1, 2)).cuda().half()
         const_1_pt = torch.randn((1, 2)).cuda().half()
         const_2_pt = torch.randn((1, 2)).cuda().half()
@@ -296,7 +298,7 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(output, target, "./tmp", "dynamic_shape_api")
+        module = safe_compile_model(output, target, "./tmp", "dynamic_shape_api")
         for batch_size in (1, 10):
             in0_pt = torch.randn([batch_size, 2]).cuda().half()
             in1_pt = torch.randn([batch_size, 2]).cuda().half()
@@ -325,7 +327,7 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["is_output"] = True
         output._attrs["name"] = "output"
 
-        module = compile_model(output, target, "./tmp", "output_is_alias_of_input")
+        module = safe_compile_model(output, target, "./tmp", "output_is_alias_of_input")
 
         in0_pt = torch.randn((2, 2)).cuda().half()
         out_shape = (4, 1) if view_of_view else (4,)
@@ -347,7 +349,7 @@ class ModelAPITestCase(unittest.TestCase):
             shape=[2, 2], dtype="float16", name="input_0", is_input=True, is_output=True
         )
 
-        module = compile_model(input_0, target, "./tmp", "output_is_input")
+        module = safe_compile_model(input_0, target, "./tmp", "output_is_input")
 
         in0_pt = torch.randn((2, 2)).cuda().half()
         out_ait = torch.empty((2, 2)).cuda().half()
@@ -374,7 +376,9 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(output, target, "./tmp", "output_is_view_of_constant")
+        module = safe_compile_model(
+            output, target, "./tmp", "output_is_view_of_constant"
+        )
 
         const_pt = torch.randn((2, 2)).cuda().half()
         out_shape = (4, 1) if view_of_view else (4,)
@@ -394,7 +398,7 @@ class ModelAPITestCase(unittest.TestCase):
     def test_output_is_constant(self):
         target = detect_target()
         const = Tensor(shape=[2, 2], dtype="float16", name="constant", is_output=True)
-        module = compile_model(const, target, "./tmp", "output_is_constant")
+        module = safe_compile_model(const, target, "./tmp", "output_is_constant")
 
         const_pt = torch.randn((2, 2)).cuda().half()
         out_ait = torch.empty((2, 2)).cuda().half()
@@ -425,7 +429,7 @@ class ModelAPITestCase(unittest.TestCase):
         output1._attrs["name"] = "output1"
 
         outputs = [output, view, output1]
-        module = compile_model(
+        module = safe_compile_model(
             outputs, target, "./tmp", "output_is_alias_of_another_output"
         )
 
@@ -468,7 +472,7 @@ class ModelAPITestCase(unittest.TestCase):
         view2._attrs["is_output"] = True
         view2._attrs["name"] = "view2"
 
-        module = compile_model(
+        module = safe_compile_model(
             [view1, view2], target, "./tmp", "output_is_alias_of_another_output"
         )
 
@@ -548,7 +552,7 @@ class ModelAPITestCase(unittest.TestCase):
         output = ops.elementwise(FuncEnum.MUL)(input_0, input_0)
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", "test_dynamic_dim_out_of_bounds"
         )
 
@@ -595,7 +599,7 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             output,
             target,
             "./tmp",
@@ -647,7 +651,7 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", "test_with_tensors_api_fails_on_strided_inputs"
         )
 
@@ -683,7 +687,7 @@ class ModelAPITestCase(unittest.TestCase):
         output_1._attrs["is_output"] = True
         output_2._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             [output_0, output_1, output_2], target, "./tmp", "test_dict_api"
         )
 
@@ -783,7 +787,7 @@ class ModelAPITestCase(unittest.TestCase):
                 is_output=True,
             )
             with self.assertRaises(ValueError):
-                compile_model(
+                safe_compile_model(
                     input_0,
                     target,
                     "./tmp",
@@ -876,7 +880,7 @@ class ModelAPITestCase(unittest.TestCase):
         out._attrs["name"] = "output"
         out._attrs["is_output"] = True
 
-        module = compile_model(out, target, "./tmp", name)
+        module = safe_compile_model(out, target, "./tmp", name)
 
         output_ait = torch.randn((size,)).half().cuda()
         module.run_with_tensors([], [output_ait])
@@ -916,7 +920,7 @@ class ModelAPITestCase(unittest.TestCase):
         out._attrs["name"] = "out1"
         out._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             [input_0, out],
             target,
             "./tmp",
@@ -961,7 +965,7 @@ class ModelAPITestCase(unittest.TestCase):
         out._attrs["name"] = "out1"
         out._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             [input_0, out],
             target,
             "./tmp",
@@ -1002,7 +1006,7 @@ class ModelAPITestCase(unittest.TestCase):
         out._attrs["name"] = "out1"
         out._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             [input_0, out],
             target,
             "./tmp",
@@ -1073,7 +1077,7 @@ class ModelAPITestCase(unittest.TestCase):
 
         for output_ordering in itertools.permutations((output0, output1, output2)):
             target = detect_target()
-            with compile_model(
+            with safe_compile_model(
                 output_ordering,
                 target,
                 "./tmp",
@@ -1098,7 +1102,7 @@ class ModelAPITestCase(unittest.TestCase):
         target = detect_target()
         self.assertRaises(
             (KeyError, ValueError),
-            compile_model,
+            safe_compile_model,
             [input0, output0],
             target,
             "./tmp",
@@ -1117,7 +1121,7 @@ class ModelAPITestCase(unittest.TestCase):
         target = detect_target()
         self.assertRaises(
             ValueError,
-            compile_model,
+            safe_compile_model,
             [output0],
             target,
             "./tmp",
@@ -1134,7 +1138,7 @@ class ModelAPITestCase(unittest.TestCase):
         target = detect_target()
         self.assertRaises(
             ValueError,
-            compile_model,
+            safe_compile_model,
             [output0, output0],
             target,
             "./tmp",
@@ -1178,7 +1182,7 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", "test_run_fails_with_unbound_constants"
         )
 
@@ -1214,7 +1218,7 @@ class ModelAPITestCase(unittest.TestCase):
             torch.zeros([1, 2]).float().cuda(),
         ):
             target = detect_target()
-            with compile_model(
+            with safe_compile_model(
                 _create_graph(), target, "./tmp", "test_set_constant_fails_wrong_dtype"
             ) as module:
                 self.assertRaises(
@@ -1240,7 +1244,7 @@ class ModelAPITestCase(unittest.TestCase):
             wrong_tensor = torch.randn(wrong_shape).half().cuda()
             target = detect_target()
             output = _create_graph()
-            with compile_model(
+            with safe_compile_model(
                 output, target, "./tmp", "test_set_constant_fails_wrong_shape"
             ) as module:
                 self.assertRaises(
@@ -1351,12 +1355,12 @@ class ModelAPITestCase(unittest.TestCase):
     def test_get_num_runtimes(self):
         self.assertEqual(AIT_DEFAULT_NUM_RUNTIMES, 1)
         x = Tensor([1], dtype="float16", is_input=True, is_output=True)
-        with compile_model(
+        with safe_compile_model(
             x, detect_target(), "./tmp", "test_get_num_runtimes_compile_module_default"
         ) as module:
             self.assertEqual(module.get_num_runtimes(), 1)
 
-        with compile_model(
+        with safe_compile_model(
             x,
             detect_target(),
             "./tmp",
@@ -1367,7 +1371,7 @@ class ModelAPITestCase(unittest.TestCase):
 
     def test_ait_data_numpy_conversions(self):
         x = Tensor([1], dtype="float16", is_input=True, is_output=True)
-        with compile_model(
+        with safe_compile_model(
             x, detect_target(), "./tmp", "test_ait_data_numpy_conversions"
         ) as module:
             x_shape = [1, 2, 3]
@@ -1387,7 +1391,7 @@ class ModelAPITestCase(unittest.TestCase):
 
     def test_numpy_to_ait_data_manual_free(self):
         x = Tensor([1], dtype="float16", is_input=True, is_output=True)
-        with compile_model(
+        with safe_compile_model(
             x, detect_target(), "./tmp", "test_numpy_to_ait_data_manual_free"
         ) as module:
             x_shape = [1, 2, 3]
@@ -1405,7 +1409,7 @@ class ModelAPITestCase(unittest.TestCase):
             AITemplateAllocatorKind.DEFAULT,
             AITemplateAllocatorKind.TRACKING,
         ):
-            with compile_model(
+            with safe_compile_model(
                 z,
                 detect_target(),
                 "./tmp",
@@ -1462,7 +1466,7 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", "test_get_constant_names", constants=constants
         )
 
@@ -1522,7 +1526,7 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             output,
             target,
             "./tmp",
@@ -1549,7 +1553,7 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(output, target, "./tmp", "test_get_constant_names")
+        module = safe_compile_model(output, target, "./tmp", "test_get_constant_names")
 
         input_0_pt = torch.randn((1, 2)).cuda().half()
         constant_1_pt = torch.randn((1, 2)).cuda().half()
@@ -1575,7 +1579,7 @@ class ModelAPITestCase(unittest.TestCase):
         output._attrs["name"] = "output"
         output._attrs["is_output"] = True
 
-        module = compile_model(output, target, "./tmp", "test_get_constant_names")
+        module = safe_compile_model(output, target, "./tmp", "test_get_constant_names")
 
         input_0_pt = torch.randn((10000, 2000)).cuda().half()
         constant_1_pt = torch.randn((10000, 2000)).cuda().half()

--- a/tests/unittest/benchmark/test_gemm_benchmark.py
+++ b/tests/unittest/benchmark/test_gemm_benchmark.py
@@ -22,7 +22,7 @@ import torch
 
 from aitemplate.compiler import ops
 from aitemplate.compiler.base import Tensor
-from aitemplate.compiler.compiler import compile_model
+from aitemplate.compiler.compiler import safe_compile_model
 
 from aitemplate.testing import detect_target
 from aitemplate.testing.benchmark_ait import make_input_output_pools, run_benchmark
@@ -90,7 +90,7 @@ def build_ait_module_gemm_rcr(*, ms, n, k, split_k, test_name):
     output = OP(a, b, bias)
     output._attrs["name"] = "output"
     output._attrs["is_output"] = True
-    return compile_model(output, target, "./tmp", test_name=test_name)
+    return safe_compile_model(output, target, "./tmp", test_name=test_name)
 
 
 def eval_pt_gemm_rcr(*, m, n, k):
@@ -162,7 +162,7 @@ def build_ait_module_bmm_rrr(*, bs, m, n, k, split_k, test_name):
     output = OP(batch_a, batch_b)
     output._attrs["name"] = "output"
     output._attrs["is_output"] = True
-    return compile_model(output, target, "./tmp", test_name=test_name)
+    return safe_compile_model(output, target, "./tmp", test_name=test_name)
 
 
 def eval_pt_bmm_rrr(*, b, m, n, k):

--- a/tests/unittest/benchmark/test_group_gemm_benchmark.py
+++ b/tests/unittest/benchmark/test_group_gemm_benchmark.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 
@@ -145,7 +145,7 @@ def _prepare_group_gemm_ait_module(
         Y._attrs["is_output"] = True
 
     target = detect_target()
-    module = compile_model(
+    module = safe_compile_model(
         output_tensors,
         target,
         "./tmp",
@@ -169,7 +169,7 @@ def _prepare_gemm_ait_module(m, nk_groups, test_idx=0, has_bias=True):
         Y._attrs["is_output"] = True
 
     target = detect_target()
-    module = compile_model(
+    module = safe_compile_model(
         output_tensors,
         target,
         "./tmp",
@@ -189,7 +189,7 @@ def _prepare_bmm_ait_module(b, m, n, k, has_bias=False):
     Y._attrs["is_output"] = True
 
     target = detect_target()
-    module = compile_model(
+    module = safe_compile_model(
         [Y],
         target,
         "./tmp",
@@ -239,7 +239,7 @@ class GroupGemmBenchTestCase(unittest.TestCase):
         Y1._attrs["is_output"] = True
         Y2._attrs["name"] = "y2"
         Y2._attrs["is_output"] = True
-        module = compile_model([Y1, Y2], target, "./tmp", "group_gemm_rcr_bias")
+        module = safe_compile_model([Y1, Y2], target, "./tmp", "group_gemm_rcr_bias")
         X1_pt = torch.randn(M, K1).cuda().half()
         X2_pt = torch.randn(M, K2).cuda().half()
         W1_pt = torch.randn(N1, K1).cuda().half()

--- a/tests/unittest/compiler/test_compilation_failure.py
+++ b/tests/unittest/compiler/test_compilation_failure.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 
 import jinja2
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import DynamicProfileStrategy
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
@@ -68,7 +68,7 @@ class CompilationFailureTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        compile_model(
+        safe_compile_model(
             Y,
             target,
             f"./tmp/{test_name}",

--- a/tests/unittest/compiler/test_fuse_bmm_permute.py
+++ b/tests/unittest/compiler/test_fuse_bmm_permute.py
@@ -18,7 +18,7 @@ from typing import Tuple
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 
 from aitemplate.compiler.base import IntVar
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
@@ -91,7 +91,7 @@ class FuseBmmPermuteCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         # Check that the new bmm is present and the original is not
         exist_new_bmm = False

--- a/tests/unittest/compiler/test_fuse_cat_view_cat.py
+++ b/tests/unittest/compiler/test_fuse_cat_view_cat.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 
 from aitemplate.compiler.base import Tensor
 from aitemplate.compiler.public import IntImm, IntVar
@@ -58,7 +58,7 @@ class FuseCatViewCatTestCase(unittest.TestCase):
         concatenate_6._attrs["name"] = "output_0"
         concatenate_6._attrs["is_output"] = True
         # Compile
-        mod = compile_model(
+        mod = safe_compile_model(
             concatenate_6,
             detect_target(),
             "./tmp",

--- a/tests/unittest/compiler/test_fuse_conv_elementwise.py
+++ b/tests/unittest/compiler/test_fuse_conv_elementwise.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -81,7 +81,7 @@ class FuseConvCase(unittest.TestCase):
         output._attrs["name"] = "output_0"
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", "test_do_not_fuse_with_add_not_1d"
         )
 
@@ -133,7 +133,7 @@ class FuseConvCase(unittest.TestCase):
         output._attrs["name"] = "output_0"
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", "test_do_not_fuse_with_add_not_1d"
         )
 
@@ -204,7 +204,7 @@ class FuseConvBiasCase(unittest.TestCase):
         conv2d_bias._attrs["name"] = "output_0"
 
         target = detect_target()
-        module = compile_model(conv2d_bias, target, "./tmp", "test_conv2d_bias")
+        module = safe_compile_model(conv2d_bias, target, "./tmp", "test_conv2d_bias")
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -253,7 +253,7 @@ class FuseConvBiasCase(unittest.TestCase):
         conv2d_bias_add_relu._attrs["name"] = "output_0"
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             conv2d_bias_add_relu, target, "./tmp", "test_conv2d_bias_add_relu"
         )
 
@@ -305,7 +305,7 @@ class FuseConvBiasCase(unittest.TestCase):
         conv2d_bias_relu._attrs["name"] = "output_0"
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             conv2d_bias_relu, target, "./tmp", "test_conv2d_bias_relu"
         )
 
@@ -350,7 +350,7 @@ class FuseConvBiasCase(unittest.TestCase):
         conv2d_bias_sigmoid._attrs["name"] = "output_0"
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             conv2d_bias_sigmoid, target, "./tmp", "test_conv2d_bias_sigmoid"
         )
 
@@ -404,7 +404,9 @@ class FuseConvBiasCase(unittest.TestCase):
         conv2d_bias_add._attrs["is_output"] = True
         conv2d_bias_add._attrs["name"] = "output_0"
 
-        module = compile_model(conv2d_bias_add, target, "./tmp", "test_conv2d_bias_add")
+        module = safe_compile_model(
+            conv2d_bias_add, target, "./tmp", "test_conv2d_bias_add"
+        )
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -459,7 +461,9 @@ class FuseConvBiasCase(unittest.TestCase):
         conv2d_bias_add._attrs["name"] = "output_0"
 
         target = detect_target()
-        module = compile_model(conv2d_bias_add, target, "./tmp", "test_conv2d_bias_add")
+        module = safe_compile_model(
+            conv2d_bias_add, target, "./tmp", "test_conv2d_bias_add"
+        )
 
         graph = module.debug_sorted_graph
 
@@ -491,7 +495,9 @@ class FuseConvBiasFewChannelCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", "test_conv_bias_relu_few_channels")
+        module = safe_compile_model(
+            Y, target, "./tmp", "test_conv_bias_relu_few_channels"
+        )
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -589,7 +595,7 @@ class FuseTransposedConvCase(unittest.TestCase):
         transposed_conv2d_bias._attrs["name"] = "output_0"
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             transposed_conv2d_bias,
             target,
             "./tmp",
@@ -651,7 +657,7 @@ class FuseTransposedConvCase(unittest.TestCase):
         transposed_conv2d_bias_relu._attrs["name"] = "output_0"
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             transposed_conv2d_bias_relu,
             target,
             "./tmp",

--- a/tests/unittest/compiler/test_fuse_expand.py
+++ b/tests/unittest/compiler/test_fuse_expand.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntVar, Tensor
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.testing import detect_target
@@ -46,7 +46,7 @@ class TestFuseExpand(unittest.TestCase):
         z._attrs["is_output"] = True
         z._attrs["name"] = "z"
 
-        with compile_model(z, detect_target(), "./tmp", name) as mod:
+        with safe_compile_model(z, detect_target(), "./tmp", name) as mod:
             self.assertFalse(graph_has_op(mod.debug_sorted_graph, "expand"))
             for batch_size in (1, 5, 10):
                 x_pt = torch.randn((batch_size, 2, 10)).half().cuda()

--- a/tests/unittest/compiler/test_fuse_mm_elementwise.py
+++ b/tests/unittest/compiler/test_fuse_mm_elementwise.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -96,7 +96,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -136,7 +136,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -180,7 +180,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -228,7 +228,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -292,7 +292,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
         output._attrs["is_output"] = True
 
         # Check value correctness
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", f"gemm_bias_fusion_add_fail_{dtype}"
         )
 
@@ -353,7 +353,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
         output._attrs["is_output"] = True
 
         # Check value correctness
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", f"gemm_bias_fusion_chained_{dtype}"
         )
 
@@ -414,7 +414,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
         output._attrs["is_output"] = True
 
         # Check value correctness
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", f"gemm_bias_fusion_fail_{dtype}"
         )
 
@@ -455,7 +455,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -501,7 +501,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -542,7 +542,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -588,7 +588,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -636,7 +636,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -859,7 +859,7 @@ class FuseGemmRcrBiasActivationCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -906,7 +906,7 @@ class FuseGemmRcrBiasActivationCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -958,7 +958,7 @@ class FuseGemmRcrBiasActivationCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -1235,7 +1235,7 @@ class FuseGemmRcrBiasSwishCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -1336,7 +1336,7 @@ class FuseBmmCcrAddCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -1397,7 +1397,7 @@ class FuseBmmCcrAddCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model([output, output_1], target, "./tmp", testname)
+        module = safe_compile_model([output, output_1], target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -1508,7 +1508,7 @@ class FuseBmmCcrAddCase(unittest.TestCase):
         output_1._attrs["is_output"] = True
 
         # Check value correctness
-        module = compile_model(
+        module = safe_compile_model(
             [output, output_1], target, "./tmp", f"bmm_ccr_double_shared_inputs_{dtype}"
         )
 
@@ -1580,7 +1580,7 @@ class FuseBmmCrrAddCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -1663,7 +1663,7 @@ class FuseBmmRrrAddCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -1724,7 +1724,7 @@ class FuseBmmRrrAddCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         check_tensor = None
         for tensor in module.debug_sorted_graph:

--- a/tests/unittest/compiler/test_fuse_mm_reshape_permute.py
+++ b/tests/unittest/compiler/test_fuse_mm_reshape_permute.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -68,7 +68,7 @@ class GEMMReshapePermuteTestCase(unittest.TestCase):
             Y = ops.permute()(Y1, [0, 2, 1, 3])
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"gemm_rcr_{test_name}")
+        module = safe_compile_model(Y, target, "./tmp", f"gemm_rcr_{test_name}")
 
         if should_fuse:
             sorted_ops = graph_utils.get_sorted_ops(module.debug_sorted_graph)

--- a/tests/unittest/compiler/test_fuse_ops.py
+++ b/tests/unittest/compiler/test_fuse_ops.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -61,7 +61,7 @@ class TestFuseGroupnormSwish(unittest.TestCase):
 
         target = detect_target()
         dll_name = "test_0.so"
-        module = compile_model(X6, target, "./tmp", op_name, dll_name=dll_name)
+        module = safe_compile_model(X6, target, "./tmp", op_name, dll_name=dll_name)
 
         x1_nhwc_pt = get_random_torch_tensor(x_shape, dtype)
         x1_nchw_pt = x1_nhwc_pt.permute(0, 3, 1, 2).contiguous()

--- a/tests/unittest/compiler/test_fuse_permute_bmm.py
+++ b/tests/unittest/compiler/test_fuse_permute_bmm.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -68,7 +68,7 @@ class FusePermuteBmmCase(unittest.TestCase):
         output._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         if dtype == "float":
             expected_bmm_type = list(bmm_type)
@@ -225,7 +225,7 @@ class FusePermuteBmmCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         # Due to massive rewriting of alignment/padding, we check whether we removed the old bmm with new one instead.
         exist_new_bmm = False
@@ -790,7 +790,7 @@ class FusePermuteBmmCase(unittest.TestCase):
         output._attrs["name"] = "output_0"
         output._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", f"permute_multiple_consumer_{dtype}"
         )
 
@@ -853,7 +853,7 @@ class FusePermuteBmmCase(unittest.TestCase):
         output._attrs["name"] = "output_0"
         output._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", f"permute_multiple_bmm_consumer_{dtype}"
         )
 

--- a/tests/unittest/compiler/test_fuse_permute_gemm.py
+++ b/tests/unittest/compiler/test_fuse_permute_gemm.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 
 from aitemplate.compiler.base import Tensor
 from aitemplate.testing import detect_target, test_utils
@@ -50,7 +50,7 @@ class FusePermuteGemmTestCase(unittest.TestCase):
         z._attrs["is_output"] = True
         z._attrs["name"] = "z"
 
-        module = compile_model(
+        module = safe_compile_model(
             z, target, "./tmp", f"test_no_fusion_odd_alignment_{dtype}"
         )
         if dtype == "float":
@@ -90,7 +90,7 @@ class FusePermuteGemmTestCase(unittest.TestCase):
         z._attrs["is_output"] = True
         z._attrs["name"] = "z"
 
-        module = compile_model(z, target, "./tmp", f"test_gemm_rrr_to_rcr_{dtype}")
+        module = safe_compile_model(z, target, "./tmp", f"test_gemm_rrr_to_rcr_{dtype}")
         self.assertFalse(test_utils.graph_has_op(module.debug_sorted_graph, "permute"))
         self.assertFalse(test_utils.graph_has_op(module.debug_sorted_graph, "gemm_rrr"))
         self.assertTrue(test_utils.graph_has_op(module.debug_sorted_graph, "gemm_rcr"))
@@ -124,7 +124,7 @@ class FusePermuteGemmTestCase(unittest.TestCase):
         z._attrs["is_output"] = True
         z._attrs["name"] = "z"
 
-        module = compile_model(
+        module = safe_compile_model(
             z,
             target,
             "./tmp",

--- a/tests/unittest/compiler/test_fused_elementwise_complex_dependency.py
+++ b/tests/unittest/compiler/test_fused_elementwise_complex_dependency.py
@@ -19,7 +19,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -80,7 +80,7 @@ class FusedElementwiseComplexDependencyTestCase(unittest.TestCase):
         R2._attrs["name"] = "R2"
         R2._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             R2,
             target,
             "./tmp",
@@ -164,7 +164,7 @@ class FusedElementwiseComplexDependencyTestCase(unittest.TestCase):
         R3._attrs["name"] = "R3"
         R3._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             [R3, R2],
             target,
             "./tmp",
@@ -252,7 +252,7 @@ class FusedElementwiseComplexDependencyTestCase(unittest.TestCase):
         R4._attrs["name"] = "R4"
         R4._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             [R1, R2, R4],
             target,
             "./tmp",
@@ -343,7 +343,7 @@ class FusedElementwiseComplexDependencyTestCase(unittest.TestCase):
         R3._attrs["name"] = "R3"
         R3._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             R3,
             target,
             "./tmp",
@@ -440,7 +440,7 @@ class FusedElementwiseComplexDependencyTestCase(unittest.TestCase):
         R4._attrs["name"] = "R4"
         R4._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             [R3, R4],
             target,
             "./tmp",
@@ -551,7 +551,7 @@ class FusedElementwiseComplexDependencyTestCase(unittest.TestCase):
         R7._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             R7,
             target,
             "./tmp",
@@ -644,7 +644,7 @@ class FusedElementwiseComplexDependencyTestCase(unittest.TestCase):
         R5._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             R5,
             target,
             "./tmp",

--- a/tests/unittest/compiler/test_fused_elementwise_out_of_order.py
+++ b/tests/unittest/compiler/test_fused_elementwise_out_of_order.py
@@ -19,7 +19,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -111,7 +111,7 @@ class FusedElementwiseOutOfOrderTestCase(unittest.TestCase):
         R5._attrs["name"] = "R5"
         R5._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             R5,
             target,
             "./tmp",

--- a/tests/unittest/compiler/test_group_fusions.py
+++ b/tests/unittest/compiler/test_group_fusions.py
@@ -18,7 +18,7 @@ import unittest
 import torch
 
 from aitemplate import compiler
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntImm, IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -159,7 +159,7 @@ class GroupOpTestCase(unittest.TestCase):
             Y._attrs["name"] = f"output_{i}"
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             Ys,
             target,
             "./tmp",
@@ -485,7 +485,7 @@ class GroupOpTestCase(unittest.TestCase):
         output_0._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             [output_0],
             target,
             "./tmp",

--- a/tests/unittest/compiler/test_memory_planning.py
+++ b/tests/unittest/compiler/test_memory_planning.py
@@ -18,7 +18,7 @@ import unittest
 import torch
 from aitemplate import compiler
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import Operator
 from aitemplate.frontend import IntImm, nn, Tensor
 from aitemplate.testing import detect_target
@@ -74,7 +74,7 @@ class MemoryPlanningTestCase(unittest.TestCase):
         OUT._attrs["name"] = "output_0"
         OUT._attrs["is_output"] = True
 
-        module = compile_model(OUT, target, "./tmp", "memory_planning")
+        module = safe_compile_model(OUT, target, "./tmp", "memory_planning")
         self.assertEqual(len(module.debug_sorted_graph), 6)
 
         assert T0._attrs["offset"] == T3._attrs["offset"]

--- a/tests/unittest/compiler/test_move_view_ops.py
+++ b/tests/unittest/compiler/test_move_view_ops.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
@@ -72,7 +72,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         self.test_count += 1
         sorted_graph = module.debug_sorted_graph
         self.assertEqual(len(sorted_graph), 5)
@@ -148,7 +148,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         self.test_count += 1
         sorted_graph = module.debug_sorted_graph
         if non_movable is True:
@@ -251,7 +251,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         self.test_count += 1
         sorted_graph = module.debug_sorted_graph
         self.assertEqual(len(sorted_graph), 5)
@@ -315,7 +315,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         self.test_count += 1
         sorted_graph = module.debug_sorted_graph
         self.assertEqual(len(sorted_graph), 3)
@@ -383,7 +383,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         self.test_count += 1
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
@@ -466,7 +466,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         self.test_count += 1
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
@@ -550,7 +550,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         self.test_count += 1
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
@@ -648,7 +648,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
         self.assertEqual(len(sorted_ops), 3)
@@ -781,7 +781,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
         self.assertEqual(len(sorted_ops), 5)
@@ -889,7 +889,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
         self.assertEqual(len(sorted_ops), 1)
@@ -976,7 +976,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
         self.assertEqual(len(sorted_ops), 1)
@@ -1061,7 +1061,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
         self.assertEqual(len(sorted_ops), 2)
@@ -1161,7 +1161,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         self.test_count += 1
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
@@ -1305,7 +1305,7 @@ class MoveViewOpsTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         self.test_count += 1
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)

--- a/tests/unittest/compiler/test_pad_bmm_rrr_bias_with_cat.py
+++ b/tests/unittest/compiler/test_pad_bmm_rrr_bias_with_cat.py
@@ -18,7 +18,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -58,7 +58,7 @@ class PadBmmBiasWithCatTestCase(unittest.TestCase):
         if int(target._arch) < 80:
             _LOGGER.warning("Skip this test on SM75")
             return
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", f"test_bmm_rrr_padding_{test_name}_{dtype}"
         )
 

--- a/tests/unittest/compiler/test_pad_gemm_rrr_with_cat.py
+++ b/tests/unittest/compiler/test_pad_gemm_rrr_with_cat.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -51,7 +51,7 @@ class PadGemmWithCatTestCase(unittest.TestCase):
             _LOGGER.warning("Skip this test on SM75")
             return
         dll_name = f"test_rrr_padding_{test_name}.so"
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", f"pad_gemm_with_cat_rrr_{dtype}", dll_name=dll_name
         )
 

--- a/tests/unittest/compiler/test_pad_gemm_with_cat.py
+++ b/tests/unittest/compiler/test_pad_gemm_with_cat.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -75,7 +75,7 @@ class PadGemmWithCatTestCase(unittest.TestCase):
             _LOGGER.warning("Skip this test on SM75")
             return
         dll_name = "test_rcr.so"
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", f"pad_gemm_with_cat_{dtype}", dll_name=dll_name
         )
 

--- a/tests/unittest/compiler/test_pad_gemm_with_elementwise.py
+++ b/tests/unittest/compiler/test_pad_gemm_with_elementwise.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -66,7 +66,7 @@ class PadGemmWithElementwise(unittest.TestCase):
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", f"pad_gemm_with_elementwise_{test_name}"
         )
 
@@ -139,7 +139,7 @@ class PadGemmWithElementwise(unittest.TestCase):
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", f"pad_bmm_with_elementwise_{test_name}"
         )
 
@@ -209,7 +209,7 @@ class PadGemmWithElementwise(unittest.TestCase):
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", f"pad_perm102_with_elementwise_{test_name}"
         )
 
@@ -267,7 +267,7 @@ class PadGemmWithElementwise(unittest.TestCase):
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", f"pad_gemm_with_elementwise_2_{test_name}"
         )
 

--- a/tests/unittest/compiler/test_parallel_gemm_fusions.py
+++ b/tests/unittest/compiler/test_parallel_gemm_fusions.py
@@ -19,7 +19,7 @@ from typing import Sequence
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.compiler.transform.fuse_parallel_gemms import fuse_parallel_gemms
 from aitemplate.compiler.transform.toposort import toposort
@@ -108,7 +108,7 @@ def _prepare_ait_module(m, nk_groups, constants, dtype, test_idx=0, has_bias=Tru
     Y._attrs["is_output"] = True
 
     target = detect_target()
-    module = compile_model(
+    module = safe_compile_model(
         Y,
         target,
         "./tmp",
@@ -239,7 +239,7 @@ class ParallelGemmCatFusionTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             [cat_output],
             target,
             "./tmp",
@@ -498,7 +498,7 @@ class ParallelGemmCatFusionTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             [cat_output],
             target,
             "./tmp",

--- a/tests/unittest/compiler/test_permute_bmm_special_op.py
+++ b/tests/unittest/compiler/test_permute_bmm_special_op.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -46,7 +46,7 @@ class FusePermuteBmmRRRN1Case(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         bmm_tensor = None
         for tensor in module.debug_sorted_graph:

--- a/tests/unittest/compiler/test_refine_graph.py
+++ b/tests/unittest/compiler/test_refine_graph.py
@@ -18,7 +18,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -77,7 +77,7 @@ class RefineGraphTestCase(unittest.TestCase):
         Y0._attrs["is_output"] = True
         Y1._attrs["name"] = "Y1"
         Y1._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             [Y0, Y1],
             target,
             "./tmp",
@@ -113,7 +113,7 @@ class RefineGraphTestCase(unittest.TestCase):
         Y1._attrs["name"] = "Y1"
         Y1._attrs["is_output"] = True
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             [Y0, Y1],
             target,
             "./tmp",
@@ -149,7 +149,7 @@ class RefineGraphTestCase(unittest.TestCase):
         Y1._attrs["name"] = "Y1"
         Y1._attrs["is_output"] = True
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             [Y0, Y1],
             target,
             "./tmp",
@@ -230,7 +230,7 @@ class RefineGraphTestCase(unittest.TestCase):
         Y2._attrs["name"] = "Y1"
         Y2._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             [Y1, Y2],
             target,
             "./tmp",
@@ -286,7 +286,7 @@ class RefineGraphTestCase(unittest.TestCase):
         Y._attrs["name"] = "output"
         Y._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",
@@ -337,7 +337,7 @@ class RefineGraphTestCase(unittest.TestCase):
 
         graph_outputs = [Y1, Y2, Y3, Y4]
 
-        module = compile_model(
+        module = safe_compile_model(
             graph_outputs, target, "./tmp", f"test_refine_graph_group_gemms_{dtype}"
         )
 

--- a/tests/unittest/compiler/test_remove_unused_ops.py
+++ b/tests/unittest/compiler/test_remove_unused_ops.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 
 from aitemplate.frontend import Tensor
@@ -58,7 +58,7 @@ class RemoveUnusedOpsTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         for b in batch_size:
             X_shape_pt = (b, *X_shape)

--- a/tests/unittest/compiler/test_slice_bmm_fusion.py
+++ b/tests/unittest/compiler/test_slice_bmm_fusion.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -139,7 +139,7 @@ class SliceBMMFusionTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = "test_{}.so".format(self.test_count)
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -427,7 +427,7 @@ class SliceBMMFusionTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = "test_{}.so".format(self.test_count)
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph

--- a/tests/unittest/compiler/test_slice_elemwise_fusion.py
+++ b/tests/unittest/compiler/test_slice_elemwise_fusion.py
@@ -16,7 +16,7 @@ import itertools
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
@@ -79,7 +79,7 @@ class SliceElemwiseFusionTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -266,7 +266,7 @@ class SliceElemwiseFusionTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -454,7 +454,7 @@ class SliceElemwiseFusionTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph

--- a/tests/unittest/compiler/test_slice_gemm_fusion.py
+++ b/tests/unittest/compiler/test_slice_gemm_fusion.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
@@ -81,7 +81,7 @@ class SliceGemmFusionTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = "test_{}.so".format(self.test_count)
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -292,7 +292,7 @@ class SliceGemmFusionTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = "test_{}.so".format(self.test_count)
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -381,7 +381,7 @@ class SliceGemmFusionTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = "test_{}.so".format(self.test_count)
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -483,7 +483,7 @@ class SliceGemmFusionTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = "test_{}.so".format(self.test_count)
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -611,7 +611,7 @@ class SliceGemmFusionTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = "test_{}.so".format(self.test_count)
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -725,7 +725,7 @@ class SliceGemmFusionTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = "test_{}.so".format(self.test_count)
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph

--- a/tests/unittest/compiler/test_slice_permute021_fusion.py
+++ b/tests/unittest/compiler/test_slice_permute021_fusion.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 
 from aitemplate.testing import detect_target
@@ -60,7 +60,7 @@ class SlicePermute021FusionTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
         Y._attrs["name"] = "output"
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             Y,
             target,
             "./tmp",

--- a/tests/unittest/compiler/test_slice_reshape_scatter.py
+++ b/tests/unittest/compiler/test_slice_reshape_scatter.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -100,7 +100,7 @@ class SliceScatterReshapeCatTestCase(unittest.TestCase):
         np.testing.assert_equal(y_shape, Y_pt.size())
 
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", "slice_scatter_reshape_cat", dll_name=dll_name
         )
         Y_src_ops = list(Y._attrs["src_ops"])
@@ -215,7 +215,7 @@ class SliceScatterReshapeCatTestCase(unittest.TestCase):
         target = detect_target()
         dll_name = "test.so"
         test_name = "slice_scatter_reshape_cat_float16_2"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         Y_src_ops = list(Y._attrs["src_ops"])
         self.assertEqual(len(Y_src_ops), 1)
         self.assertEqual(Y_src_ops[0]._attrs["op"], "concatenate")

--- a/tests/unittest/compiler/test_slice_scatter_pattern.py
+++ b/tests/unittest/compiler/test_slice_scatter_pattern.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops, transform
+from aitemplate.compiler import ops, safe_compile_model, transform
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -154,7 +154,7 @@ class SliceScatterPatternTestCase(unittest.TestCase):
         np.testing.assert_equal(y_shape, Y_pt.size())
 
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", "slice_scatter_e2e", dll_name=dll_name
         )
 
@@ -196,7 +196,7 @@ class SliceScatterPatternTestCase(unittest.TestCase):
         y_shape = [var._attrs["values"][0] for var in Y._attrs["shape"]]
 
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", "slice_scatter_e2d_batch", dll_name=dll_name
         )
 
@@ -381,7 +381,9 @@ class SliceScatterPatternTestCase(unittest.TestCase):
 
         test_name = "slice_scatter_multi_dsts"
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model((Y0, Y1), target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(
+            (Y0, Y1), target, "./tmp", test_name, dll_name=dll_name
+        )
         debug_sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(debug_sorted_graph)
         self.assertEqual(len(sorted_ops), 2)
@@ -498,7 +500,7 @@ class SliceScatterPatternTestCase(unittest.TestCase):
 
         test_name = "slice_scatter_multi_dsts_2"
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         debug_sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(debug_sorted_graph)
         self.assertEqual(len(sorted_ops), 1)

--- a/tests/unittest/compiler/test_slice_view_strided.py
+++ b/tests/unittest/compiler/test_slice_view_strided.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntVar
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.testing import detect_target, test_utils
@@ -68,7 +68,7 @@ class SliceViewStridedOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", f"slice_reshape_gemm_fusible_{dtype}"
         )
 
@@ -125,7 +125,7 @@ class SliceViewStridedOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", f"slice_reshape_gemm_non_fusible_{dtype}"
         )
 
@@ -193,7 +193,7 @@ class SliceViewStridedOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model([Y], target, "./tmp", test_name)
+        module = safe_compile_model([Y], target, "./tmp", test_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -272,7 +272,7 @@ class SliceViewStridedOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model([Y], target, "./tmp", test_name)
+        module = safe_compile_model([Y], target, "./tmp", test_name)
 
         # Prepare PyTorch tensors.
         for batch_size in batch_dim._attrs["values"]:
@@ -346,7 +346,7 @@ class SliceViewStridedOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model([Y], target, "./tmp", test_name)
+        module = safe_compile_model([Y], target, "./tmp", test_name)
 
         # Prepare PyTorch tensors.
         for batch_size in batch_dim._attrs["values"]:
@@ -424,7 +424,7 @@ class SliceViewStridedOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model([Y], target, "./tmp", test_name)
+        module = safe_compile_model([Y], target, "./tmp", test_name)
 
         # Prepare PyTorch tensors.
         for batch_size in batch_dim._attrs["values"]:

--- a/tests/unittest/compiler/test_split_bmm_fusion.py
+++ b/tests/unittest/compiler/test_split_bmm_fusion.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -89,7 +89,7 @@ class SplitBmmFusionTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", testname)
+        module = safe_compile_model(Y, target, "./tmp", testname)
         graph = module.debug_sorted_graph
         if not with_padding:
             assert len(graph) == 3, (
@@ -199,7 +199,7 @@ class SplitBmmFusionTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", testname)
+        module = safe_compile_model(Y, target, "./tmp", testname)
         graph = module.debug_sorted_graph
         assert len(graph) == 3, (
             f"The final graph should have only 3 tensors. "
@@ -285,7 +285,7 @@ class SplitBmmFusionTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", testname)
+        module = safe_compile_model(Y, target, "./tmp", testname)
         graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(graph)
         if should_fail:

--- a/tests/unittest/compiler/test_split_bmm_softmax_bmm.py
+++ b/tests/unittest/compiler/test_split_bmm_softmax_bmm.py
@@ -20,7 +20,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -53,7 +53,9 @@ class SplitBMMTestCase(unittest.TestCase):
 
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"split_bmm_softmax_bmm_{test_name}")
+        module = safe_compile_model(
+            Y, target, "./tmp", f"split_bmm_softmax_bmm_{test_name}"
+        )
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
         # 1 input tensors + 1 output tensor

--- a/tests/unittest/compiler/test_split_full_idx.py
+++ b/tests/unittest/compiler/test_split_full_idx.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -70,7 +70,7 @@ class SplitGetItemTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
         src_ops = set()
         for tensor in module.debug_sorted_graph:
@@ -150,7 +150,7 @@ class SplitGetItemTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
         src_ops = set()
         for tensor in module.debug_sorted_graph:

--- a/tests/unittest/compiler/test_split_large_concat.py
+++ b/tests/unittest/compiler/test_split_large_concat.py
@@ -18,7 +18,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -66,7 +66,7 @@ class SplitLargeConcatTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -133,7 +133,7 @@ class SplitLargeConcatTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         inputs_pt = [
             get_random_torch_tensor(input_shape, dtype) for _ in range(num_inputs)
@@ -187,7 +187,7 @@ class SplitLargeConcatTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         add_inputs_pt = [get_random_torch_tensor(input_shape, dtype) for _ in range(2)]
         y1_pt = add_inputs_pt[0] + add_inputs_pt[1]
@@ -251,7 +251,7 @@ class SplitLargeConcatTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         add_inputs_pt = [
             get_random_torch_tensor(input_shape, dtype) for _ in range(num_inputs * 2)
@@ -331,7 +331,7 @@ class SplitLargeConcatTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         add_inputs_pt = [
             get_random_torch_tensor(input_shape, dtype) for _ in range(num_inputs * 2)
@@ -420,7 +420,7 @@ class SplitLargeConcatTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         slice_inputs_pt = [
             get_random_torch_tensor(slice_input_shape, dtype)
@@ -497,7 +497,7 @@ class SplitLargeConcatTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         self.test_count += 1
 
         x_pt = get_random_torch_tensor(reshape_shape, dtype)

--- a/tests/unittest/compiler/test_split_large_slice_scatter.py
+++ b/tests/unittest/compiler/test_split_large_slice_scatter.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -66,7 +66,7 @@ class SliceScatterLargeInputsTestCase(unittest.TestCase):
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
         test_name = "slice_scatter_large_inputs"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         self.test_count += 1
         Y_src_ops = list(Y._attrs["src_ops"])
         self.assertEqual(len(Y_src_ops), 5)

--- a/tests/unittest/compiler/test_split_large_split.py
+++ b/tests/unittest/compiler/test_split_large_split.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -71,7 +71,7 @@ class SplitLargeSplitTestCase(unittest.TestCase):
             logging.info(f"AITemplate output_{idx} shape: {y_shape}")
             y_shapes.append(y_shape)
 
-        module = compile_model(Ys, target, "./tmp", testname)
+        module = safe_compile_model(Ys, target, "./tmp", testname)
 
         outputs = {
             f"output_{idx}": get_torch_empty_tensor(y_shape, input_type)
@@ -138,7 +138,7 @@ class SplitLargeSplitTestCase(unittest.TestCase):
             logging.info(f"AITemplate output_{idx} shape: {y_shape}")
             y_shapes.append(y_shape)
 
-        module = compile_model(Ys, target, "./tmp", "split_with_strided_ops")
+        module = safe_compile_model(Ys, target, "./tmp", "split_with_strided_ops")
 
         outputs = {
             f"output_{idx}": get_torch_empty_tensor(y_shape)

--- a/tests/unittest/compiler/test_split_view_strided.py
+++ b/tests/unittest/compiler/test_split_view_strided.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import Tensor
 from aitemplate.testing import detect_target, test_utils
 from aitemplate.testing.test_utils import (
@@ -73,7 +73,7 @@ class SplitViewStridedOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(Cs, target, "./tmp", testname)
+        module = safe_compile_model(Cs, target, "./tmp", testname)
         graph = module.debug_sorted_graph
         self.assertEqual(len(graph), expected_num_tensors)
         self.assertEqual(len(graph_utils.get_sorted_ops(graph)), expected_num_ops)

--- a/tests/unittest/compiler/test_strided_group_gemm.py
+++ b/tests/unittest/compiler/test_strided_group_gemm.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.stable_set import StableSet
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
@@ -66,7 +66,7 @@ class StridedGroupGemmTestCase(unittest.TestCase):
         Y = concat_op([Y1, Y2, X3], dim=dim)
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
-        module = compile_model([Y], target, "./tmp", test_name)
+        module = safe_compile_model([Y], target, "./tmp", test_name)
         Y_src_ops = Y._attrs["src_ops"]
         np.testing.assert_equal(len(Y_src_ops), 2)
         np.testing.assert_equal(Y_src_ops, StableSet({group_gemm_op, concat_op}))
@@ -152,7 +152,7 @@ class StridedGroupGemmTestCase(unittest.TestCase):
             Y = concat_op([Y1, Y2, X3], dim=dim)
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             [Y],
             target,
             "./tmp",

--- a/tests/unittest/compiler/test_strided_group_layernorm.py
+++ b/tests/unittest/compiler/test_strided_group_layernorm.py
@@ -17,7 +17,7 @@ import unittest
 from typing import List
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.utils import shape_utils, torch_utils
@@ -85,7 +85,7 @@ def build_ait_module(
         output._attrs["is_output"] = True
         output._attrs["name"] = f"output_{i}"
     dll_name = f"test_{test_id}.so"
-    return compile_model(
+    return safe_compile_model(
         outputs,
         target,
         workdir,

--- a/tests/unittest/compiler/test_strided_layernorm.py
+++ b/tests/unittest/compiler/test_strided_layernorm.py
@@ -17,7 +17,7 @@ import unittest
 from typing import List
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -84,7 +84,7 @@ def build_ait_module(
     output._attrs["is_output"] = True
     output._attrs["name"] = "output"
     dll_name = f"test_{test_id}.so"
-    return compile_model(
+    return safe_compile_model(
         output,
         target,
         workdir,

--- a/tests/unittest/compiler/test_strided_layernorm_reshape.py
+++ b/tests/unittest/compiler/test_strided_layernorm_reshape.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.utils import shape_utils, torch_utils
@@ -71,7 +71,7 @@ def build_ait_module(
     return (
         inputs,
         output,
-        compile_model(output, target, workdir, test_name, dll_name=dll_name),
+        safe_compile_model(output, target, workdir, test_name, dll_name=dll_name),
     )
 
 

--- a/tests/unittest/compiler/test_strided_op_cat_pattern.py
+++ b/tests/unittest/compiler/test_strided_op_cat_pattern.py
@@ -22,7 +22,7 @@ from typing import List, Optional
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntVar
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntImm, Tensor
@@ -89,7 +89,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             [X8],
             target,
             "./tmp",
@@ -295,7 +295,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             [X6],
             target,
             "./tmp",
@@ -347,7 +347,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             [X5, X6],
             target,
             "./tmp",
@@ -470,7 +470,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             [X9],
             target,
             "./tmp",
@@ -610,7 +610,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             [Y],
             target,
             "./tmp",
@@ -837,7 +837,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             [X7],
             target,
             "./tmp",
@@ -1075,7 +1075,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
             Y._attrs["name"] = f"output_{i}"
 
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             Ys,
             target,
             "./tmp",
@@ -1368,7 +1368,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        with compile_model(Y, target, "./tmp", test_name) as module:
+        with safe_compile_model(Y, target, "./tmp", test_name) as module:
             input_name_to_index = module.get_input_name_to_index_map()
             inputs = [0 for i in range(2 * n)]
             for i in range(n):
@@ -1558,7 +1558,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        with compile_model(Y, target, "./tmp", test_name) as module:
+        with safe_compile_model(Y, target, "./tmp", test_name) as module:
             input_name_to_index = module.get_input_name_to_index_map()
             inputs = [0 for i in range(3 * n)]
             for i in range(n):
@@ -1716,7 +1716,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", testname)
+        module = safe_compile_model(Y, target, "./tmp", testname)
 
         input_name_to_index = module.get_input_name_to_index_map()
         inputs = [0] * num_inputs
@@ -1839,7 +1839,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
         logging.info("AITemplate output_shape: {}".format(y_shape))
         logging.info("AITemplate output_type: {}".format(y_dtype))
 
-        with compile_model(Y, target, "./tmp", test_name) as module:
+        with safe_compile_model(Y, target, "./tmp", test_name) as module:
             Y_src_ops = list(Y._attrs["src_ops"])
             np.testing.assert_equal(len(Y_src_ops), 2)
             if Y_src_ops[0]._attrs["op"] == "concatenate":
@@ -1948,7 +1948,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
         logging.info("AITemplate output_shape: {}".format(y_shape))
         logging.info("AITemplate output_type: {}".format(y_dtype))
 
-        with compile_model(Y, target, "./tmp", test_name) as module:
+        with safe_compile_model(Y, target, "./tmp", test_name) as module:
             Y_src_ops = list(Y._attrs["src_ops"])
             np.testing.assert_equal(len(Y_src_ops), 1)
             fused_add_op = Y_src_ops[0]
@@ -2066,7 +2066,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
         logging.info("AITemplate output_shape: {}".format(y_shape))
         logging.info("AITemplate output_type: {}".format(y_dtype))
 
-        with compile_model(Y, target, "./tmp", test_name) as module:
+        with safe_compile_model(Y, target, "./tmp", test_name) as module:
             Y_src_ops = list(Y._attrs["src_ops"])
             np.testing.assert_equal(len(Y_src_ops), 2)
             if Y_src_ops[0]._attrs["op"] == "concatenate":
@@ -2170,7 +2170,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
 
         logging.info("AITemplate output_type: {}".format(y_dtype))
 
-        with compile_model(Y, target, "./tmp", test_name) as module:
+        with safe_compile_model(Y, target, "./tmp", test_name) as module:
             Y_src_ops = list(Y._attrs["src_ops"])
             np.testing.assert_equal(len(Y_src_ops), 2)
             if Y_src_ops[0]._attrs["op"] == "concatenate":
@@ -2224,7 +2224,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
         Y._attrs["name"] = "output"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
         self.assertEqual(len(sorted_ops), 2)
@@ -2270,7 +2270,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
         Y._attrs["name"] = "output"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         x0_pt = get_random_torch_tensor(x0_shape, dtype)
         x1_pt = get_random_torch_tensor(x1_shape, dtype)
@@ -2316,7 +2316,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
         Y._attrs["name"] = "output"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(sorted_graph)
         self.assertEqual(len(sorted_ops), 2)

--- a/tests/unittest/compiler/test_strided_reshape_cat.py
+++ b/tests/unittest/compiler/test_strided_reshape_cat.py
@@ -17,7 +17,7 @@ import unittest
 
 import numpy as np
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.stable_set import StableSet
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
@@ -102,7 +102,7 @@ class StridedReshapeCatTestCase(unittest.TestCase):
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", "strided_reshape_cat", dll_name=dll_name
         )
 
@@ -210,7 +210,7 @@ class StridedReshapeCatTestCase(unittest.TestCase):
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", "strided_reshape_cat_bias", dll_name=dll_name
         )
         Y_src_ops = Y._attrs["src_ops"]

--- a/tests/unittest/compiler/test_strided_scatter.py
+++ b/tests/unittest/compiler/test_strided_scatter.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntImm, IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -122,7 +122,7 @@ class StridedScatterTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -229,7 +229,7 @@ class StridedScatterTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -412,7 +412,7 @@ class StridedScatterTestCase(unittest.TestCase):
 
         test_name = "strided_scatter_multi_dsts_2"
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         sorted_graph = module.debug_sorted_graph
         # len(inputs) + 1 output
         self.assertEqual(len(sorted_graph), len(input_shapes) + 1)
@@ -505,7 +505,7 @@ class StridedScatterTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -629,7 +629,7 @@ class StridedScatterTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -731,7 +731,7 @@ class StridedScatterTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -845,7 +845,7 @@ class StridedScatterTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph

--- a/tests/unittest/compiler/test_strided_split_group_gemm.py
+++ b/tests/unittest/compiler/test_strided_split_group_gemm.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -66,7 +66,7 @@ class StridedSplitGroupGemmTestCase(unittest.TestCase):
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
         dll_name = "test_rcr_cat.so"
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", "strided_split_group_gemm_rcr_cat", dll_name=dll_name
         )
         Y_src_ops = Y._attrs["src_ops"]
@@ -137,7 +137,7 @@ class StridedSplitGroupGemmTestCase(unittest.TestCase):
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
         dll_name = "test_rcr_bias_cat.so"
-        module = compile_model(
+        module = safe_compile_model(
             [Y],
             target,
             "./tmp",
@@ -214,7 +214,7 @@ class StridedSplitGroupGemmTestCase(unittest.TestCase):
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
         dll_name = "test_rcr_cat_reorder.so"
-        module = compile_model(
+        module = safe_compile_model(
             [Y], target, "./tmp", "strided_split_group_gemm_rcr_cat", dll_name=dll_name
         )
         Y_src_ops = Y._attrs["src_ops"]
@@ -285,7 +285,7 @@ class StridedSplitGroupGemmTestCase(unittest.TestCase):
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
         dll_name = "test_rcr_bias_cat_reorder.so"
-        module = compile_model(
+        module = safe_compile_model(
             [Y],
             target,
             "./tmp",

--- a/tests/unittest/compiler/test_strided_view_cat.py
+++ b/tests/unittest/compiler/test_strided_view_cat.py
@@ -17,7 +17,7 @@ from typing import List
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm, IntVar, Tensor
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.testing import detect_target, test_utils
@@ -197,7 +197,7 @@ class StridedViewCatOpTestCase(unittest.TestCase):
         Z._attrs["is_output"] = True
 
         # Gen module.
-        module = compile_model([Z], target, "./tmp", test_name)
+        module = safe_compile_model([Z], target, "./tmp", test_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -306,7 +306,7 @@ class StridedViewCatOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             Z, target, "./tmp", f"strided_layernorm_view_cat_fusion_{dtype}"
         )
 

--- a/tests/unittest/compiler/test_strided_view_op.py
+++ b/tests/unittest/compiler/test_strided_view_op.py
@@ -19,7 +19,7 @@ from typing import Callable, List, Tuple
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntVar
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntImm, Tensor
@@ -194,7 +194,7 @@ class StridedViewOpTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self._test_id}.so"
-        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -250,7 +250,7 @@ class StridedViewOpTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self._test_id}.so"
-        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -308,7 +308,7 @@ class StridedViewOpTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self._test_id}.so"
-        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -351,7 +351,7 @@ class StridedViewOpTestCase(unittest.TestCase):
         # Gen module.
         target = detect_target()
         dll_name = f"test_{self._test_id}.so"
-        module = compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model([Y], target, "./tmp", test_name, dll_name=dll_name)
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -389,7 +389,9 @@ class StridedViewOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model([Y1, Y2], target, "./tmp", f"two_view_outputs_{dtype}")
+        module = safe_compile_model(
+            [Y1, Y2], target, "./tmp", f"two_view_outputs_{dtype}"
+        )
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -429,7 +431,7 @@ class StridedViewOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             [Y1, Y2], target, "./tmp", f"two_parallel_view_outputs_{dtype}"
         )
 

--- a/tests/unittest/compiler/test_tensor.py
+++ b/tests/unittest/compiler/test_tensor.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model
+from aitemplate.compiler import safe_compile_model
 
 from aitemplate.compiler.base import Tensor
 from aitemplate.testing import detect_target
@@ -48,7 +48,7 @@ class TensorTestCase(unittest.TestCase):
         expected_bytes = x_pt.numel() * x_pt.element_size()
         self.assertEqual(x.size_bytes(), expected_bytes)
 
-        mod = compile_model(x, self.target, "./tmp", f"test_tensor_size_{dtype}")
+        mod = safe_compile_model(x, self.target, "./tmp", f"test_tensor_size_{dtype}")
 
         out = torch.empty_like(x_pt)
         mod.run_with_tensors([x_pt], [out])

--- a/tests/unittest/compiler/test_transform_memory_ops.py
+++ b/tests/unittest/compiler/test_transform_memory_ops.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops, transform
+from aitemplate.compiler import ops, safe_compile_model, transform
 from aitemplate.frontend import IntImm, IntVar, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -69,7 +69,7 @@ class MemoryOpTransformationTestCase(unittest.TestCase):
         if dtype == "float" and target.name == "rocm":
             self.skipTest("float tensors not supported by ROCM")
         OUTPUT = self._prepare_cat_elimination_graph(dtype)
-        module = compile_model(OUTPUT, target, "./tmp", f"cat_elimination_{dtype}")
+        module = safe_compile_model(OUTPUT, target, "./tmp", f"cat_elimination_{dtype}")
 
         x0_pt = get_random_torch_tensor([self.BATCH_SIZE, self.M, self.N], dtype)
         out_pt = torch.cat([x0_pt, x0_pt], dim=1)
@@ -144,7 +144,7 @@ class MemoryOpTransformationTestCase(unittest.TestCase):
         if dtype == "float" and target.name == "rocm":
             self.skipTest("float tensors not supported by ROCM")
         OUTPUT = self._prepare_split_cat_elimination_graph(dtype)
-        module = compile_model(
+        module = safe_compile_model(
             OUTPUT, target, "./tmp", f"split_cat_elimination_{dtype}"
         )
 
@@ -240,7 +240,9 @@ class MemoryOpTransformationTestCase(unittest.TestCase):
         if dtype == "float" and target.name == "rocm":
             self.skipTest("float tensors not supported by ROCM")
         OUTPUT = self._prepare_cat_cat_elimination_graph(dtype)
-        module = compile_model(OUTPUT, target, "./tmp", f"cat_cat_elimination_{dtype}")
+        module = safe_compile_model(
+            OUTPUT, target, "./tmp", f"cat_cat_elimination_{dtype}"
+        )
 
         x0_pt = get_random_torch_tensor(
             [self.BATCH_SIZE, int(self.M / 2), self.N], dtype
@@ -298,7 +300,9 @@ class MemoryOpTransformationTestCase(unittest.TestCase):
         if dtype == "float" and target.name == "rocm":
             self.skipTest("float tensors not supported by ROCM")
         OUTPUT = self._prepare_skip_cat_elimination_graph(dtype)
-        module = compile_model(OUTPUT, target, "./tmp", f"skip_cat_elimination_{dtype}")
+        module = safe_compile_model(
+            OUTPUT, target, "./tmp", f"skip_cat_elimination_{dtype}"
+        )
 
         x0_pt = get_random_torch_tensor([self.BATCH_SIZE, self.M, self.N], dtype)
         out0_pt = torch.cat([x0_pt], dim=1)
@@ -349,7 +353,7 @@ class MemoryOpTransformationTestCase(unittest.TestCase):
         if dtype == "float" and target.name == "rocm":
             self.skipTest("float tensors not supported by ROCM")
         OUTPUT = self._prepare_skip_split_cat_elimination_graph(dtype)
-        module = compile_model(
+        module = safe_compile_model(
             OUTPUT, target, "./tmp", f"skip_split_cat_elimination_{dtype}"
         )
 
@@ -445,7 +449,7 @@ class MemoryOpTransformationTestCase(unittest.TestCase):
         if dtype == "float" and target.name == "rocm":
             self.skipTest("float tensors not supported by ROCM")
         OUTPUT = self._prepare_skip_cat_cat_elimination_graph(dtype)
-        module = compile_model(
+        module = safe_compile_model(
             OUTPUT, target, "./tmp", f"skip_cat_cat_elimination_{dtype}"
         )
 

--- a/tests/unittest/compiler/test_transform_odd_alignment.py
+++ b/tests/unittest/compiler/test_transform_odd_alignment.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import _TorchConstantTensorData, Tensor
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.testing import detect_target
@@ -103,7 +103,7 @@ class TransformOddAlignmentCase(unittest.TestCase):
 
             # Check value correctness
             target = detect_target()
-            module = compile_model(
+            module = safe_compile_model(
                 output,
                 target,
                 "./tmp",
@@ -266,7 +266,7 @@ class TransformOddAlignmentCase(unittest.TestCase):
 
             # Check value correctness
             target = detect_target()
-            module = compile_model(
+            module = safe_compile_model(
                 output,
                 target,
                 "./tmp",
@@ -408,7 +408,7 @@ class TransformOddAlignmentCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", "alignment_permute_bmm_epilogue"
         )
 
@@ -461,7 +461,7 @@ class TransformOddAlignmentCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", "alignment_pad_bmm")
+        module = safe_compile_model(output, target, "./tmp", "alignment_pad_bmm")
 
         exist_new_bmm = False
         for tensor in module.debug_sorted_graph:

--- a/tests/unittest/compiler/test_transform_permute_to_reshape.py
+++ b/tests/unittest/compiler/test_transform_permute_to_reshape.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 
 from aitemplate.compiler.base import IntVar, Tensor
 from aitemplate.testing import detect_target, test_utils
@@ -88,7 +88,7 @@ class TransformPermuteToReshapeTestCase(unittest.TestCase):
         model_name = _generate_model_name(
             shape, permutation, is_reshape, dtype, is_complex=False
         )
-        module = compile_model(Z, target, "./tmp", model_name)
+        module = safe_compile_model(Z, target, "./tmp", model_name)
         has_permute_op = any(
             test_utils.graph_has_op(module.debug_sorted_graph, op_name)
             for op_name in _PERMUTE_OPS

--- a/tests/unittest/compiler/test_transform_special_op.py
+++ b/tests/unittest/compiler/test_transform_special_op.py
@@ -18,7 +18,7 @@ from typing import List
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -62,7 +62,7 @@ class GemmRrrSmallNkTestCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model([output, gemm_tensor], target, "./tmp", testname)
+        module = safe_compile_model([output, gemm_tensor], target, "./tmp", testname)
 
         output_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -137,7 +137,7 @@ class GemmRrrSmallNkTestCase(unittest.TestCase):
         M, K, N = 8, 8, 16
         _, _, output = self._create_gemm_rrr_graph(M, K, N, dtype)
 
-        module = compile_model(
+        module = safe_compile_model(
             output, target, "./tmp", f"test_small_nk_fail_{M}_{K}_{N}_{dtype}"
         )
 
@@ -196,7 +196,7 @@ class BmmRcrN1TestCase(unittest.TestCase):
 
         # Check value correctness
         target = detect_target()
-        module = compile_model(output, target, "./tmp", testname)
+        module = safe_compile_model(output, target, "./tmp", testname)
 
         output_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -252,7 +252,7 @@ class BmmRcrN1TestCase(unittest.TestCase):
         _, _, output = self._create_bmm_rcr_graph(B, M, K, N, dtype)
         output._attrs["is_output"] = True
 
-        module = compile_model(output, target, "./tmp", f"bmm_rcr_n_non1_{dtype}")
+        module = safe_compile_model(output, target, "./tmp", f"bmm_rcr_n_non1_{dtype}")
 
         output_tensor = None
         for tensor in module.debug_sorted_graph:
@@ -330,7 +330,7 @@ class OneByOneConvTestCase(unittest.TestCase):
         conv2d._attrs["name"] = "output"
         conv2d._attrs["is_output"] = True
 
-        with compile_model(
+        with safe_compile_model(
             conv2d,
             detect_target(),
             "./tmp",

--- a/tests/unittest/compiler/test_transform_toposort.py
+++ b/tests/unittest/compiler/test_transform_toposort.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import Tensor
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.testing import detect_target
@@ -36,7 +36,7 @@ class TestTopoSort(unittest.TestCase):
         x._attrs["name"] = "output"
 
         target = detect_target()
-        module = compile_model(x, target, "./tmp", "test_very_deep_toposort")
+        module = safe_compile_model(x, target, "./tmp", "test_very_deep_toposort")
 
         x_pt = torch.randn((2, 10)).half().cuda()
         out_pt = torch.relu(x_pt)

--- a/tests/unittest/compiler/test_transform_utils.py
+++ b/tests/unittest/compiler/test_transform_utils.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops, transform
+from aitemplate.compiler import ops, safe_compile_model, transform
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.compiler.stable_set import StableSet
 from aitemplate.frontend import Tensor
@@ -127,7 +127,7 @@ class TransformUtilsReplaceTensorTestCase(unittest.TestCase):
         transform.transform_utils.replace_tensor(X3, R)
 
         target = detect_target()
-        module = compile_model(X5, target, "./tmp", "original_inputs_replace")
+        module = safe_compile_model(X5, target, "./tmp", "original_inputs_replace")
 
         x_pt = torch.randn(X_shape).cuda().half()
         x1_pt = torch.randn(X_shape).cuda().half()
@@ -155,7 +155,7 @@ class TransformUtilsReplaceTensorTestCase(unittest.TestCase):
         transform.transform_utils.replace_tensor(X2, R)
 
         target = detect_target()
-        module = compile_model(X4, target, "./tmp", "view_replace")
+        module = safe_compile_model(X4, target, "./tmp", "view_replace")
 
         x_pt = torch.randn(X_shape).cuda().half()
         x1_pt = torch.cos(x_pt)

--- a/tests/unittest/compiler/test_view_strided_op.py
+++ b/tests/unittest/compiler/test_view_strided_op.py
@@ -18,7 +18,7 @@ from typing import List, Optional
 
 import torch
 
-from aitemplate.compiler import compile_model, Model, ops
+from aitemplate.compiler import Model, ops, safe_compile_model
 from aitemplate.compiler.base import IntVar
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target, test_utils
@@ -184,7 +184,7 @@ class ViewStridedOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(Ys, target, "./tmp", f"{test_name}_{dtype}")
+        module = safe_compile_model(Ys, target, "./tmp", f"{test_name}_{dtype}")
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph
@@ -361,7 +361,7 @@ class ViewStridedOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             Ys, target, "./tmp", f"multi_view_multi_bmm_fusion_{dtype}"
         )
 
@@ -544,7 +544,9 @@ class ViewStridedOpTestCase(unittest.TestCase):
 
         # Gen module.
         target = detect_target()
-        module = compile_model(Ys, target, "./tmp", f"single_view_gemm_fusion_{dtype}")
+        module = safe_compile_model(
+            Ys, target, "./tmp", f"single_view_gemm_fusion_{dtype}"
+        )
 
         # Verify the generated graph.
         sorted_graph = module.debug_sorted_graph

--- a/tests/unittest/ops/test_activation.py
+++ b/tests/unittest/ops/test_activation.py
@@ -19,7 +19,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
@@ -78,7 +78,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X2._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
+        module = safe_compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
 
         x1_pt = get_random_torch_tensor(input_size, dtype=dtype)
         OP_pt = torch.nn.LeakyReLU(negative_slope)
@@ -118,7 +118,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X2._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
+        module = safe_compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
 
         x1_pt = get_random_torch_tensor(input_size, dtype)
         x2_pt = torch.div(x1_pt, dividend, rounding_mode="floor")
@@ -165,7 +165,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X2._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
+        module = safe_compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
 
         x1_pt = get_random_torch_tensor(input_size, dtype)
         OP_pt = torch.nn.Hardtanh(min_val=min_val, max_val=max_val)
@@ -213,7 +213,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X2._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
+        module = safe_compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
 
         x1_pt = get_random_torch_tensor(input_size, dtype)
         OP_pt = torch.nn.Softplus(beta=beta, threshold=threshold)
@@ -241,7 +241,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X2._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
+        module = safe_compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
 
         x1_pt = get_random_torch_tensor(input_size, dtype)
         x2_pt = TORCH_EQUIVALENTS[function](x1_pt)
@@ -274,7 +274,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X2._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
+        module = safe_compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
         x1_pt = get_random_torch_tensor(input_size, dtype)
         OP_pt = torch.nn.ELU(alpha=alpha)
         x2_pt = OP_pt(x1_pt)
@@ -304,7 +304,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X2._attrs["name"] = "output"
 
         target = detect_target()
-        module = compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
+        module = safe_compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
 
         x1_pt = get_random_torch_tensor(input_size, dtype)
         OP_pt = torch.nn.Softsign()
@@ -343,7 +343,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X2._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
+        module = safe_compile_model(X2, target, "./tmp", f"{test_name}_{dtype}")
         x1_pt = get_random_torch_tensor(input_size, dtype)
         OP_pt = torch.nn.CELU(alpha=alpha)
         x2_pt = OP_pt(x1_pt)
@@ -362,7 +362,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
     )
     def test_lrelu(self, dtype):
-        self._test_leaky_relu([512, 512], test_name="leaky_relu_1", dtype=dtype)
+        self._test_leaky_relu([512, 512], test_name="leaky_relu_1_{dtype}", dtype=dtype)
         self._test_leaky_relu(
             [1024, 1024],
             negative_slope=0.5,
@@ -376,7 +376,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
             copy_op=True,
             dtype=dtype,
         )
-        self._test_leaky_relu([63, 63], test_name="leaky_relu_3", dtype=dtype)
+        self._test_leaky_relu([63, 63], test_name="leaky_relu_3__{dtype}", dtype=dtype)
 
     @parameterized.expand(
         filter_test_cases_by_params(
@@ -388,7 +388,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
     )
     def test_htanh(self, dtype):
-        self._test_hardtanh([511, 511], test_name="hard_tanh_1", dtype=dtype)
+        self._test_hardtanh([511, 511], test_name="hard_tanh_1__{dtype}", dtype=dtype)
         self._test_hardtanh(
             [1024, 1024], min_val=-2, max_val=2, test_name="hard_tanh_2", dtype=dtype
         )

--- a/tests/unittest/ops/test_argmax.py
+++ b/tests/unittest/ops/test_argmax.py
@@ -18,7 +18,7 @@ Unittests for argmax Operator.
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -50,7 +50,7 @@ class ArgmaxTestCase(unittest.TestCase):
         X4._attrs["name"] = "output"
 
         target = detect_target()
-        module = compile_model(X4, target, "./tmp", test_name)
+        module = safe_compile_model(X4, target, "./tmp", test_name)
 
         scores = get_random_torch_tensor(shape, dtype=dtype)
         y_pt = torch.argmax(scores, dim=dim)

--- a/tests/unittest/ops/test_argmax_sm80.py
+++ b/tests/unittest/ops/test_argmax_sm80.py
@@ -18,7 +18,7 @@ Unittests for argmax Operator.
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -48,7 +48,7 @@ class ArgmaxSM80TestCase(unittest.TestCase):
         X4._attrs["name"] = "output"
 
         target = detect_target()
-        module = compile_model(X4, target, "./tmp", test_name)
+        module = safe_compile_model(X4, target, "./tmp", test_name)
 
         scores = get_random_torch_tensor(shape, dtype=dtype)
         y_pt = torch.argmax(scores, dim=dim)

--- a/tests/unittest/ops/test_attention.py
+++ b/tests/unittest/ops/test_attention.py
@@ -23,7 +23,7 @@ import unittest
 import torch
 import torch.nn.functional as F
 
-from aitemplate.compiler import compile_model, Model, ops
+from aitemplate.compiler import Model, ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import benchmark_pt, detect_target
@@ -247,7 +247,7 @@ class AttentionTestCase(unittest.TestCase):
 
         if rebuild:
             target = detect_target()
-            module = compile_model(Y, target, "./tmp", test_name)
+            module = safe_compile_model(Y, target, "./tmp", test_name)
         else:
             module = Model(os.path.join("./tmp", test_name, "test.so"))
 
@@ -357,7 +357,7 @@ class AttentionTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
         if rebuild:
             target = detect_target()
-            module = compile_model(Y, target, "./tmp", test_name)
+            module = safe_compile_model(Y, target, "./tmp", test_name)
         else:
             module = Model(os.path.join("./tmp", test_name, "test.so"))
 
@@ -504,7 +504,7 @@ class AttentionTestCase(unittest.TestCase):
 
         if rebuild:
             target = detect_target()
-            module = compile_model(Y, target, "./tmp", test_name)
+            module = safe_compile_model(Y, target, "./tmp", test_name)
         else:
             module = Model(os.path.join("./tmp", test_name, "test.so"))
 
@@ -714,7 +714,7 @@ class AttentionTestCase(unittest.TestCase):
 
         if rebuild:
             target = detect_target()
-            module = compile_model(Y, target, "./tmp", test_name)
+            module = safe_compile_model(Y, target, "./tmp", test_name)
         else:
             module = Model(os.path.join("./tmp", test_name, "test.so"))
 

--- a/tests/unittest/ops/test_avg_pool2d.py
+++ b/tests/unittest/ops/test_avg_pool2d.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model
+from aitemplate.compiler import safe_compile_model
 
 from aitemplate.frontend import IntVar, nn, Tensor
 from aitemplate.testing import detect_target
@@ -36,7 +36,7 @@ class AvgPoolTestCase(unittest.TestCase):
         Y = OP(X)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "avg_pool2d")
+        module = safe_compile_model(Y, target, "./tmp", "avg_pool2d")
         for batch in batch_size:
             X_pt = get_random_torch_tensor([batch, 2048, 7, 7], dtype=dtype)
             OP_pt = torch.nn.AvgPool2d(kernel_size=7, stride=1, padding=0)

--- a/tests/unittest/ops/test_b2b_bmm.py
+++ b/tests/unittest/ops/test_b2b_bmm.py
@@ -21,7 +21,7 @@ from typing import List, Tuple
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.utils import shape_utils
@@ -101,7 +101,7 @@ class ClassicB2bBmmTestCase(unittest.TestCase):
         Y._attrs["name"] = "output"
 
         target = detect_target(use_fp16_acc=True)
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         # Run tests.
         torch_dtype = string_to_torch_dtype(dtype)

--- a/tests/unittest/ops/test_batch_gather.py
+++ b/tests/unittest/ops/test_batch_gather.py
@@ -19,7 +19,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -70,7 +70,9 @@ class batchGatherTestCase(gatherTestCase):
         X4._attrs["name"] = "output"
 
         target = detect_target()
-        module = compile_model(X4, target, "./tmp", f"{test_name}_{self.test_count}")
+        module = safe_compile_model(
+            X4, target, "./tmp", f"{test_name}_{self.test_count}"
+        )
 
         input_x = get_random_torch_tensor(in_shape, dtype)
         init_index = torch.randint(max_ind, size=ind_shape, dtype=torch.int64).cuda()
@@ -155,7 +157,9 @@ class batchGatherTopkTestCase(gatherTestCase):
         X4._attrs["name"] = "output"
 
         target = detect_target()
-        module = compile_model(X4, target, "./tmp", f"{test_name}_{self.test_count}")
+        module = safe_compile_model(
+            X4, target, "./tmp", f"{test_name}_{self.test_count}"
+        )
 
         input_x = get_random_torch_tensor(m_shape, dtype)
         scores = self._create_tensors(N, dtype)

--- a/tests/unittest/ops/test_batched_dense_vec_jagged_2d_mul.py
+++ b/tests/unittest/ops/test_batched_dense_vec_jagged_2d_mul.py
@@ -19,7 +19,7 @@ import unittest
 from typing import List
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm, IntVar, JaggedDim, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.jagged_utils import batched_dense_vec_jagged_2d_mul_ref
@@ -111,7 +111,7 @@ class BatchedDenseVecJagged2DMulTestCase(unittest.TestCase):
         assert JAGGED.is_jagged()
         assert not RESULT.is_jagged()
 
-        model = compile_model(
+        model = safe_compile_model(
             [RESULT],
             detect_target(use_fp16_acc=use_fp16_acc),
             "./tmp",

--- a/tests/unittest/ops/test_bert_embeddings.py
+++ b/tests/unittest/ops/test_bert_embeddings.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -125,7 +125,7 @@ class bertEmbeddingsTestCase(unittest.TestCase):
         y._attrs["name"] = "output"
 
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             y,
             target,
             "./tmp",

--- a/tests/unittest/ops/test_bmm.py
+++ b/tests/unittest/ops/test_bmm.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -50,7 +50,7 @@ class BMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_rcr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rcr_{}".format(test_name))
 
         for (b, m) in itertools.product(bs, ms):
             X_pt = get_random_torch_tensor([b, m, K], dtype)
@@ -92,7 +92,7 @@ class BMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_crr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_crr_{}".format(test_name))
 
         for (b, k) in itertools.product(bs, ks):
             X_pt = get_random_torch_tensor([b, k, M], dtype)
@@ -124,7 +124,7 @@ class BMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_rrr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rrr_{}".format(test_name))
 
         for (b, m) in itertools.product(bs, ms):
             X_pt = get_random_torch_tensor([b, m, K], dtype)
@@ -152,7 +152,7 @@ class BMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_ccr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_ccr_{}".format(test_name))
 
         for b in bs:
             X_pt = get_random_torch_tensor([b, K, M], dtype)
@@ -181,7 +181,7 @@ class BMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_rcc_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rcc_{}".format(test_name))
 
         for (b, m) in itertools.product(bs, ms):
             X_pt = get_random_torch_tensor([b, m, K], dtype)
@@ -224,7 +224,7 @@ class BMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_crc_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_crc_{}".format(test_name))
 
         for (b, k) in itertools.product(bs, ks):
             X_pt = get_random_torch_tensor([b, k, M], dtype)
@@ -257,7 +257,7 @@ class BMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_rrc_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rrc_{}".format(test_name))
 
         for (b, m) in itertools.product(bs, ms):
             X_pt = get_random_torch_tensor([b, m, K], dtype)
@@ -286,7 +286,7 @@ class BMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_ccc_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_ccc_{}".format(test_name))
 
         for b in bs:
             X_pt = get_random_torch_tensor([b, K, M], dtype)
@@ -377,7 +377,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
 
         test_name = f"bmm_rcr_with_accessor_{dtype}"
         target = detect_target()
-        module = compile_model(out, target, "./tmp", test_name)
+        module = safe_compile_model(out, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -415,7 +415,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
 
         target = detect_target()
         test_name = f"bmm_rcr_merge_with_accessor_{dtype}"
-        module = compile_model(out, target, "./tmp", test_name)
+        module = safe_compile_model(out, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -457,7 +457,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_rcr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rcr_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -492,7 +492,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_crr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_crr_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -527,7 +527,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_rrr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rrr_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -561,7 +561,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_ccr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_ccr_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -597,7 +597,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_rcc_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rcc_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -633,7 +633,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_crc_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_crc_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -669,7 +669,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_rrc_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rrc_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -704,7 +704,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_ccc_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_ccc_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -758,7 +758,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_rcr_should_fail")
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rcr_should_fail")
 
         X_pt = get_random_torch_tensor([2, 10, K], dtype)
         W_pt = get_random_torch_tensor([16, 8, K], dtype)
@@ -786,7 +786,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_rrr_should_fail")
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rrr_should_fail")
 
         X_pt = get_random_torch_tensor([2, 10, K], dtype)
         W_pt = get_random_torch_tensor([16, K, 8], dtype)
@@ -814,7 +814,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_rcc_should_fail")
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rcc_should_fail")
 
         X_pt = get_random_torch_tensor([2, 10, K], dtype)
         W_pt = get_random_torch_tensor([16, 8, K], dtype)

--- a/tests/unittest/ops/test_bmm_add.py
+++ b/tests/unittest/ops/test_bmm_add.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -54,7 +54,7 @@ class BMMAddTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"bmm_rrr_add_{dtype}", dll_name=dll_name
         )
         X_pt = get_random_torch_tensor([B, M, K], dtype)
@@ -81,7 +81,7 @@ class BMMAddTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         X_pt = get_random_torch_tensor([B, K, M], dtype)
         W_pt = get_random_torch_tensor([B, N, K], dtype)
         D_pt = get_random_torch_tensor([B, M, N], dtype)
@@ -110,7 +110,7 @@ class BMMAddTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         X_pt = get_random_torch_tensor([B, M, K], dtype)
         W_pt = get_random_torch_tensor([B, N, K], dtype)
         D_pt = get_random_torch_tensor([B, M, N], dtype)
@@ -154,7 +154,7 @@ class BMMAddTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
         test_name = f"bmm_crr_add_{dtype}"
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         X_pt = get_random_torch_tensor([B, K, M], dtype)
         W_pt = get_random_torch_tensor([B, K, N], dtype)
         D_pt = get_random_torch_tensor([B, M, N], dtype)
@@ -180,7 +180,7 @@ class BMMAddTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         X_pt = get_random_torch_tensor([B, M, K], dtype)
         W_pt = get_random_torch_tensor([B, N, K], dtype)
         D_pt = get_random_torch_tensor([B, N, M], dtype)
@@ -209,7 +209,7 @@ class BMMAddTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"bmm_rrc_add_{dtype}", dll_name=dll_name
         )
         X_pt = get_random_torch_tensor([B, M, K], dtype)
@@ -252,7 +252,7 @@ class BMMAddTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
         test_name = f"bmm_crc_add_{dtype}"
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         X_pt = get_random_torch_tensor([B, K, M], dtype)
         W_pt = get_random_torch_tensor([B, K, N], dtype)
         D_pt = get_random_torch_tensor([B, N, M], dtype)
@@ -278,7 +278,7 @@ class BMMAddTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         X_pt = get_random_torch_tensor([B, K, M], dtype)
         W_pt = get_random_torch_tensor([B, N, K], dtype)
         D_pt = get_random_torch_tensor([B, N, M], dtype)
@@ -368,7 +368,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_crr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_crr_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -418,7 +418,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_rrr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rrr_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -467,7 +467,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_rcr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rcr_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -517,7 +517,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_ccr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_ccr_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -568,7 +568,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_crc_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_crc_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -595,7 +595,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_rrr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rrr_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -644,7 +644,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_rcc_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rcc_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)
@@ -694,7 +694,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", "bmm_ccc_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_ccc_{}".format(test_name))
 
         X_pt = get_random_torch_tensor(A_shape, dtype)
         W_pt = get_random_torch_tensor(B_shape, dtype)

--- a/tests/unittest/ops/test_bmm_alpha.py
+++ b/tests/unittest/ops/test_bmm_alpha.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -65,7 +65,7 @@ class BMMAlphaTestCase(unittest.TestCase):
         Y2 = ops.elementwise(elem_func_type)(Y1, Tensor([], value=cst_val, dtype=dtype))
         Y2._attrs["name"] = "output_0"
         Y2._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y2, target, "./tmp", f"bmm_alpha_{B}_{M}_{N}_{K}_{use_fp16_acc}_{dtype}"
         )
         expected_cst_val = 1.0 / float(cst_val) if is_div else float(cst_val)

--- a/tests/unittest/ops/test_bmm_permute.py
+++ b/tests/unittest/ops/test_bmm_permute.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -47,7 +47,7 @@ class BMMPermuteTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_rrr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rrr_{}".format(test_name))
 
         for (b, m) in itertools.product(bs, ms):
             X_pt = get_random_torch_tensor([b, m, K], dtype)
@@ -89,7 +89,7 @@ class BMMPermuteTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "bmm_rcr_{}".format(test_name))
+        module = safe_compile_model(Y, target, "./tmp", "bmm_rcr_{}".format(test_name))
 
         for (b, m) in itertools.product(bs, ms):
             X_pt = get_random_torch_tensor([b, m, K], dtype)

--- a/tests/unittest/ops/test_bmm_rcr_n1.py
+++ b/tests/unittest/ops/test_bmm_rcr_n1.py
@@ -18,7 +18,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -70,7 +70,7 @@ class BMMRcrN1TestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",

--- a/tests/unittest/ops/test_bmm_rrr_k1_tanh.py
+++ b/tests/unittest/ops/test_bmm_rrr_k1_tanh.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -39,7 +39,9 @@ class BMMRrrK1TanhTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self.test_count}")
+        module = safe_compile_model(
+            Y, target, "./tmp", f"{test_name}_{self.test_count}"
+        )
         X_pt = get_random_torch_tensor([B, M, K], dtype)
         W_pt = get_random_torch_tensor([B, K, N], dtype)
 

--- a/tests/unittest/ops/test_bmm_softmax.py
+++ b/tests/unittest/ops/test_bmm_softmax.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 
@@ -46,7 +46,7 @@ class BMMSoftmaxTestCase(unittest.TestCase):
         if type(target).__name__ == "FBCUDA":
             _LOGGER.warning("Skip this test for special profiling requirement")
             return
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         X_pt = torch.randn(B, M, K).cuda().half()
         W_pt = torch.randn(B, N, K).cuda().half()
 

--- a/tests/unittest/ops/test_bmm_softmax_bmm.py
+++ b/tests/unittest/ops/test_bmm_softmax_bmm.py
@@ -21,7 +21,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.utils import shape_utils
@@ -79,7 +79,7 @@ class BMMSoftmaxBMMTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"bmm_{test_name}_permute", dll_name=dll_name
         )
 
@@ -152,7 +152,7 @@ class BMMSoftmaxBMMTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"bmm_{test_name}_permute", dll_name=dll_name
         )
 

--- a/tests/unittest/ops/test_chunk.py
+++ b/tests/unittest/ops/test_chunk.py
@@ -18,7 +18,7 @@ from typing import List
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -49,7 +49,7 @@ class ChunkTestCase(unittest.TestCase):
             Y._attrs["name"] = "output_{}".format(idx)
             Y._attrs["is_output"] = True
 
-        module = compile_model(Ys, target, "./tmp", "chunk")
+        module = safe_compile_model(Ys, target, "./tmp", "chunk")
 
         for batch_size in input_shape[0]._attrs["values"]:
             logging.info(f"Testing {batch_size=}")

--- a/tests/unittest/ops/test_clamp_nan_to_num.py
+++ b/tests/unittest/ops/test_clamp_nan_to_num.py
@@ -18,7 +18,7 @@ from typing import Callable, List
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm, IntVar
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
@@ -80,7 +80,9 @@ class ClampTestCase(unittest.TestCase):
         result._attrs["name"] = "output"
 
         target = detect_target()
-        module = compile_model(result, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(
+            result, target, "./tmp", f"{test_name}_{self._test_id}"
+        )
         self._test_id += 1
 
         torch_dtype = string_to_torch_dtype(dtype)

--- a/tests/unittest/ops/test_concatenate.py
+++ b/tests/unittest/ops/test_concatenate.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm, IntVar
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -56,7 +56,9 @@ class ConcatenateTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", "concatenate", dll_name=dll_name)
+        module = safe_compile_model(
+            Y, target, "./tmp", "concatenate", dll_name=dll_name
+        )
 
         input_tensors_ait = {
             f"input_{idx}": input_tensors_pt[idx] for idx in range(len(inputs))
@@ -93,7 +95,7 @@ class ConcatenateTestCase(unittest.TestCase):
 
         batch_tag = "_".join([str(b) for b in batch_sizes])
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"concatenate_batched_{batch_tag}", dll_name=dll_name
         )
         for batch in batch_sizes:
@@ -157,7 +159,7 @@ class ConcatenateTestCase(unittest.TestCase):
         concatenate_op._attrs["input_accessors"] = input_accessors
 
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", "concatenate_masked", dll_name=dll_name
         )
 

--- a/tests/unittest/ops/test_concatenate_tanh.py
+++ b/tests/unittest/ops/test_concatenate_tanh.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -73,7 +73,7 @@ class ConcatenateTanhTestCase(unittest.TestCase):
 
         logging.info(f"AITemplate output_shape: {y_shape}")
 
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         input_tensors_ait = {
@@ -111,7 +111,7 @@ class ConcatenateTanhTestCase(unittest.TestCase):
         Y = concatenate_op(inputs) if dim is None else concatenate_op(inputs, dim)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
         for batch in batch_sizes:
             logging.info(f"checking batch: {batch}")
@@ -187,7 +187,7 @@ class ConcatenateTanhTestCase(unittest.TestCase):
 
         logging.info(f"AITemplate output_shape: {y_shape}")
 
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         inputs = []

--- a/tests/unittest/ops/test_conv.py
+++ b/tests/unittest/ops/test_conv.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -55,7 +55,7 @@ class ConvTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, 128, 28, 28], dtype=dtype)
         W_pt = get_random_torch_tensor([256, 128, 3, 3], dtype=dtype)

--- a/tests/unittest/ops/test_conv2d_bias_add.py
+++ b/tests/unittest/ops/test_conv2d_bias_add.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -70,7 +70,7 @@ class ConvBiasAddTestCase(unittest.TestCase):
         Y = OP(X, W, B, R)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, CI, HH, WW], dtype=dtype)
         W_pt = get_random_torch_tensor([CO, CI, 3, 3], dtype=dtype)

--- a/tests/unittest/ops/test_conv3d.py
+++ b/tests/unittest/ops/test_conv3d.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -66,7 +66,7 @@ class Conv3dTestCase(unittest.TestCase):
 
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "conv3d_has_bias")
+        module = safe_compile_model(Y, target, "./tmp", "conv3d_has_bias")
 
         X_pt = get_random_torch_tensor([4, ci, tt, hh, ww], dtype=dtype)
         W_pt = get_random_torch_tensor([co, ci, kt, kh, kw], dtype=dtype)
@@ -133,7 +133,7 @@ class Conv3dTestCase(unittest.TestCase):
             Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{has_bias}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{has_bias}")
 
         X_pt = get_random_torch_tensor([batch, ci, tt, hh, ww], dtype=dtype)
         W_pt = get_random_torch_tensor([co, ci, kt, kh, kw], dtype=dtype)

--- a/tests/unittest/ops/test_conv3d_profiler_cache.py
+++ b/tests/unittest/ops/test_conv3d_profiler_cache.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 from aitemplate.backend.profiler_cache import ProfileCacheDB
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import DynamicProfileStrategy
 from aitemplate.frontend import IntImm, IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -70,7 +70,7 @@ class Conv3DProfilerCacheTestCase(unittest.TestCase):
             logger=logger,
             level="INFO",
         ) as logs:
-            compile_model(
+            safe_compile_model(
                 Y,
                 target,
                 "./tmp",

--- a/tests/unittest/ops/test_conv_bias.py
+++ b/tests/unittest/ops/test_conv_bias.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -65,7 +65,7 @@ class ConvBiasTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, 128, 28, 28], dtype=dtype)
         W_pt = get_random_torch_tensor([256, 128, 3, 3], dtype=dtype)

--- a/tests/unittest/ops/test_conv_bias_act_few_channels.py
+++ b/tests/unittest/ops/test_conv_bias_act_few_channels.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -74,7 +74,7 @@ class ConvBiasActFewChannelsTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, CI, HH, WW], dtype=dtype)
         W_pt = get_random_torch_tensor([CO, CI, KK, KK], dtype=dtype)
@@ -149,7 +149,7 @@ class ConvBiasActFewChannelsTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, CI, HH, WW], dtype=dtype)
         W_pt = get_random_torch_tensor([CO, CI, KK, KK], dtype=dtype)

--- a/tests/unittest/ops/test_conv_bias_add_hardswish.py
+++ b/tests/unittest/ops/test_conv_bias_add_hardswish.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -75,7 +75,7 @@ class ConvBiasAddHardswishTestCase(unittest.TestCase):
         Y = OP(X, W, B, R)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, CI, HH, WW], dtype=dtype)
         W_pt = get_random_torch_tensor([CO, CI, 3, 3], dtype=dtype)

--- a/tests/unittest/ops/test_conv_bias_add_relu.py
+++ b/tests/unittest/ops/test_conv_bias_add_relu.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -70,7 +70,7 @@ class ConvBiasAddReluTestCase(unittest.TestCase):
         Y = OP(X, W, B, R)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, CI, HH, WW], dtype=dtype)
         W_pt = get_random_torch_tensor([CO, CI, 3, 3], dtype=dtype)

--- a/tests/unittest/ops/test_conv_bias_hardswish.py
+++ b/tests/unittest/ops/test_conv_bias_hardswish.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -67,7 +67,7 @@ class ConvBiasHardswishTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, 128, 28, 28], dtype=dtype)
         W_pt = get_random_torch_tensor([256, 128, 3, 3], dtype=dtype)

--- a/tests/unittest/ops/test_conv_bias_relu.py
+++ b/tests/unittest/ops/test_conv_bias_relu.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -65,7 +65,7 @@ class ConvBiasReluTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, 128, 28, 28], dtype=dtype)
         W_pt = get_random_torch_tensor([256, 128, 3, 3], dtype=dtype)

--- a/tests/unittest/ops/test_conv_bias_sigmoid.py
+++ b/tests/unittest/ops/test_conv_bias_sigmoid.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -61,7 +61,7 @@ class ConvBiasSigmoidTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, 128, 28, 28], dtype=dtype)
         W_pt = get_random_torch_tensor([256, 128, 3, 3], dtype=dtype)

--- a/tests/unittest/ops/test_conv_depthwise.py
+++ b/tests/unittest/ops/test_conv_depthwise.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 
@@ -37,7 +37,7 @@ class ConvDepthwiseTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "conv2d_dw")
+        module = safe_compile_model(Y, target, "./tmp", "conv2d_dw")
 
         X_pt = torch.randn(batch, 32, *size).cuda().half()
         W_pt = torch.randn(32, 1, 3, 3).cuda().half()

--- a/tests/unittest/ops/test_conv_depthwise_bias.py
+++ b/tests/unittest/ops/test_conv_depthwise_bias.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 
@@ -38,7 +38,7 @@ class ConvDepthwiseBiasTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "conv2d_dw_bias")
+        module = safe_compile_model(Y, target, "./tmp", "conv2d_dw_bias")
 
         X_pt = torch.randn(batch, 32, *size).cuda().half()
         W_pt = torch.randn(32, 1, 3, 3).cuda().half()

--- a/tests/unittest/ops/test_conv_profiler_cache.py
+++ b/tests/unittest/ops/test_conv_profiler_cache.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 from aitemplate.backend.profiler_cache import ProfileCacheDB
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import DynamicProfileStrategy
 from aitemplate.frontend import IntImm, IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -59,7 +59,7 @@ class ConvProfilerCacheTestCase(unittest.TestCase):
             logger=logger,
             level="INFO",
         ) as logs:
-            compile_model(
+            safe_compile_model(
                 Y,
                 target,
                 "./tmp",

--- a/tests/unittest/ops/test_cross_attention.py
+++ b/tests/unittest/ops/test_cross_attention.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import torch
-from aitemplate.compiler import compile_model
+from aitemplate.compiler import safe_compile_model
 from aitemplate.frontend import nn, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.utils import shape_utils
@@ -102,7 +102,7 @@ class crossattentionTestCase(unittest.TestCase):
         Y = Y + inputs_ait
         mark_output(Y)
         target = detect_target(use_fp16_acc=False)
-        exe_module = compile_model(
+        exe_module = safe_compile_model(
             Y, target, "./tmp", f"cross_attn_dynamic_{self.test_id}"
         )
         self.test_id += 1

--- a/tests/unittest/ops/test_depthwise_conv3d.py
+++ b/tests/unittest/ops/test_depthwise_conv3d.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -60,7 +60,7 @@ class Conv3dDepthwiseTestCase(unittest.TestCase):
         Y = OP(X, W, B) if bias else OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, ci, tt, hh, ww], dtype=dtype)
         W_pt = get_random_torch_tensor([co, 1, 3, 3, 3], dtype=dtype)
@@ -149,7 +149,9 @@ class Conv3dDepthwiseTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"depthwise_conv3d_mvit_{test_case}")
+        module = safe_compile_model(
+            Y, target, "./tmp", f"depthwise_conv3d_mvit_{test_case}"
+        )
 
         X_pt = torch.randn(batch, ci, tt, hh, ww).cuda().half()
         W_pt = (

--- a/tests/unittest/ops/test_dual_bmm.py
+++ b/tests/unittest/ops/test_dual_bmm.py
@@ -16,7 +16,7 @@ import logging
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -67,7 +67,7 @@ class DUALBMMTestCase(unittest.TestCase):
         Y = OP(X, B0, B1)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         X_pt = get_random_torch_tensor([B, M, K], dtype=dtype) + 1.0

--- a/tests/unittest/ops/test_dual_gemm.py
+++ b/tests/unittest/ops/test_dual_gemm.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import nn, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -124,7 +124,7 @@ class DUALGEMMTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
         X_pt = get_random_torch_tensor([M, K], dtype=dtype) * 0.01
         W_pt = get_random_torch_tensor([N, K], dtype=dtype)
@@ -333,7 +333,9 @@ class DUALGEMMTestCase(unittest.TestCase):
         Y = ait_mod(inputs_ait)
         mark_output(Y)
         target = detect_target(use_fp16_acc=False)
-        exe_module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        exe_module = safe_compile_model(
+            Y, target, "./tmp", f"{test_name}_{self._test_id}"
+        )
         self._test_id += 1
         for name, weight in params_ait.items():
             exe_module.set_constant_with_tensor(name, weight)

--- a/tests/unittest/ops/test_dynamic_conv.py
+++ b/tests/unittest/ops/test_dynamic_conv.py
@@ -18,7 +18,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import DynamicProfileStrategy
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -57,7 +57,7 @@ class ConvDynamicTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",
@@ -126,7 +126,7 @@ class ConvDynamicTestCase(unittest.TestCase):
         Y = conv_op2(Y1, W2)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",
@@ -201,7 +201,7 @@ class ConvDynamicTestCase(unittest.TestCase):
         Y = conv_op2(Y1, W2)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",

--- a/tests/unittest/ops/test_efficient_nms.py
+++ b/tests/unittest/ops/test_efficient_nms.py
@@ -23,7 +23,7 @@ from unittest import skipIf
 
 import numpy as np
 import torch
-from aitemplate.compiler import compile_model, Model, ops
+from aitemplate.compiler import Model, ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.benchmark_pt import benchmark_torch_function
@@ -208,7 +208,7 @@ class nmsTestCase(unittest.TestCase):
                 shutil.rmtree("./tmp/" + str(test_name))
             except FileNotFoundError:
                 pass
-            module = compile_model(Y, target, "./tmp", test_name)
+            module = safe_compile_model(Y, target, "./tmp", test_name)
         else:
             module = Model(os.path.join("./tmp", test_name, "test.so"))
 

--- a/tests/unittest/ops/test_expand.py
+++ b/tests/unittest/ops/test_expand.py
@@ -19,7 +19,7 @@ import unittest
 import torch
 
 from aitemplate import compiler
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm, IntVar, JaggedDim, Tensor
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.testing import detect_target
@@ -63,7 +63,7 @@ class ExpandTestCase(unittest.TestCase):
         x_pt = get_random_torch_tensor([1, 2, 3], dtype=dtype)
         z_pt = x_pt * x_pt
         z_ait = torch.empty_like(z_pt)
-        with compile_model(z, detect_target(), "./tmp", test_name) as module:
+        with safe_compile_model(z, detect_target(), "./tmp", test_name) as module:
             module.run_with_tensors({"input_0": x_pt}, {"output_0": z_ait})
             self.assertFalse(graph_has_op(module.debug_sorted_graph, "expand"))
             self.assertTrue(torch.equal(z_ait, z_pt))
@@ -101,7 +101,7 @@ class ExpandTestCase(unittest.TestCase):
         x_pt = get_random_torch_tensor([1, 2, 3], dtype=dtype)
         z_pt = x_pt * x_pt
         z_ait = torch.empty_like(z_pt)
-        with compile_model(z, detect_target(), "./tmp", test_name) as module:
+        with safe_compile_model(z, detect_target(), "./tmp", test_name) as module:
             module.run_with_tensors({"input_0": x_pt}, {"output_0": z_ait})
             self.assertFalse(graph_has_op(module.debug_sorted_graph, "expand"))
             self.assertTrue(torch.equal(z_ait, z_pt))
@@ -148,7 +148,7 @@ class ExpandTestCase(unittest.TestCase):
         y_pt = get_random_torch_tensor([1, 2, 3], dtype=dtype)
         z_pt = x_pt * y_pt
         z_ait = torch.empty_like(z_pt)
-        with compile_model(z, detect_target(), "./tmp", test_name) as module:
+        with safe_compile_model(z, detect_target(), "./tmp", test_name) as module:
             module.run_with_tensors(
                 {"input_0": x_pt, "input_1": y_pt}, {"output_0": z_ait}
             )
@@ -392,7 +392,7 @@ class ExpandTestCase(unittest.TestCase):
         start_event_pt = torch.cuda.Event(enable_timing=True)
         end_event_pt = torch.cuda.Event(enable_timing=True)
         num_iters = 20
-        with compile_model(
+        with safe_compile_model(
             y, detect_target(), "./tmp", "test_expand_codegen_" + name
         ) as module:
             module.run_with_tensors({"X": x_pt}, {"Y": y_ait})

--- a/tests/unittest/ops/test_flatten.py
+++ b/tests/unittest/ops/test_flatten.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model
+from aitemplate.compiler import safe_compile_model
 from aitemplate.compiler.base import IntImm, IntVar
 from aitemplate.frontend import nn, Tensor
 from aitemplate.testing import detect_target
@@ -58,7 +58,7 @@ class FlattenTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         x_shape_values = [var._attrs["values"] for var in X_shape]

--- a/tests/unittest/ops/test_fpn_roi_align.py
+++ b/tests/unittest/ops/test_fpn_roi_align.py
@@ -17,7 +17,7 @@ import unittest
 from unittest import skipIf
 
 import torch
-from aitemplate.compiler import compile_model, Model, ops
+from aitemplate.compiler import Model, ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.utils.torch_utils import string_to_torch_dtype
@@ -96,7 +96,7 @@ class RoiAlignTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
         if rebuild:
-            module = compile_model(Y, target, "./tmp", test_name)
+            module = safe_compile_model(Y, target, "./tmp", test_name)
         else:
             module = Model(os.path.join("./tmp", test_name, "test.so"))
 

--- a/tests/unittest/ops/test_full.py
+++ b/tests/unittest/ops/test_full.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.public import FuncEnum
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -54,7 +54,7 @@ class TestFull(unittest.TestCase):
         Z._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(Z, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Z, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         if isinstance(shape[0], IntVar):

--- a/tests/unittest/ops/test_fused_elementwise.py
+++ b/tests/unittest/ops/test_fused_elementwise.py
@@ -22,7 +22,7 @@ from typing import List
 
 import torch
 
-from aitemplate.compiler import compile_model, ops, transform
+from aitemplate.compiler import ops, safe_compile_model, transform
 from aitemplate.compiler.base import IntImm
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.compiler.stable_set import StableSet
@@ -144,7 +144,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X4._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             X4,
             target,
             "./tmp",
@@ -238,7 +238,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X9._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(
+        module = safe_compile_model(
             X9, target, "./tmp", f"fused_elementwise_kernel1_{ait_dtype}"
         )
 
@@ -276,7 +276,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X2._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(X2, target, "./tmp", test_name)
+        module = safe_compile_model(X2, target, "./tmp", test_name)
 
         x1_pt = (
             (torch.rand(input_size, device="cuda", dtype=torch_dtype) - 0.5) * 2.0
@@ -318,7 +318,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X2._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(X2, target, "./tmp", test_name)
+        module = safe_compile_model(X2, target, "./tmp", test_name)
 
         x1_pt = torch.randn(input_size).cuda().to(dtype=torch_dtype)
         x2_pt = torch.tanh(x1_pt)
@@ -359,7 +359,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         X2._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(X2, target, "./tmp", test_name)
+        module = safe_compile_model(X2, target, "./tmp", test_name)
 
         x1_pt = torch.randn(input_size).cuda().to(dtype=torch_dtype)
         x2_pt = torch.nn.functional.gelu(x1_pt)
@@ -411,7 +411,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         result._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(result, target, "./tmp", test_name)
+        module = safe_compile_model(result, target, "./tmp", test_name)
 
         x0_pt = get_random_torch_tensor(input_size, ait_dtype)
         x1_pt = get_random_torch_tensor(input_size, ait_dtype)
@@ -505,7 +505,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         result._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(result, target, "./tmp", test_name)
+        module = safe_compile_model(result, target, "./tmp", test_name)
 
         x0_pt = torch.randn(input_size).cuda().to(dtype=torch_dtype)
 
@@ -552,7 +552,9 @@ class FusedElementwiseTestCase(unittest.TestCase):
         OUTPUT._attrs["name"] = "output"
 
         target = detect_target()
-        module = compile_model(OUTPUT, target, "./tmp", f"test_op_overload_{ait_dtype}")
+        module = safe_compile_model(
+            OUTPUT, target, "./tmp", f"test_op_overload_{ait_dtype}"
+        )
 
         x1_pt = torch.randn(input_size).cuda().to(dtype=torch_dtype)
         x2_pt = torch.randn(input_size).cuda().to(dtype=torch_dtype)
@@ -588,7 +590,9 @@ class FusedElementwiseTestCase(unittest.TestCase):
         OUTPUT._attrs["name"] = "output"
 
         target = detect_target()
-        module = compile_model(OUTPUT, target, "./tmp", f"test_op_overload_{ait_dtype}")
+        module = safe_compile_model(
+            OUTPUT, target, "./tmp", f"test_op_overload_{ait_dtype}"
+        )
 
         x1_pt = torch.randn(input_size).cuda().to(dtype=torch_dtype)
         output_pt = 10 / torch.tanh(x1_pt + 5)
@@ -629,7 +633,7 @@ class FusedElementwisePowerTestCase(unittest.TestCase):
         X2._attrs["name"] = "output0"
 
         target = detect_target()
-        module = compile_model(X2, target, "./tmp", test_name)
+        module = safe_compile_model(X2, target, "./tmp", test_name)
 
         if abs(exp) < 1.0:
             x1_pt = torch.randn(input_size).cuda().to(dtype=torch_dtype) + 0.5

--- a/tests/unittest/ops/test_fused_elementwise_broadcast.py
+++ b/tests/unittest/ops/test_fused_elementwise_broadcast.py
@@ -20,7 +20,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
@@ -77,7 +77,7 @@ class FusedElementwiseBroadcastTestCase(unittest.TestCase):
         self.assertEqual(X4._attrs["shape"], [batch_dim, m_dim, k_dim])
 
         target = detect_target()
-        module = compile_model(X4, target, "./tmp", test_name)
+        module = safe_compile_model(X4, target, "./tmp", test_name)
 
         debug_sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(debug_sorted_graph)
@@ -257,7 +257,7 @@ class FusedElementwiseBroadcastTestCase(unittest.TestCase):
         )
 
         target = detect_target()
-        module = compile_model(X4, target, "./tmp", test_name)
+        module = safe_compile_model(X4, target, "./tmp", test_name)
 
         debug_sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(debug_sorted_graph)
@@ -476,7 +476,7 @@ class FusedElementwiseBroadcastTestCase(unittest.TestCase):
         self.assertEqual(X5._attrs["shape"], [batch_dim, n_dim, k_dim, m_dim])
 
         target = detect_target()
-        module = compile_model(X5, target, "./tmp", test_name)
+        module = safe_compile_model(X5, target, "./tmp", test_name)
 
         debug_sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(debug_sorted_graph)
@@ -682,7 +682,7 @@ class FusedElementwiseBroadcastTestCase(unittest.TestCase):
         self.assertEqual(X3._attrs["shape"], X1._attrs["shape"])
 
         target = detect_target()
-        module = compile_model(X3, target, "./tmp", test_name)
+        module = safe_compile_model(X3, target, "./tmp", test_name)
 
         debug_sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(debug_sorted_graph)
@@ -787,7 +787,7 @@ class FusedElementwiseBroadcastTestCase(unittest.TestCase):
         output._attrs["is_output"] = True
 
         target = detect_target()
-        module = compile_model(output, target, "./tmp", test_name)
+        module = safe_compile_model(output, target, "./tmp", test_name)
 
         debug_sorted_graph = module.debug_sorted_graph
         sorted_ops = graph_utils.get_sorted_ops(debug_sorted_graph)

--- a/tests/unittest/ops/test_fused_elementwise_with_strided_outputs.py
+++ b/tests/unittest/ops/test_fused_elementwise_with_strided_outputs.py
@@ -21,7 +21,7 @@ from typing import List
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
@@ -89,7 +89,7 @@ class FusedElementwiseWithStridedOutputsTestCase(unittest.TestCase):
 
         target = detect_target()
         # Gen module.
-        with compile_model(
+        with safe_compile_model(
             [X7],
             target,
             "./tmp",

--- a/tests/unittest/ops/test_gather.py
+++ b/tests/unittest/ops/test_gather.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -74,7 +74,7 @@ class GatherTestCase(unittest.TestCase):
         np.testing.assert_equal(y_shape, index_shape)
 
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         X_pt = get_random_torch_tensor(input_shape, input_type)

--- a/tests/unittest/ops/test_gemm.py
+++ b/tests/unittest/ops/test_gemm.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -59,7 +59,7 @@ class GEMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"gemm_rcr_{test_name}_{self._test_id}"
         )
         self._test_id += 1
@@ -117,7 +117,7 @@ class GEMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"gemm_rcr_{test_name}_{self._test_id}"
         )
         self._test_id += 1
@@ -171,7 +171,7 @@ class GEMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"gemm_3d_2d_rcr_{test_name}_{self._test_id}"
         )
         self._test_id += 1
@@ -209,7 +209,7 @@ class GEMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"gemm_rrr_{test_name}_{self._test_id}"
         )
         self._test_id += 1
@@ -248,7 +248,7 @@ class GEMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"gemm_rrr_{test_name}_{self._test_id}"
         )
         self._test_id += 1
@@ -280,7 +280,7 @@ class GEMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"hgemm_rcr_{ait_dtype}_{self._test_id}"
         )
         self._test_id += 1

--- a/tests/unittest/ops/test_gemm_bias.py
+++ b/tests/unittest/ops/test_gemm_bias.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -53,7 +53,7 @@ class GEMMBiasTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"gemm_rcr_bias_{test_name}_{self._test_id}"
         )
         self._test_id += 1

--- a/tests/unittest/ops/test_gemm_bias_broadcast.py
+++ b/tests/unittest/ops/test_gemm_bias_broadcast.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -65,7 +65,7 @@ class GEMMBiasBroadcastTestCase(unittest.TestCase):
         Y = OP(self.X, self.W, self.B, self.D0, self.D1)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"gemm_rcr_bias_mul_add_k_{k}_n_{n}_{dtype}"
         )
         Y_pt = (
@@ -90,7 +90,7 @@ class GEMMBiasBroadcastTestCase(unittest.TestCase):
         Y = OP(self.X, self.W, self.B, self.D0)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",
@@ -120,7 +120,7 @@ class GEMMBiasBroadcastTestCase(unittest.TestCase):
         Y = OP(self.X, self.W, self.B, self.D0)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",
@@ -151,7 +151,7 @@ class GEMMBiasBroadcastTestCase(unittest.TestCase):
         Y = OP(self.X, self.W, self.B, self.D0)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",
@@ -179,7 +179,7 @@ class GEMMBiasBroadcastTestCase(unittest.TestCase):
         Y = OP(self.X, self.W, self.B, self.D0)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",
@@ -207,7 +207,7 @@ class GEMMBiasBroadcastTestCase(unittest.TestCase):
         Y = OP(self.X, self.W, self.B, self.D0, self.D1)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",
@@ -243,7 +243,7 @@ class GEMMBiasBroadcastTestCase(unittest.TestCase):
         Y = OP(self.X, self.W, self.B, self.D0)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",
@@ -271,7 +271,7 @@ class GEMMBiasBroadcastTestCase(unittest.TestCase):
         Y = OP(self.X, self.W, self.B, self.D0, self.D1)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",
@@ -301,7 +301,7 @@ class GEMMBiasBroadcastTestCase(unittest.TestCase):
         Y = OP(self.X, self.W, self.B, self.D0)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",

--- a/tests/unittest/ops/test_gemm_bias_hardswish.py
+++ b/tests/unittest/ops/test_gemm_bias_hardswish.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -57,7 +57,7 @@ class GEMMBiasHardSwishTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
         test_name = f"gemm_rcr_bias_hardswish_{dtype}_{self._test_id}"
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         X_pt = get_random_torch_tensor([M, K], dtype)
         W_pt = get_random_torch_tensor([N, K], dtype)
         B_pt = get_random_torch_tensor([N], dtype)

--- a/tests/unittest/ops/test_gemm_bias_permute.py
+++ b/tests/unittest/ops/test_gemm_bias_permute.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -66,7 +66,7 @@ class GEMMBiasPermuteTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         X_pt = get_random_torch_tensor([M, K], dtype=dtype)
         W_pt = get_random_torch_tensor([N, K], dtype=dtype)
         B_pt = get_random_torch_tensor([N], dtype=dtype)
@@ -132,7 +132,7 @@ class GEMMBiasPermuteTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "gemm_rcr_bias_permute_m3n2")
+        module = safe_compile_model(Y, target, "./tmp", "gemm_rcr_bias_permute_m3n2")
         X_pt = get_random_torch_tensor([M, K], dtype=dtype)
         W_pt = get_random_torch_tensor([N, K], dtype=dtype)
         B_pt = get_random_torch_tensor([N], dtype=dtype)
@@ -191,7 +191,7 @@ class GEMMBiasPermuteTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "gemm_rcr_permute_m2n3")
+        module = safe_compile_model(Y, target, "./tmp", "gemm_rcr_permute_m2n3")
         X_pt = get_random_torch_tensor([M, K], dtype=dtype)
         W_pt = get_random_torch_tensor([N, K], dtype=dtype)
 
@@ -235,7 +235,7 @@ class GEMMBiasPermuteTestCase(unittest.TestCase):
     #     Y = OP(X, W, B)
     #     Y._attrs["name"] = "output_0"
     #     Y._attrs["is_output"] = True
-    #     module = compile_model(Y, target, "./tmp", "gemm_rcr_bias_permute")
+    #     module = safe_compile_model(Y, target, "./tmp", "gemm_rcr_bias_permute")
     #     X_pt = torch.randn(M, K).cuda().half()
     #     W_pt = torch.randn(N, K).cuda().half()
     #     B_pt = torch.randn(N).cuda().half()
@@ -266,7 +266,7 @@ class GEMMBiasPermuteTestCase(unittest.TestCase):
     #     Y = OP(X, W, B)
     #     Y._attrs["name"] = "output_0"
     #     Y._attrs["is_output"] = True
-    #     module = compile_model(Y, target, "./tmp", "gemm_rrr_bias_permute")
+    #     module = safe_compile_model(Y, target, "./tmp", "gemm_rrr_bias_permute")
     #     X_pt = torch.randn(M, K).cuda().half()
     #     W_pt = torch.randn(K, N).cuda().half()
     #     B_pt = torch.randn(N).cuda().half()

--- a/tests/unittest/ops/test_gemm_bias_relu.py
+++ b/tests/unittest/ops/test_gemm_bias_relu.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -53,7 +53,7 @@ class GEMMBiasReluTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
         test_name = f"gemm_rcr_bias_relu_{dtype}_{self._test_id}"
         self._test_id += 1
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         X_pt = get_random_torch_tensor([M, K], dtype)
         W_pt = get_random_torch_tensor([N, K], dtype)
         B_pt = get_random_torch_tensor([N], dtype)
@@ -93,7 +93,7 @@ class GEMMBiasReluTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
         test_name = f"gemm_rcr_bias_add_relu_{dtype}_{self._test_id}"
         self._test_id += 1
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         X_pt = get_random_torch_tensor([M, K], dtype)
         W_pt = get_random_torch_tensor([N, K], dtype)
         B_pt = get_random_torch_tensor([N], dtype)

--- a/tests/unittest/ops/test_gemm_bias_sigmoid.py
+++ b/tests/unittest/ops/test_gemm_bias_sigmoid.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -53,7 +53,7 @@ class GEMMBiasSigmoidTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
         test_name = f"gemm_rcr_bias_sigmoid_{dtype}_{self._test_id}"
         self._test_id += 1
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         X_pt = get_random_torch_tensor([M, K], dtype)
         W_pt = get_random_torch_tensor([N, K], dtype)
         B_pt = get_random_torch_tensor([N], dtype)

--- a/tests/unittest/ops/test_gemm_bias_softmax.py
+++ b/tests/unittest/ops/test_gemm_bias_softmax.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import torch
-from aitemplate.compiler import compile_model, Model, ops
+from aitemplate.compiler import Model, ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -59,7 +59,7 @@ class GEMMBiasSoftmaxTestCase(unittest.TestCase):
         test_name = f"gemm_bias_softmax_{dtype}"
         if rebuild:
             target = detect_target()
-            module = compile_model(Y, target, "./tmp", test_name)
+            module = safe_compile_model(Y, target, "./tmp", test_name)
         else:
             module = Model(os.path.join("./tmp", test_name, "test.so"))
         inputs = {"input_0": X_pt, "input_1": W_pt, "input_2": B_pt}

--- a/tests/unittest/ops/test_gemm_bias_swish.py
+++ b/tests/unittest/ops/test_gemm_bias_swish.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -55,7 +55,7 @@ class GEMMBiasSwishTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
         test_name = f"gemm_rcr_bias_swish_{dtype}_{self._test_id}"
         self._test_id += 1
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         X_pt = get_random_torch_tensor([M, K], dtype)
         W_pt = get_random_torch_tensor([N, K], dtype)
         B_pt = get_random_torch_tensor([N], dtype)

--- a/tests/unittest/ops/test_gemm_bias_tanh.py
+++ b/tests/unittest/ops/test_gemm_bias_tanh.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -57,7 +57,7 @@ class GEMMBiasTanhTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"gemm_rcr_bias_tanh_{test_name}_{self._test_id}"
         )
         self._test_id += 1

--- a/tests/unittest/ops/test_gemm_permute.py
+++ b/tests/unittest/ops/test_gemm_permute.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -72,7 +72,7 @@ class GEMMPermuteTestCase(unittest.TestCase):
             Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         for m in ms:
@@ -148,7 +148,7 @@ class GEMMPermuteTestCase(unittest.TestCase):
             Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         for m in ms:
@@ -230,7 +230,7 @@ class GEMMPermuteTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         for m in ms:

--- a/tests/unittest/ops/test_gemm_profiler_cache.py
+++ b/tests/unittest/ops/test_gemm_profiler_cache.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 from aitemplate.backend.profiler_cache import ProfileCacheDB
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 
@@ -60,7 +60,7 @@ class GemmProfilerCacheTestCase(unittest.TestCase):
             logger=logger,
             level="INFO",
         ) as logs:
-            compile_model(
+            safe_compile_model(
                 Y,
                 target,
                 "./tmp",

--- a/tests/unittest/ops/test_gemm_rcr_bias_fast_gelu.py
+++ b/tests/unittest/ops/test_gemm_rcr_bias_fast_gelu.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -53,7 +53,7 @@ class GEMMRcrBiasFastGeluTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             Y,
             target,
             "./tmp",

--- a/tests/unittest/ops/test_gemm_rcr_fast_gelu.py
+++ b/tests/unittest/ops/test_gemm_rcr_fast_gelu.py
@@ -18,7 +18,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -73,7 +73,9 @@ class GEMMRcrFastGeluTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", f"gemm_rcr_fast_gelu_{test_name}")
+        module = safe_compile_model(
+            Y, target, "./tmp", f"gemm_rcr_fast_gelu_{test_name}"
+        )
 
         for M in Ms:
             logging.info(f"Testing {M=}")

--- a/tests/unittest/ops/test_gemm_rrr_small_nk.py
+++ b/tests/unittest/ops/test_gemm_rrr_small_nk.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -48,7 +48,7 @@ class GEMMRrrSmallNKTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"gemm_rrr_small_nk_{self.test_count}"
         )
 

--- a/tests/unittest/ops/test_gemm_softmax.py
+++ b/tests/unittest/ops/test_gemm_softmax.py
@@ -18,7 +18,7 @@ import unittest
 
 import numpy as np
 import torch
-from aitemplate.compiler import compile_model, Model, ops
+from aitemplate.compiler import Model, ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -55,7 +55,7 @@ class GEMMSoftmaxTestCase(unittest.TestCase):
         test_name = f"gemm_softmax_{dtype}"
         if rebuild:
             target = detect_target()
-            module = compile_model(Y, target, "./tmp", test_name)
+            module = safe_compile_model(Y, target, "./tmp", test_name)
         else:
             module = Model(os.path.join("./tmp", test_name, "test.so"))
         inputs = {"input_0": X_pt, "input_1": W_pt}

--- a/tests/unittest/ops/test_group_gemm_rcr.py
+++ b/tests/unittest/ops/test_group_gemm_rcr.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -69,7 +69,7 @@ class GroupGEMMRcrTestCase(unittest.TestCase):
             Y3._attrs["is_output"] = True
             graph_outputs.append(Y3)
 
-        module = compile_model(graph_outputs, target, "./tmp", test_name)
+        module = safe_compile_model(graph_outputs, target, "./tmp", test_name)
         X1_pt = get_random_torch_tensor(shape=(M, K1), dtype=dtype)
         X2_pt = get_random_torch_tensor(shape=(M, K2), dtype=dtype)
         W1_pt = get_random_torch_tensor(shape=(N1, K1), dtype=dtype)

--- a/tests/unittest/ops/test_group_gemm_rcr_bias.py
+++ b/tests/unittest/ops/test_group_gemm_rcr_bias.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -59,7 +59,7 @@ class GroupGEMMRcrBiasTestCase(unittest.TestCase):
         Y1._attrs["is_output"] = True
         Y2._attrs["name"] = "y2"
         Y2._attrs["is_output"] = True
-        module = compile_model([Y1, Y2], target, "./tmp", test_name)
+        module = safe_compile_model([Y1, Y2], target, "./tmp", test_name)
         X1_pt = get_random_torch_tensor(shape=(M, K1), dtype=dtype)
         X2_pt = get_random_torch_tensor(shape=(M, K2), dtype=dtype)
         W1_pt = get_random_torch_tensor(shape=(N1, K1), dtype=dtype)

--- a/tests/unittest/ops/test_group_gemm_rcr_bias_activation.py
+++ b/tests/unittest/ops/test_group_gemm_rcr_bias_activation.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -66,7 +66,7 @@ class GroupGEMMRcrBiasActTestCase(unittest.TestCase):
         Y1._attrs["is_output"] = True
         Y2._attrs["name"] = "y2"
         Y2._attrs["is_output"] = True
-        module = compile_model([Y1, Y2], target, "./tmp", test_name)
+        module = safe_compile_model([Y1, Y2], target, "./tmp", test_name)
         X1_pt = get_random_torch_tensor(shape=(M, K1), dtype=dtype)
         X2_pt = get_random_torch_tensor(shape=(M, K2), dtype=dtype)
         W1_pt = get_random_torch_tensor(shape=(N1, K1), dtype=dtype)

--- a/tests/unittest/ops/test_group_gemm_rcr_bias_cat.py
+++ b/tests/unittest/ops/test_group_gemm_rcr_bias_cat.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -56,7 +56,7 @@ class GroupGEMMRcrBiasCatTestCase(unittest.TestCase):
         Y = OP(operand_groups=[[X1, W1, B1], [X2, W2, B2]], output_stride_dim=1)
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
-        module = compile_model([Y], target, "./tmp", test_name)
+        module = safe_compile_model([Y], target, "./tmp", test_name)
         X1_pt = get_random_torch_tensor(shape=(M, K1), dtype=dtype)
         X2_pt = get_random_torch_tensor(shape=(M, K2), dtype=dtype)
         W1_pt = get_random_torch_tensor(shape=(N1, K1), dtype=dtype)

--- a/tests/unittest/ops/test_group_gemm_rcr_cat.py
+++ b/tests/unittest/ops/test_group_gemm_rcr_cat.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -54,7 +54,7 @@ class GroupGEMMRcrCatTestCase(unittest.TestCase):
         Y = OP(operand_groups=[[X1, W1], [X2, W2]], output_stride_dim=1)
         Y._attrs["name"] = "y"
         Y._attrs["is_output"] = True
-        module = compile_model([Y], target, "./tmp", test_name)
+        module = safe_compile_model([Y], target, "./tmp", test_name)
 
         X1_pt = get_random_torch_tensor(shape=(M, K1), dtype=dtype)
         X2_pt = get_random_torch_tensor(shape=(M, K2), dtype=dtype)

--- a/tests/unittest/ops/test_groupnorm.py
+++ b/tests/unittest/ops/test_groupnorm.py
@@ -20,7 +20,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -81,7 +81,7 @@ class GroupnormTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(X4, target, "./tmp", op_name, dll_name=dll_name)
+        module = safe_compile_model(X4, target, "./tmp", op_name, dll_name=dll_name)
 
         x1_nhwc_pt = get_random_torch_tensor(x_shape, dtype)
         x1_nchw_pt = x1_nhwc_pt.permute(0, 3, 1, 2).contiguous()

--- a/tests/unittest/ops/test_int_elementwise_dynamic_reshape.py
+++ b/tests/unittest/ops/test_int_elementwise_dynamic_reshape.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm, IntVarTensor
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
@@ -53,7 +53,7 @@ class IntElementwiseReshapeOpTestCase(unittest.TestCase):
         Y = ops.reshape()(X, [Y6, Y4, Y5])
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         for b, x1 in zip(batch_size, x1_size):
             X_shape_pt = (b, x1, *X_shape)
@@ -114,7 +114,7 @@ class IntElementwiseReshapeOpTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         for b, x1, x2, x3 in zip(batch_size, x1_size, x2_size, x3_size):
             X_shape_pt = (b, x1, x2, x3)
@@ -168,7 +168,7 @@ class IntElementwiseReshapeOpTestCase(unittest.TestCase):
         Y = ops.reshape()(X, [Y2 * Y3 * f1 / f2, f2])
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         for b, x1 in zip(batch_size, x1_size):
             X_shape_pt = (b, x1, *X_shape)
@@ -229,7 +229,7 @@ class IntElementwiseReshapeOpTestCase(unittest.TestCase):
         Y = ops.elementwise(FuncEnum.ADD)(Y5, X1)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         for b in batch_size:
             X_shape_pt = (b, *X_shape)

--- a/tests/unittest/ops/test_jagged_elementwise.py
+++ b/tests/unittest/ops/test_jagged_elementwise.py
@@ -20,7 +20,7 @@ from typing import List
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import JaggedDim
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntImm, IntVar, Tensor
@@ -110,7 +110,7 @@ class JaggedElementwiseTestCase(unittest.TestCase):
         assert JAGGED.is_jagged()
         assert RESULT.is_jagged()
 
-        model = compile_model(
+        model = safe_compile_model(
             [RESULT],
             detect_target(use_jagged_space_indexing=use_jagged_space_indexing),
             "./tmp",
@@ -345,7 +345,7 @@ class JaggedElementwiseTestCase(unittest.TestCase):
         assert JAGGED2.is_jagged()
         assert RESULT.is_jagged()
 
-        model = compile_model(
+        model = safe_compile_model(
             [RESULT],
             detect_target(),
             "./tmp",
@@ -492,7 +492,7 @@ class JaggedElementwiseTestCase(unittest.TestCase):
         RESULT._attrs["name"] = "result"
         RESULT._attrs["is_output"] = True
 
-        model = compile_model(
+        model = safe_compile_model(
             [RESULT],
             detect_target(use_jagged_space_indexing=use_jagged_space_indexing),
             "./tmp",

--- a/tests/unittest/ops/test_jagged_to_padded_dense.py
+++ b/tests/unittest/ops/test_jagged_to_padded_dense.py
@@ -26,7 +26,7 @@ import aitemplate.testing.jagged_utils as jagged_utils
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import JaggedDim
 from aitemplate.frontend import IntImm, IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -98,7 +98,7 @@ class JaggedToPaddedDenseTestCase(unittest.TestCase):
         assert JAGGED.is_jagged()
         assert not RESULT.is_jagged()
 
-        model = compile_model(
+        model = safe_compile_model(
             [RESULT],
             detect_target(),
             "./tmp",
@@ -229,7 +229,7 @@ class JaggedToPaddedDenseTestCase(unittest.TestCase):
         RESULT._attrs["name"] = "result"
         RESULT._attrs["is_output"] = True
 
-        model = compile_model(
+        model = safe_compile_model(
             [RESULT],
             detect_target(),
             "./tmp",

--- a/tests/unittest/ops/test_layernorm.py
+++ b/tests/unittest/ops/test_layernorm.py
@@ -20,7 +20,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm, IntVar
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -98,7 +98,7 @@ class LayernormTestCase(unittest.TestCase):
 
         target = detect_target()
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(X4, target, "./tmp", "layernorm", dll_name=dll_name)
+        module = safe_compile_model(X4, target, "./tmp", "layernorm", dll_name=dll_name)
 
         for batch_size in [50, 900, 1024]:
             x1_pt = torch.randn(batch_size, *MS, *NS, dtype=torch_dtype).cuda()

--- a/tests/unittest/ops/test_layernorm_sigmoid_mul.py
+++ b/tests/unittest/ops/test_layernorm_sigmoid_mul.py
@@ -20,7 +20,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm, IntVar
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
@@ -96,7 +96,7 @@ class FusedLayernormSigmoidMulTestCase(unittest.TestCase):
         X6._attrs["name"] = "output"
 
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             X6,
             target,
             "./tmp",
@@ -424,7 +424,7 @@ class FusedLayernormSigmoidMulTestCase(unittest.TestCase):
         X4._attrs["name"] = "output"
 
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             X4,
             target,
             "./tmp",
@@ -530,7 +530,7 @@ class FusedLayernormSigmoidMulTestCase(unittest.TestCase):
         X4._attrs["name"] = "output"
 
         target = detect_target()
-        with compile_model(
+        with safe_compile_model(
             X4,
             target,
             "./tmp",
@@ -761,7 +761,7 @@ class FusedLayernormSigmoidMulTestCase(unittest.TestCase):
 
         target = detect_target()
 
-        with compile_model(
+        with safe_compile_model(
             Ys,
             target,
             "./tmp",

--- a/tests/unittest/ops/test_make_jagged.py
+++ b/tests/unittest/ops/test_make_jagged.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import JaggedDim, JaggedIntVar
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntImm, IntVar, Tensor
@@ -98,7 +98,7 @@ class MakeJaggedTestCase(unittest.TestCase):
         Z._attrs["name"] = "Z"
         Z._attrs["is_output"] = True
 
-        model = compile_model([Y, Z], detect_target(), "./tmp", test_name)
+        model = safe_compile_model([Y, Z], detect_target(), "./tmp", test_name)
 
         offsets1_pt = torch.tensor([0, 1, 3, 5], dtype=torch.int32).cuda()
         offsets2_pt = torch.tensor([0, 2, 4, 4, 7, 10], dtype=torch.int32).cuda()
@@ -204,7 +204,7 @@ class MakeJaggedTestCase(unittest.TestCase):
         RESULT._attrs["name"] = "result"
         RESULT._attrs["is_output"] = True
 
-        model = compile_model(
+        model = safe_compile_model(
             [RESULT],
             detect_target(),
             "./tmp",

--- a/tests/unittest/ops/test_masked_select.py
+++ b/tests/unittest/ops/test_masked_select.py
@@ -18,7 +18,7 @@ Unittests for masked_select Operator.
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.benchmark_pt import benchmark_torch_function
@@ -61,7 +61,7 @@ class maskedSelectTestCase(unittest.TestCase):
         X4._attrs["name"] = "output_values"
 
         target = detect_target()
-        module = compile_model([X4], target, "./tmp", test_name)
+        module = safe_compile_model([X4], target, "./tmp", test_name)
         x = get_random_torch_tensor(shape, dtype=dtype)
         if zero_mask:
             mask = torch.zeros_like(x)
@@ -208,7 +208,7 @@ class maskedSelectTestCase(unittest.TestCase):
         X4._attrs["name"] = "output_values"
 
         target = detect_target()
-        module = compile_model([X4], target, "./tmp", test_name)
+        module = safe_compile_model([X4], target, "./tmp", test_name)
 
         x = get_random_torch_tensor(shape, dtype=dtype)
         mask = get_random_torch_tensor(shape, dtype="float16") > 0

--- a/tests/unittest/ops/test_max_pool2d.py
+++ b/tests/unittest/ops/test_max_pool2d.py
@@ -15,7 +15,7 @@
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model
+from aitemplate.compiler import safe_compile_model
 
 from aitemplate.frontend import IntVar, nn, Tensor
 from aitemplate.testing import detect_target
@@ -36,7 +36,7 @@ class MaxPool2dTestCase(unittest.TestCase):
         Y = OP(X)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "max_pool2d")
+        module = safe_compile_model(Y, target, "./tmp", "max_pool2d")
         for batch in batch_size:
             X_pt = get_random_torch_tensor([batch, 64, 112, 112], dtype=dtype)
             OP_pt = torch.nn.MaxPool2d(kernel_size=3, stride=2, padding=1)

--- a/tests/unittest/ops/test_ndhwc3to8.py
+++ b/tests/unittest/ops/test_ndhwc3to8.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import torch
-from aitemplate.compiler import compile_model
+from aitemplate.compiler import safe_compile_model
 
 from aitemplate.frontend import IntVar, nn, Tensor
 from aitemplate.testing import detect_target
@@ -39,7 +39,7 @@ class Ndhcw3To8TestCase(unittest.TestCase):
         Y = OP(X)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "ndhwc3to8")
+        module = safe_compile_model(Y, target, "./tmp", "ndhwc3to8")
         for batch in batch_size:
             X_np = np.random.uniform(-1, 1, (batch, 4, 224, 224, 3)).astype("float16")
             Y_np = np.zeros((batch, 4, 224, 224, 8)).astype("float16")

--- a/tests/unittest/ops/test_nhwc3to4.py
+++ b/tests/unittest/ops/test_nhwc3to4.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -39,7 +39,7 @@ class Nhcw3To4TestCase(unittest.TestCase):
         Y = OP(X)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "nhwc3to4")
+        module = safe_compile_model(Y, target, "./tmp", "nhwc3to4")
         for batch in batch_size:
             X_np = np.random.uniform(-1, 1, (batch, 224, 224, 3)).astype(dtype)
             Y_np = np.zeros((batch, 224, 224, 4)).astype(dtype)

--- a/tests/unittest/ops/test_nhwc3to8.py
+++ b/tests/unittest/ops/test_nhwc3to8.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import torch
-from aitemplate.compiler import compile_model
+from aitemplate.compiler import safe_compile_model
 
 from aitemplate.frontend import IntVar, nn, Tensor
 from aitemplate.testing import detect_target
@@ -39,7 +39,7 @@ class Nhcw3To8TestCase(unittest.TestCase):
         Y = OP(X)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "nhwc3to8")
+        module = safe_compile_model(Y, target, "./tmp", "nhwc3to8")
         for batch in batch_size:
             X_np = np.random.uniform(-1, 1, (batch, 224, 224, 3)).astype("float16")
             Y_np = np.zeros((batch, 224, 224, 8)).astype("float16")

--- a/tests/unittest/ops/test_nms.py
+++ b/tests/unittest/ops/test_nms.py
@@ -21,7 +21,7 @@ from unittest import skipIf
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.utils.torch_utils import string_to_torch_dtype
@@ -129,7 +129,7 @@ class nmsTestCase(unittest.TestCase):
         X4._attrs["is_output"] = True
         X4._attrs["name"] = "output"
 
-        module = compile_model(X4, target, "./tmp", test_name)
+        module = safe_compile_model(X4, target, "./tmp", test_name)
 
         torch_dtype = string_to_torch_dtype(dtype)
         boxes, scores = self._create_tensors(N, dtype=dtype)
@@ -219,7 +219,7 @@ class nmsTestCase(unittest.TestCase):
         Y[1]._attrs["is_output"] = True
         Y[1]._attrs["name"] = "output_1"
 
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         torch_dtype = string_to_torch_dtype(dtype)
         boxes, scores = self._create_tensors(N, dtype=dtype)

--- a/tests/unittest/ops/test_norm.py
+++ b/tests/unittest/ops/test_norm.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, IntVar, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -63,7 +63,7 @@ class VectorNormTestCase(unittest.TestCase):
         logging.info("AITemplate output_shape: {}".format(y_shape))
         logging.info("AITemplate output_type: {}".format(y_dtype))
 
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
         X_pt = get_random_torch_tensor(input_shape, input_type)
         output_dtype_pt = (
             string_to_torch_dtype(output_type)
@@ -305,7 +305,7 @@ class VectorNormTestCase(unittest.TestCase):
             if output_type is not None
             else string_to_torch_dtype(input_type)
         )
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         for B in [5, 128, 1024, 1237, 2002]:
             input_shape = [M, B, N]

--- a/tests/unittest/ops/test_pad_last_dim.py
+++ b/tests/unittest/ops/test_pad_last_dim.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -51,7 +51,7 @@ class PadLastDim(unittest.TestCase):
         Y._attrs["is_output"] = True
         Y._attrs["name"] = "output"
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([NN, HH, WW, CI], dtype=dtype)
         Pad_pt = get_torch_zeros_tensor([NN, HH, WW, CO - CI], dtype=dtype)
@@ -106,7 +106,7 @@ class PadLastDim(unittest.TestCase):
         Y._attrs["is_output"] = True
         Y._attrs["name"] = "output"
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([NN, CI], dtype=dtype)
         Pad_pt = get_torch_zeros_tensor([NN, CO - CI], dtype=dtype)

--- a/tests/unittest/ops/test_padded_dense_to_jagged.py
+++ b/tests/unittest/ops/test_padded_dense_to_jagged.py
@@ -26,7 +26,7 @@ import aitemplate.testing.jagged_utils as jagged_utils
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import JaggedDim
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntImm, IntVar, Tensor
@@ -114,7 +114,7 @@ class PaddedDenseToJaggedTestCase(unittest.TestCase):
         assert ANOTHER.is_jagged()
         assert RESULT.is_jagged()
 
-        model = compile_model(
+        model = safe_compile_model(
             [RESULT],
             detect_target(use_jagged_space_indexing=use_jagged_space_indexing),
             "./tmp",
@@ -265,7 +265,7 @@ class PaddedDenseToJaggedTestCase(unittest.TestCase):
         RESULT._attrs["name"] = "result"
         RESULT._attrs["is_output"] = True
 
-        model = compile_model(
+        model = safe_compile_model(
             [RESULT],
             detect_target(use_jagged_space_indexing=use_jagged_space_indexing),
             "./tmp",

--- a/tests/unittest/ops/test_perm021fc_ccr.py
+++ b/tests/unittest/ops/test_perm021fc_ccr.py
@@ -22,7 +22,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -59,7 +59,7 @@ class Perm021FCCCRTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([B, K, M], dtype=dtype)
         W_pt = get_random_torch_tensor([N, K], dtype=dtype)

--- a/tests/unittest/ops/test_perm021fc_ccr_bias.py
+++ b/tests/unittest/ops/test_perm021fc_ccr_bias.py
@@ -22,7 +22,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -66,7 +66,7 @@ class Perm021FCCCRBiasTestCase(unittest.TestCase):
         Y = OP(X, W, BIAS)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([B, K, M], dtype=dtype)
         W_pt = get_random_torch_tensor([N, K], dtype=dtype)

--- a/tests/unittest/ops/test_perm021fc_ccr_bias_perm021.py
+++ b/tests/unittest/ops/test_perm021fc_ccr_bias_perm021.py
@@ -22,7 +22,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -65,7 +65,7 @@ class Perm021FCCCRBiasPerm021TestCase(unittest.TestCase):
         Y = OP(X, W, BIAS)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([B, K, M], dtype=dtype)
         W_pt = get_random_torch_tensor([N, K], dtype=dtype)

--- a/tests/unittest/ops/test_perm021fc_crc.py
+++ b/tests/unittest/ops/test_perm021fc_crc.py
@@ -22,7 +22,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -59,7 +59,7 @@ class Perm021FCCRCTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([B, K, M], dtype=dtype)
         W_pt = get_random_torch_tensor([N, K], dtype=dtype)

--- a/tests/unittest/ops/test_perm021fc_crc_bias.py
+++ b/tests/unittest/ops/test_perm021fc_crc_bias.py
@@ -22,7 +22,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 
@@ -69,7 +69,7 @@ class Perm021FCCRCBiasTestCase(unittest.TestCase):
         Y = OP(X, W, BIAS)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([B, K, M], dtype=dtype)
         W_pt = get_random_torch_tensor([N, K], dtype=dtype)

--- a/tests/unittest/ops/test_perm102_bmm_rcr.py
+++ b/tests/unittest/ops/test_perm102_bmm_rcr.py
@@ -25,7 +25,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -58,7 +58,7 @@ class Perm102BMM_RCR_TestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"perm102_bmm_rcr_{dtype}")
+        module = safe_compile_model(Y, target, "./tmp", f"perm102_bmm_rcr_{dtype}")
 
         X_pt = get_random_torch_tensor(shape=(M, B, K), dtype=dtype)
         W_pt = get_random_torch_tensor(shape=(B, N, K), dtype=dtype)
@@ -95,7 +95,7 @@ class Perm102BMM_RCR_BiasTestCase(unittest.TestCase):
         Y = OP(X, W, BIAS)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", f"perm102_bmm_rcr_bias_{dtype}")
+        module = safe_compile_model(Y, target, "./tmp", f"perm102_bmm_rcr_bias_{dtype}")
 
         X_pt = get_random_torch_tensor(shape=(M, B, K), dtype=dtype)
         W_pt = get_random_torch_tensor(shape=(B, N, K), dtype=dtype)

--- a/tests/unittest/ops/test_perm102_bmm_rrr.py
+++ b/tests/unittest/ops/test_perm102_bmm_rrr.py
@@ -25,7 +25,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -58,7 +58,7 @@ class Perm102BMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "perm102_bmm_rrr")
+        module = safe_compile_model(Y, target, "./tmp", "perm102_bmm_rrr")
 
         X_pt = get_random_torch_tensor(shape=(M, B, K), dtype=dtype)
         W_pt = get_random_torch_tensor(shape=(B, K, N), dtype=dtype)
@@ -95,7 +95,7 @@ class Perm102BMMBiasTestCase(unittest.TestCase):
         Y = OP(X, W, BIAS)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "perm102_bmm_rrr_bias")
+        module = safe_compile_model(Y, target, "./tmp", "perm102_bmm_rrr_bias")
 
         X_pt = get_random_torch_tensor(shape=(M, B, K), dtype=dtype)
         W_pt = get_random_torch_tensor(shape=(B, K, N), dtype=dtype)

--- a/tests/unittest/ops/test_permute.py
+++ b/tests/unittest/ops/test_permute.py
@@ -17,7 +17,7 @@ from typing import Sequence
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.utils.torch_utils import torch_dtype_to_string
@@ -44,7 +44,7 @@ class GenericPermuteTest(unittest.TestCase):
         Y._attrs["is_output"] = True
         Y._attrs["name"] = "output"
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", f"{testname}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{testname}_{self._test_id}")
         self._test_id += 1
 
         X_pt = torch.randn(input_shapes, dtype=torch_dtype).cuda()

--- a/tests/unittest/ops/test_permute021.py
+++ b/tests/unittest/ops/test_permute021.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -46,7 +46,7 @@ class Permute021Test(unittest.TestCase):
         Y._attrs["is_output"] = True
         Y._attrs["name"] = "output"
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         batch_dim = input_shape[0]

--- a/tests/unittest/ops/test_permute0213.py
+++ b/tests/unittest/ops/test_permute0213.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -45,7 +45,7 @@ class Permute0213Test(unittest.TestCase):
         Y._attrs["is_output"] = True
         Y._attrs["name"] = "output"
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", f"perm0213_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"perm0213_{self._test_id}")
         self._test_id += 1
 
         batch_dim = input_shape[0]

--- a/tests/unittest/ops/test_permute102.py
+++ b/tests/unittest/ops/test_permute102.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -45,7 +45,7 @@ class Permute102Test(unittest.TestCase):
         Y._attrs["is_output"] = True
         Y._attrs["name"] = "output"
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", f"perm102_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"perm102_{self._test_id}")
         self._test_id += 1
 
         batch_dim = input_shape[0]

--- a/tests/unittest/ops/test_permute210.py
+++ b/tests/unittest/ops/test_permute210.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -45,7 +45,7 @@ class Permute210Test(unittest.TestCase):
         Y._attrs["is_output"] = True
         Y._attrs["name"] = "output"
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", f"perm210_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"perm210_{self._test_id}")
         self._test_id += 1
 
         batch_dim = input_shape[0]

--- a/tests/unittest/ops/test_proposal.py
+++ b/tests/unittest/ops/test_proposal.py
@@ -19,7 +19,7 @@ import unittest
 
 import numpy.random as npr
 import torch
-from aitemplate.compiler import compile_model
+from aitemplate.compiler import safe_compile_model
 
 from aitemplate.frontend import nn, Tensor
 from aitemplate.testing import detect_target
@@ -489,7 +489,7 @@ class ProposalTestCase(unittest.TestCase):
 
         y = OP(X_bbox_deltas, X_scores)
         mark_output(y)
-        module = compile_model(y, target, "./tmp", test_name)
+        module = safe_compile_model(y, target, "./tmp", test_name)
 
         anchors = torch.from_numpy(OP._anchors.copy()).cuda()
         batch_inds = torch.from_numpy(OP._batch_inds.copy()).cuda()

--- a/tests/unittest/ops/test_reduce.py
+++ b/tests/unittest/ops/test_reduce.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -71,7 +71,7 @@ class ReduceTestCase(unittest.TestCase):
         _LOGGER.info("AITemplate output_type: {}".format(y_dtype))
 
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         X_pt = get_random_torch_tensor(input_shape, input_type)
         dtype_pt = string_to_torch_dtype(output_type)
         if keepdim is None:
@@ -414,7 +414,7 @@ class ReduceTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
 
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         for batch_size in batch_sizes:
             input_shape = [batch_size] + non_batch_shape
             X_pt = get_random_torch_tensor(input_shape, input_type)

--- a/tests/unittest/ops/test_reshape.py
+++ b/tests/unittest/ops/test_reshape.py
@@ -16,7 +16,7 @@ import itertools
 import unittest
 
 import torch
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntVarTensor
 
 from aitemplate.frontend import IntImm, IntVar, nn, Tensor
@@ -87,7 +87,7 @@ class ReshapeTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         for b in batch_size:
             # C, H, W
@@ -127,7 +127,7 @@ class ReshapeTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         # yank shape inference from op internals to let pt know what the real runtime shape will be
         x_shapes = list(itertools.product(*[var._attrs["values"] for var in X_shape]))

--- a/tests/unittest/ops/test_roi_align.py
+++ b/tests/unittest/ops/test_roi_align.py
@@ -17,7 +17,7 @@ from unittest import skipIf
 
 import numpy as np
 import torch
-from aitemplate.compiler import compile_model
+from aitemplate.compiler import safe_compile_model
 
 from aitemplate.frontend import IntVar, nn, Tensor
 from aitemplate.testing import detect_target
@@ -107,7 +107,7 @@ class RoiAlignTestCase(unittest.TestCase):
         Y = OP(X, R)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         for b in batch_size:
             X_pt = get_random_torch_tensor([b, CC, WW, HH], dtype=dtype)

--- a/tests/unittest/ops/test_size_getitem_ops.py
+++ b/tests/unittest/ops/test_size_getitem_ops.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -54,7 +54,7 @@ class SizeGetItemTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         for b in batch_size:
@@ -132,7 +132,7 @@ class SizeGetItemTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         self.assertEqual(len(module.debug_sorted_graph), 6)

--- a/tests/unittest/ops/test_slice.py
+++ b/tests/unittest/ops/test_slice.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntVarTensor
 from aitemplate.frontend import IntImm, IntVar, Tensor
 from aitemplate.testing import detect_target
@@ -67,7 +67,9 @@ class DynamicSliceTestCase(unittest.TestCase):
         logging.info("AITemplate output_0 shape: {}".format(y_shape))
         np.testing.assert_equal(y_shape, Y_pt.size())
 
-        module = compile_model(Y, target, "./tmp", f"dynamic_slice_{self.test_count}")
+        module = safe_compile_model(
+            Y, target, "./tmp", f"dynamic_slice_{self.test_count}"
+        )
 
         y_ait = torch.empty_like(Y_pt)
         module.run_with_tensors([X_pt], [y_ait])
@@ -207,7 +209,7 @@ class DynamicSliceBatchedTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(
+        module = safe_compile_model(
             Y, target, "./tmp", f"dynamic_slice_batched_{self.test_count}"
         )
 

--- a/tests/unittest/ops/test_softmax.py
+++ b/tests/unittest/ops/test_softmax.py
@@ -19,7 +19,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntVar
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -53,7 +53,7 @@ class SoftmaxTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
         Y._attrs["name"] = "output"
 
-        module = compile_model(Y, target, "./tmp", testname)
+        module = safe_compile_model(Y, target, "./tmp", testname)
 
         for batch_size in batch_sizes:
             x_pt = torch.randn(batch_size, *input_shapes, dtype=torch_dtype).cuda()

--- a/tests/unittest/ops/test_split.py
+++ b/tests/unittest/ops/test_split.py
@@ -17,7 +17,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -85,7 +85,7 @@ class SplitTestCase(unittest.TestCase):
             y_shapes.append(y_shape)
 
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Ys, target, "./tmp", "split", dll_name=dll_name)
+        module = safe_compile_model(Ys, target, "./tmp", "split", dll_name=dll_name)
 
         outputs = {
             f"output_{idx}": get_torch_empty_tensor(y_shape, input_type)
@@ -132,7 +132,7 @@ class SplitTestCase(unittest.TestCase):
             Y._attrs["is_output"] = True
 
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(Ys, target, "./tmp", "split", dll_name=dll_name)
+        module = safe_compile_model(Ys, target, "./tmp", "split", dll_name=dll_name)
 
         for batch in batch_sizes:
             logging.info(f"checking batch: {batch}")

--- a/tests/unittest/ops/test_split_getitem.py
+++ b/tests/unittest/ops/test_split_getitem.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -77,7 +77,7 @@ class SplitGetItemTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         for b in batch_size:
@@ -142,7 +142,7 @@ class SplitGetItemTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         for b in batch_size:
@@ -225,7 +225,7 @@ class SplitGetItemTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
 
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         for b in batch_size:

--- a/tests/unittest/ops/test_squeeze.py
+++ b/tests/unittest/ops/test_squeeze.py
@@ -17,7 +17,7 @@ import unittest
 from typing import List, Optional, Tuple
 
 import torch
-from aitemplate.compiler import compile_model
+from aitemplate.compiler import safe_compile_model
 
 from aitemplate.compiler.ops import elementwise, squeeze, unsqueeze
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
@@ -73,7 +73,7 @@ class SqueezeTestCase(unittest.TestCase):
         output._attrs["name"] = "output_0"
         output._attrs["is_output"] = True
 
-        module = compile_model(output, target, "./tmp", test_name)
+        module = safe_compile_model(output, target, "./tmp", test_name)
 
         all_input_0_shapes = itertools.product(*shape)
         all_input_1_shapes = itertools.product(*expected_shape)

--- a/tests/unittest/ops/test_topk.py
+++ b/tests/unittest/ops/test_topk.py
@@ -20,7 +20,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.utils.torch_utils import string_to_torch_dtype
@@ -64,7 +64,9 @@ class topkTestCase(unittest.TestCase):
         X4._attrs["name"] = "output"
 
         target = detect_target()
-        module = compile_model(X4, target, "./tmp", f"{test_name}_{self.test_count}")
+        module = safe_compile_model(
+            X4, target, "./tmp", f"{test_name}_{self.test_count}"
+        )
 
         scores = self._create_tensors(shape, dtype)
         (values, y_pt) = torch.topk(scores, k=topK, dim=dim)

--- a/tests/unittest/ops/test_transpose.py
+++ b/tests/unittest/ops/test_transpose.py
@@ -17,7 +17,7 @@ from typing import Sequence
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -49,7 +49,7 @@ class TransposeTest(unittest.TestCase):
         Y._attrs["is_output"] = True
         Y._attrs["name"] = "output"
         target = detect_target()
-        module = compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
+        module = safe_compile_model(Y, target, "./tmp", f"{test_name}_{self._test_id}")
         self._test_id += 1
 
         X_pt = get_random_torch_tensor(input_shape, dtype=dtype)

--- a/tests/unittest/ops/test_transpose_conv2d.py
+++ b/tests/unittest/ops/test_transpose_conv2d.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -52,7 +52,7 @@ class Conv2dTransposeTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, 256, 28, 28], dtype=dtype)
         W_pt = get_random_torch_tensor([256, 256, 2, 2], dtype=dtype)

--- a/tests/unittest/ops/test_transpose_conv2d_bias.py
+++ b/tests/unittest/ops/test_transpose_conv2d_bias.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -65,7 +65,7 @@ class Conv2dTransposeBiasTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, c_in, 14, 14], dtype=dtype)
         W_pt = get_random_torch_tensor([c_in, c_out, 2, 2], dtype=dtype)

--- a/tests/unittest/ops/test_transpose_conv2d_bias_relu.py
+++ b/tests/unittest/ops/test_transpose_conv2d_bias_relu.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
@@ -59,7 +59,7 @@ class Conv2dTransposeBiasReluTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor([batch, 256, 14, 14], dtype=dtype)
         W_pt = get_random_torch_tensor([256, 256, 2, 2], dtype=dtype)

--- a/tests/unittest/ops/test_tuple_list_construct.py
+++ b/tests/unittest/ops/test_tuple_list_construct.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -55,7 +55,7 @@ class TupleListConstructTestCase(unittest.TestCase):
         Y3._attrs["name"] = "output_2"
         Y3._attrs["is_output"] = True
 
-        module = compile_model([Y1, Y2, Y3], target, "./tmp", test_name)
+        module = safe_compile_model([Y1, Y2, Y3], target, "./tmp", test_name)
 
         for b in batch_size:
             X_shape_pt = (b, *X_shape)

--- a/tests/unittest/ops/test_upsamping2d.py
+++ b/tests/unittest/ops/test_upsamping2d.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model
+from aitemplate.compiler import safe_compile_model
 from aitemplate.frontend import IntVar, nn, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -47,7 +47,7 @@ class UpsamplingTestCase(unittest.TestCase):
         Y = OP(X)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         for b in batch_size:
             X_pt = get_random_torch_tensor([b, channels, HH, WW], dtype=dtype)

--- a/tests/unittest/ops/test_upsamping2d_add.py
+++ b/tests/unittest/ops/test_upsamping2d_add.py
@@ -16,7 +16,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model
+from aitemplate.compiler import safe_compile_model
 from aitemplate.frontend import IntVar, nn, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -60,7 +60,7 @@ class UpsamplingAddTestCase(unittest.TestCase):
         Y = OP(X, R)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         for b in batch_size:
             X_pt = get_random_torch_tensor([b, channels, HH, WW], dtype=dtype)

--- a/tests/unittest/ops/test_vanilla_attention.py
+++ b/tests/unittest/ops/test_vanilla_attention.py
@@ -23,7 +23,7 @@ import unittest
 import torch
 import torch.nn.functional as F
 
-from aitemplate.compiler import compile_model, Model
+from aitemplate.compiler import Model, safe_compile_model
 from aitemplate.frontend import nn, Tensor
 from aitemplate.frontend.nn.vanilla_attention import vanilla_attention
 from aitemplate.testing import detect_target
@@ -180,7 +180,7 @@ class VanillaAttentionTestCase(unittest.TestCase):
 
         if rebuild:
             target = detect_target()
-            module = compile_model(Y, target, "./tmp", test_name)
+            module = safe_compile_model(Y, target, "./tmp", test_name)
         else:
             module = Model(os.path.join("./tmp", test_name, "test.so"))
 
@@ -289,7 +289,7 @@ class VanillaAttentionTestCase(unittest.TestCase):
         Y = Y + inputs_ait
         mark_output(Y)
         target = detect_target(use_fp16_acc=False)
-        exe_module = compile_model(Y, target, "./tmp", "cross_attn_dynamic")
+        exe_module = safe_compile_model(Y, target, "./tmp", "cross_attn_dynamic")
         for name, weight in params_ait.items():
             exe_module.set_constant_with_tensor(name, weight)
 

--- a/tests/unittest/ops/test_var.py
+++ b/tests/unittest/ops/test_var.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.frontend import IntImm, IntVar, Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import get_random_torch_tensor
@@ -65,7 +65,7 @@ class VarTestCase(unittest.TestCase):
         logging.info("AITemplate output_shape: {}".format(y_shape))
         logging.info("AITemplate output_type: {}".format(y_dtype))
 
-        module = compile_model(Y, target, "./tmp", f"var_{self.test_count}")
+        module = safe_compile_model(Y, target, "./tmp", f"var_{self.test_count}")
         X_pt = get_random_torch_tensor(input_shape, input_type)
         if output_type is None:
             torch_dtype = None
@@ -129,7 +129,7 @@ class VarTestCase(unittest.TestCase):
         logging.info("AITemplate output_type: {}".format(y_dtype))
 
         test_name = "batched_var"
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = safe_compile_model(Y, target, "./tmp", test_name)
 
         for B in [5, 128, 1024, 1237, 2002]:
             input_shape = [M, B, N]

--- a/tests/unittest/util/test_debug_utils.py
+++ b/tests/unittest/util/test_debug_utils.py
@@ -20,7 +20,7 @@ import pytest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
@@ -45,7 +45,7 @@ def _test_inf_and_nan(
 
     target = detect_target()
     debug_settings = AITDebugSettings(check_all_nan_and_inf=check_all)
-    module = compile_model(
+    module = safe_compile_model(
         X2, target, "./tmp", test_name, debug_settings=debug_settings
     )
 
@@ -81,7 +81,7 @@ def _test_outputs(
 
     target = detect_target()
     debug_settings = AITDebugSettings(check_all_outputs=check_all)
-    module = compile_model(
+    module = safe_compile_model(
         X2, target, "./tmp", test_name, debug_settings=debug_settings
     )
 
@@ -128,7 +128,7 @@ def _test_special_outputs(
 
     target = detect_target()
     debug_settings = AITDebugSettings(check_all_outputs=check_all)
-    module = compile_model(
+    module = safe_compile_model(
         X2, target, "./tmp", test_name, debug_settings=debug_settings
     )
 

--- a/tests/unittest/util/test_serdes.py
+++ b/tests/unittest/util/test_serdes.py
@@ -20,7 +20,7 @@ import unittest
 
 import torch
 
-from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler import ops, safe_compile_model
 from aitemplate.compiler.base import IntImm, IntVar
 from aitemplate.compiler.ops.common.epilogue import FuncEnum
 from aitemplate.frontend import Tensor
@@ -91,7 +91,7 @@ class SerDesTestCase(unittest.TestCase):
         outputs, _ = get_program(test_path)
 
         target = detect_target()
-        module = compile_model(outputs, target, "./tmp", "simple_serdes")
+        module = safe_compile_model(outputs, target, "./tmp", "simple_serdes")
 
         x1_pt = torch.randn(3, 4).cuda().half()
         x2_pt = torch.randn(1).cuda().half()
@@ -120,7 +120,7 @@ class SerDesTestCase(unittest.TestCase):
         outputs, _ = get_program(test_path)
 
         target = detect_target()
-        module = compile_model(outputs, target, "./tmp", "serdes_multi_outputs")
+        module = safe_compile_model(outputs, target, "./tmp", "serdes_multi_outputs")
 
         y_shapes = [(4, 10), (4, 10)]
         outputs = {
@@ -151,7 +151,7 @@ class SerDesSpecialOpTestCase(unittest.TestCase):
         outputs, _ = get_program(test_path)
 
         target = detect_target()
-        module = compile_model(outputs, target, "./tmp", "serdes_elementwise")
+        module = safe_compile_model(outputs, target, "./tmp", "serdes_elementwise")
 
         x1_pt = torch.randn(3, 4).cuda().half()
         x2_pt = torch.clamp(x1_pt, max=0.5)
@@ -178,7 +178,7 @@ class SerDesSpecialOpTestCase(unittest.TestCase):
         outputs, _ = get_program(test_path)
 
         target = detect_target()
-        module = compile_model(outputs, target, "./tmp", "serdes_concat")
+        module = safe_compile_model(outputs, target, "./tmp", "serdes_concat")
 
         input_tensors_ait = {f"input_{idx}": X_pts[idx] for idx in range(5)}
         y = torch.empty_like(Y_pt)
@@ -202,7 +202,7 @@ class SerDesSpecialOpTestCase(unittest.TestCase):
         outputs, _ = get_program(test_path)
 
         target = detect_target()
-        module = compile_model(outputs, target, "./tmp", "serdes_reshape")
+        module = safe_compile_model(outputs, target, "./tmp", "serdes_reshape")
 
         X_pt = torch.randn(5, 4, 6, 8).cuda().half()
         Y_pt = torch.reshape(X_pt, (-1, 6, 32))
@@ -232,7 +232,7 @@ class SerDesSpecialOpTestCase(unittest.TestCase):
         test_path = "./tmp/test_serdes_group_gemm.py"
         dump_program([Y1, Y2], test_path)
         outputs, _ = get_program(test_path)
-        module = compile_model(outputs, target, "./tmp", "serdes_group_gemm")
+        module = safe_compile_model(outputs, target, "./tmp", "serdes_group_gemm")
 
         X1_pt = torch.randn(M, K1).cuda().half()
         X2_pt = torch.randn(M, K2).cuda().half()
@@ -275,7 +275,7 @@ class SerDesSpecialOpTestCase(unittest.TestCase):
         outputs, _ = get_program(test_path)
 
         target = detect_target()
-        module = compile_model(outputs, target, "./tmp", "serdes_dynamic_slice")
+        module = safe_compile_model(outputs, target, "./tmp", "serdes_dynamic_slice")
 
         for batch in batch_sizes:
             # generate torch reference result


### PR DESCRIPTION
Summary:
This diff extends D44374161 in the following ways:

one criticism with respect to compile_model locking it's build dir is, that this is kind of unexpected behavior and not part of the function's core functionality.

So I factored out the locking into an outer function called **safe_compile_model** which can act as a drop-in replacement for compile_model, but locks the build_directory and then delegates to compile_model.

Additionally, all references to compile_model in unit tests were replaced by references to safe_compile_model.

Differential Revision: D44421367

