### PR TITLE
full: pass input dtype when dtype is None

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -1623,11 +1623,11 @@ def acc_ops_tile(
     input_dim_len = len(input_val.shape())
     result = input_val
     if len(shape_dims) < input_dim_len:
-        for i in range(input_dim_len - len(shape_dims)):
+        for _ in range(input_dim_len - len(shape_dims)):
             shape_dims.insert(0, 1)
     if input_dim_len < len(shape_dims):
         shape = input_val.shape()
-        for i in range(len(shape_dims) - input_dim_len):
+        for _ in range(len(shape_dims) - input_dim_len):
             shape.insert(0, IntImm(1))
         result = expand()(input_val, shape)
 
@@ -1674,7 +1674,11 @@ def acc_ops_new_full(
     if not isinstance(input_val, AITTensor):
         raise RuntimeError(f"Non-tensor inputs for {name}: {input_val}")
     size = kwargs["size"]
-    dtype = kwargs["dtype"] if "dtype" in kwargs else input_val.dtype()
+    dtype = (
+        kwargs["dtype"]
+        if "dtype" in kwargs and kwargs["dtype"] is not None
+        else input_val.dtype()
+    )
     fill_value = kwargs["fill_value"]
     return full()(size, fill_value=fill_value, dtype=dtype)
 
@@ -1698,7 +1702,11 @@ def acc_ops_new_ones(
     if not isinstance(input_val, AITTensor):
         raise RuntimeError(f"Non-tensor inputs for {name}: {input_val}")
     size = kwargs["size"]
-    dtype = kwargs["dtype"] if "dtype" in kwargs else input_val.dtype()
+    dtype = (
+        kwargs["dtype"]
+        if "dtype" in kwargs and kwargs["dtype"] is not None
+        else input_val.dtype()
+    )
     return full()(size, 1, dtype=dtype)
 
 
@@ -1720,7 +1728,11 @@ def acc_ops_new_zeros(
     if not isinstance(input_val, AITTensor):
         raise RuntimeError(f"Non-tensor inputs for {name}: {input_val}")
     size = kwargs["size"]
-    dtype = kwargs["dtype"] if "dtype" in kwargs else input_val.dtype()
+    dtype = (
+        kwargs["dtype"]
+        if "dtype" in kwargs and kwargs["dtype"] is not None
+        else input_val.dtype()
+    )
     return full()(size, 0, dtype=dtype)
 
 

--- a/python/aitemplate/compiler/ops/tensor/full.py
+++ b/python/aitemplate/compiler/ops/tensor/full.py
@@ -18,6 +18,7 @@ from typing import List
 from aitemplate import backend
 from aitemplate.backend import registry
 from aitemplate.compiler.base import IntVar, Operator, Tensor
+from aitemplate.compiler.dtype import get_dtype_size
 
 
 class full(Operator):
@@ -55,6 +56,9 @@ class full(Operator):
         if not isinstance(fill_value, (int, float)):
             raise TypeError(f"fill_value must be a scalar, but got {fill_value}.")
         fill_value = float(fill_value)
+
+        # validation inside
+        get_dtype_size(dtype)
 
         self._attrs["inputs"] = []
         self._attrs["fill_value"] = fill_value


### PR DESCRIPTION
Summary:
When the `fx2ait` converters for the `full` op pass `kwargs["dtype"]` to the op, apparently, it can be `None`. This breaks the downstream graph.

This diff adds a check to the converter and a validation to the `full` op's front-end to prevent this from happening.

Reviewed By: tissue3

Differential Revision: D44433380

