### PR TITLE
Apply json formatting to debug graph

### DIFF
--- a/python/aitemplate/utils/graph_utils.py
+++ b/python/aitemplate/utils/graph_utils.py
@@ -68,7 +68,7 @@ def sorted_graph_debug_json(tensors) -> str:
     json_dict["Operators"] = get_sorted_ops(tensors)
 
     op_names = gen_unique_op_names(tensors)
-    encoder = GraphJsonEncoder(op_names)
+    encoder = GraphJsonEncoder(op_names, indent=2)
 
     return encoder.encode(json_dict)
 


### PR DESCRIPTION
`compile_model()` function dumps model graph to txt, json and html after each transformation.

Currently `xxx_graph.json` file contains just one huge json line
For better readability we can format the json.

Before:
```json
{"Tensors": [{"name": "X", "depth": 0, "nop": false, "shape": [{"_attrs": {"name": "batch", "depth": 0,
```

After:
```json
{
  "Tensors": [
    {
      "name": "X",
      "depth": 0,
      "nop": false,
      "shape": [
        {
          "_attrs": {
            "name": "batch",
            "depth": 0,
            "nop": false,
            "values": [
              1,
              8
            ],
            "symbolic_value": "batch"
          }
        },
        {
          "_attrs": {
            "name": "dim1",
            "depth": 0,
            "nop": false,
            "values": [
              3
```