### PR TITLE
Format json arrays in vis html

### DIFF
--- a/python/aitemplate/utils/visualization/plot.py
+++ b/python/aitemplate/utils/visualization/plot.py
@@ -300,8 +300,8 @@ def plot_graph(
         basename = os.path.splitext(os.path.basename(file_path))[0]
         dot_src = dot_graph.to_string()
         modal_src = "\n".join(modal_set)
-        items_src = [f'"{item}"' for item in items]
-        popover_src = json.dumps(popover_data)
+        items_src = json.dumps(items, indent=2)
+        popover_src = json.dumps(popover_data, indent=2)
         index = INDEX_TEMPLATE.render(
             dot_src=dot_src,
             modals=modal_src,

--- a/python/aitemplate/utils/visualization/web_template.py
+++ b/python/aitemplate/utils/visualization/web_template.py
@@ -135,7 +135,7 @@ input[type=submit] {
   
 
   <script>
-  items = [{{items|join(", ")}}];
+  items = {{items}};
   function autocomplete(inp, arr) {
   /*the autocomplete function takes two arguments,
   the text field element and an array of possible autocompleted values:*/


### PR DESCRIPTION
Problem:
When we visualize Large models the html files will have very long lines for particular data arrays.
For example, [test model](https://apivovarov-tmp.s3.us-west-2.amazonaws.com/www/toposort_graph_vis_1000_new.html) with 1000 Linear operators has two long lines. The biggest one is 254,594 chars!

It does not work well with text editors or other html tools.

We can apply pretty formatting to large json arrays in html file. In that case the dumped arrays will grow vertically but not horizontally in html.

I identified two arrays with this problem - `popover_data` and `items`.
This PR uses `indent=2` in `json.dumps()` to format the array. 

The result of the arrays formatting in html:

```
    var popover_data = {
  "X": "shape: [(1, 8), 3]",
  "gemm_rcr_bias_0": "op: gemm_rcr_bias, depth: 0, nop: False, has_profiler: True, epilogue: LinearCombination, epilogue_alignment: 1, split_k: 1",
  "tensor_0": "shape: [3, 3]",
  "tensor_1": "shape: [3]",
  "gemm_rcr_bias_0_0": "shape: [(1, 8), 3]",
  "gemm_rcr_bias_1": "op: gemm_rcr_bias, depth: 1, nop: False, has_profiler: True, epilogue: LinearCombination, epilogue_alignment: 1, split_k: 1",
  "tensor_2": "shape: [3, 3]",
  "tensor_3": "shape: [3]",
...
  "gemm_rcr_bias_99": "op: gemm_rcr_bias, depth: 99, nop: False, has_profiler: True, epilogue: LinearCombination, epilogue_alignment: 1, split_k: 1",
  "tensor_198": "shape: [3, 3]",
  "tensor_199": "shape: [3]",
  "Y": "shape: [(1, 8), 3]"
};
```
```
  items = [
  "X",
  "gemm_rcr_bias_0",
  "tensor_0",
  "tensor_1",
  "gemm_rcr_bias_0_0",
  "gemm_rcr_bias_1",
  "tensor_2",
  "tensor_3",
  "gemm_rcr_bias_1_0",
  "gemm_rcr_bias_2",
  "tensor_4",
  "tensor_5",
...
  "tensor_198",
  "tensor_199",
  "Y"
];
```

[Test report](https://apivovarov-tmp.s3.us-west-2.amazonaws.com/www/toposort_graph_vis_100_new_formatted.html) with arrays formatting

`items` array - at line 18,860
`popover_data` array - at line 20,201