### PR TITLE
Fix OrderedDict comprehensions usage

### DIFF
--- a/fx2ait/fx2ait/converters/ait_module_converters.py
+++ b/fx2ait/fx2ait/converters/ait_module_converters.py
@@ -12,7 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-from typing import Any, Dict, OrderedDict, Tuple
+from collections import OrderedDict
+from typing import Any, Dict, Tuple
 
 import numpy as np
 

--- a/python/aitemplate/backend/rocm/normalization/groupnorm.py
+++ b/python/aitemplate/backend/rocm/normalization/groupnorm.py
@@ -15,9 +15,9 @@
 """
 Groupnorm codegen for ROCM.
 """
-
+from collections import OrderedDict
 from hashlib import sha1
-from typing import Any, Dict, OrderedDict
+from typing import Any, Dict
 
 import jinja2
 

--- a/python/aitemplate/backend/rocm/normalization/layernorm.py
+++ b/python/aitemplate/backend/rocm/normalization/layernorm.py
@@ -15,9 +15,9 @@
 """
 Layernorm codegen for ROCM.
 """
-
+from collections import OrderedDict
 from hashlib import sha1
-from typing import Any, Dict, OrderedDict
+from typing import Any, Dict
 
 import jinja2
 

--- a/python/aitemplate/backend/rocm/normalization/norm_common.py
+++ b/python/aitemplate/backend/rocm/normalization/norm_common.py
@@ -18,8 +18,9 @@ Normalization common codegen for ROCM.
 
 import os
 import re
+from collections import OrderedDict
 from hashlib import sha1
-from typing import Any, Dict, OrderedDict
+from typing import Any, Dict
 
 import jinja2
 

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_common.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_common.py
@@ -495,11 +495,9 @@ class gemm(Operator):
         filter_func = registry.get(func_key)
         # run compile-time filter
         new_op_instance = OrderedDict(
-            {
-                k: v
-                for k, v in self._attrs["op_instance"].items()
-                if filter_func(k, self._attrs, ab_alignments[0])
-            }
+            (k, v)
+            for k, v in self._attrs["op_instance"].items()
+            if filter_func(k, self._attrs, ab_alignments[0])
         )
         _LOGGER.debug(
             f"Filtered profiler kernels for {self._attrs['op']}: reduced the "

--- a/python/aitemplate/compiler/ops/gemm_universal/group_gemm_rcr.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/group_gemm_rcr.py
@@ -278,11 +278,9 @@ class group_gemm_rcr(common.gemm):
         filter_func = registry.get(func_key)
         # run compile-time filter
         new_op_instance = OrderedDict(
-            {
-                k: v
-                for k, v in self._attrs["op_instance"].items()
-                if filter_func(k, self._attrs, ab_alignments[0])
-            }
+            (k, v)
+            for k, v in self._attrs["op_instance"].items()
+            if filter_func(k, self._attrs, ab_alignments[0])
         )
         _LOGGER.debug(
             f"Filtered profiler kernels for {self._attrs['op']}: reduced the "

--- a/python/aitemplate/compiler/transform/profile.py
+++ b/python/aitemplate/compiler/transform/profile.py
@@ -17,9 +17,10 @@ Graph pass to invoke profiling.
 """
 import logging
 import os
+from collections import OrderedDict
 from copy import deepcopy
 from datetime import datetime
-from typing import List, OrderedDict
+from typing import List
 
 from aitemplate.backend import builder, codegen
 
@@ -55,7 +56,6 @@ def profile(
     devices=None,
     dynamic_profiling_strategy=DynamicProfileStrategy.MAX,
 ):
-
     """Profiles kernels.
 
     Parameters
@@ -89,13 +89,12 @@ def profile(
     compile_engine.make_profilers(generated_profilers, profiler_dir)
     _LOGGER.info(f"compiled profilers elapsed time: {elapsed_dt_sec(start_t)}")
     funcs_to_profile = OrderedDict(
-        {
-            func._attrs["name"]: func
-            for node in sorted_graph
-            for func in node.src_ops()
-            if func._attrs["has_profiler"]
-        }
+        (func._attrs["name"], func)
+        for node in sorted_graph
+        for func in node.src_ops()
+        if func._attrs["has_profiler"]
     )
+
     start_t = datetime.now()
     gemms, non_gemms = _splitter(
         funcs_to_profile.values(), lambda f: isinstance(f, gemm)

--- a/python/aitemplate/compiler/transform/profile_dynamic_dim.py
+++ b/python/aitemplate/compiler/transform/profile_dynamic_dim.py
@@ -16,8 +16,9 @@
 Graph pass to invoke profiling with dynamic shapes.
 """
 import logging
+from collections import OrderedDict
 from copy import deepcopy
-from typing import List, OrderedDict
+from typing import List
 
 from aitemplate.backend import builder, codegen
 from aitemplate.compiler.base import Tensor
@@ -35,12 +36,10 @@ def profile_dynamic_dim(sorted_graph: List[Tensor], workdir="./tmp"):
     compile_engine = builder.Builder()
     compile_engine.make_profilers(generated_profilers, workdir)
     funcs_to_profile = OrderedDict(
-        {
-            func._attrs["name"]: func
-            for node in sorted_graph
-            for func in node.src_ops()
-            if func._attrs["has_profiler"]
-        }
+        (func._attrs["name"], func)
+        for node in sorted_graph
+        for func in node.src_ops()
+        if func._attrs["has_profiler"]
     )
     for f in funcs_to_profile.values():
         f.profile_dynamic_dim(

--- a/python/aitemplate/frontend/nn/container.py
+++ b/python/aitemplate/frontend/nn/container.py
@@ -131,7 +131,7 @@ class Sequential(Module):
             delattr(self, key)
         # To preserve numbering
         str_indices = [str(i) for i in range(len(self._modules))]
-        self._modules = OrderedDict(list(zip(str_indices, self._modules.values())))
+        self._modules = OrderedDict(zip(str_indices, self._modules.values()))
 
     def __len__(self) -> int:
         return len(self._modules)
@@ -309,7 +309,7 @@ class ModuleList(Module):
             delattr(self, self._get_abs_string_index(idx))
         # To preserve numbering, self._modules is being reconstructed with modules after deletion
         str_indices = [str(i) for i in range(len(self._modules))]
-        self._modules = OrderedDict(list(zip(str_indices, self._modules.values())))
+        self._modules = OrderedDict(zip(str_indices, self._modules.values()))
 
     def __len__(self) -> int:
         return len(self._modules)

--- a/tests/unittest/frontend/test_module.py
+++ b/tests/unittest/frontend/test_module.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 #
 import unittest
-from typing import OrderedDict
+from collections import OrderedDict
 
 import torch
 import torch as pt
@@ -59,7 +59,7 @@ class NNModule(unittest.TestCase):
         b = PTModule()
         pt_param_names = [x[0] for x in b.named_parameters()]
 
-        for (x, y) in zip(ait_param_names, pt_param_names):
+        for x, y in zip(ait_param_names, pt_param_names):
             assert x == y
 
     def test_sequential_1(self):
@@ -100,7 +100,7 @@ class NNModule(unittest.TestCase):
         ait_param_names = [x[0] for x in a.named_parameters()]
         pt_param_names = [x[0] for x in b.named_parameters()]
 
-        for (x, y) in zip(ait_param_names, pt_param_names):
+        for x, y in zip(ait_param_names, pt_param_names):
             assert x == y
 
     def test_sequential_2(self):
@@ -153,7 +153,7 @@ class NNModule(unittest.TestCase):
         ait_param_names = [x[0] for x in a.named_parameters()]
         pt_param_names = [x[0] for x in b.named_parameters()]
 
-        for (x, y) in zip(ait_param_names, pt_param_names):
+        for x, y in zip(ait_param_names, pt_param_names):
             assert x == y
 
     def test_module_dict(self):
@@ -238,7 +238,7 @@ class NNModule(unittest.TestCase):
         ait_param_names = [x[0] for x in a.named_parameters()]
         pt_param_names = [x[0] for x in b.named_parameters()]
 
-        for (x, y) in zip(ait_param_names, pt_param_names):
+        for x, y in zip(ait_param_names, pt_param_names):
             assert x == y
 
 


### PR DESCRIPTION
1. When we create `OrderedDict` from another collection or iterable there is not need to wrap it with `list` or `dict`. Wrapping with `dict` is especially strange because it could change the items order before python 3.6.

More info on it - [OrderedDict comprehensions](https://stackoverflow.com/questions/21103732/ordereddict-comprehensions)

2. Another improvement is to import `OrderedDict` from `collections` instead of from `typing`. It is recommended to import `OrderedDict` from `collections` rather than from other places.