### PR TITLE
Use .exe ext on Windows only

### DIFF
--- a/python/aitemplate/backend/builder.py
+++ b/python/aitemplate/backend/builder.py
@@ -38,7 +38,7 @@ from aitemplate.utils import environ
 
 from aitemplate.utils.debug_settings import AITDebugSettings
 
-from aitemplate.utils.misc import is_debug
+from aitemplate.utils.misc import is_debug, is_windows
 
 # pylint: disable=W0221,C0103
 
@@ -457,7 +457,9 @@ clean_constants:
         build_standalone_rules = ""
         if debug_settings.gen_standalone:
             build_exe_cmd = f"$(CC) $(CFLAGS) -o $@ {standalone_obj} {dll_name}"
-            exe_name = os.path.splitext(dll_name)[0] + ".exe"
+            exe_name = os.path.splitext(dll_name)[0]
+            if is_windows():
+                exe_name += ".exe"
             exe_target_deps = f"{dll_name} {standalone_obj}"
             build_standalone_rules = standalone_rules_template.render(
                 standalone_src=standalone_src,

--- a/python/aitemplate/utils/misc.py
+++ b/python/aitemplate/utils/misc.py
@@ -25,6 +25,10 @@ def is_debug():
     return logger.level == logging.DEBUG
 
 
+def is_windows() -> bool:
+    return os.name == "nt"
+
+
 def setup_logger(name):
     root_logger = logging.getLogger(name)
     info_handle = logging.StreamHandler()

--- a/tests/unittest/backend/test_gen_standalone.py
+++ b/tests/unittest/backend/test_gen_standalone.py
@@ -30,6 +30,7 @@ from aitemplate.testing.test_utils import (
     get_torch_empty_tensor,
 )
 from aitemplate.utils.debug_settings import AITDebugSettings
+from aitemplate.utils.misc import is_windows
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -115,7 +116,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
         )
         self.assertTrue(torch.allclose(y, y_pt, atol=1e-2, rtol=1e-2))
 
-        # Now we run the generate executable
+        # Now we run the generated executable
         cwd = os.getcwd()
         workdir = os.path.join(cwd, "tmp", test_name)
         working_env = os.environ.copy()
@@ -126,8 +127,9 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
         else:
             working_env["LD_LIBRARY_PATH"] = workdir
         _LOGGER.info(f"work dir: {workdir}")
+        exe_name = "./test.exe" if is_windows() else "./test"
         with subprocess.Popen(
-            ["./test.exe"],
+            [exe_name],
             shell=True,
             cwd=workdir,
             env=working_env,
@@ -147,7 +149,7 @@ class StridedOpCatPatternTestCase(unittest.TestCase):
                 if proc.returncode != 0:
                     _LOGGER.info(f"stdout:\n\n{stdout}")
                     _LOGGER.info(f"stderr:\n\n{stderr}")
-                    raise RuntimeError("failed to execute test.exe")
+                    raise RuntimeError(f"failed to execute {exe_name}")
                 else:
                     _LOGGER.info(f"stdout:\n\n{stdout}")
                     all_output_lines = stdout.split("\n")


### PR DESCRIPTION
`compile_model()` allows to build standalone model app.
```
debug_settings.gen_standalone = True
m = aitemplate.compiler.compile_model(...
    debug_settings=debug_settings,
)
```

Currently the generated app will have `.exe.` extension regardless of the OS.

Lets add `.exe.` extension on Windows platform only

This PR also adds `is_windows()` to `aitemplate.utils.misc`