### PR TITLE
Fix default number of runtimes 2->1 in comments

### DIFF
--- a/python/aitemplate/backend/cuda/groupnorm/groupnorm_kernel.cuh
+++ b/python/aitemplate/backend/cuda/groupnorm/groupnorm_kernel.cuh
@@ -198,7 +198,7 @@ __forceinline__ __device__ bfloat16 Rsqrt<bfloat16>(bfloat16 x) {
 
 template <typename T>
 inline __device__ void WelfordCombine(T val, T* mean, T* m2, int* count) {
-  // Use Welford Online algorithem to compute mean and variance
+  // Use Welford Online algorithm to compute mean and variance
   // For more details you can refer to:
   // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
   *count += 1;

--- a/python/aitemplate/backend/cuda/groupnorm/layer_norm.cuh
+++ b/python/aitemplate/backend/cuda/groupnorm/layer_norm.cuh
@@ -227,7 +227,7 @@ struct DirectStore {
 
 template <typename T>
 inline __device__ void WelfordCombine(T val, T* mean, T* m2, T* count) {
-  // Use Welford Online algorithem to compute mean and variance
+  // Use Welford Online algorithm to compute mean and variance
   // For more details you can refer to:
   // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
   *count += 1;

--- a/python/aitemplate/backend/cuda/tensor/concatenate_fast.cuh
+++ b/python/aitemplate/backend/cuda/tensor/concatenate_fast.cuh
@@ -99,7 +99,7 @@ Tensor ConcatKernelDimN(const TestCase & tc, int64_t concatDim) {
 */
 
 ////////////////////////////////////////////////////////////
-// Here go the facilities that are resposible for post-processing,
+// Here go the facilities that are responsible for post-processing,
 //   such as applying tanh on top of values on a concatenated tensor.
 
 // does no processing

--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -181,7 +181,7 @@ def compile_model(
     num_runtimes: int
         How many runtimes should be stored in the internal pool. This
         determines how many inferences can happen concurrently. By
-        default, set to 2. Must be positive.
+        default, set to 1. Must be positive.
     allocator_kind: AITemplateAllocatorKind, optional
         The GPU allocator to use. If none is specified, use the default allocator.
     debug_settings: AITDebugSettings

--- a/python/aitemplate/compiler/model.py
+++ b/python/aitemplate/compiler/model.py
@@ -198,7 +198,7 @@ class Model:
         num_runtimes : int, optional
             How many runtimes should be stored in the internal pool. This
             determines how many inferences can happen concurrently. By
-            default, set to 2. Must be positive.
+            default, set to 1. Must be positive.
         allocator_kind : AITemplateAllocatorKind, optional
             What type of allocator to use when allocating GPU memory.
         """


### PR DESCRIPTION
`AIT_DEFAULT_NUM_RUNTIMES=1`, however, `compile_model()`, and `Model.__init__()` descriptions say that it is 2.

This PR fixes the description for `num_runtimes` param. Plus fixes some typos in other places.