### PR TITLE
Remove hack in [fx/aten]2ait

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -84,7 +84,6 @@ from .utils import (
     identical_elem_tuple_to_int,
     ncdhw2ndhwc,
     nchw2nhwc,
-    unify_dynamic_shape_name,
     weight_ncdhw2ndhwc,
     weight_nchw2nhwc,
 )
@@ -346,10 +345,6 @@ def acc_ops_cat(
     if not isinstance(dim, int):
         raise ValueError(f"Unexpected {type(dim)} dim for {name}: {dim}")
 
-    # TODO:  unify_dynamic_shape_name is a hack to workaround AIT's dynamic shape requirement.
-    # We will remove it after AIT provides vanilla support.
-    for i in range(len(tensors) - 1):
-        unify_dynamic_shape_name(tensors[i], tensors[i + 1])
     return concatenate()(tensors, dim=dim)
 
 

--- a/fx2ait/fx2ait/converters/aten2ait_converters.py
+++ b/fx2ait/fx2ait/converters/aten2ait_converters.py
@@ -60,7 +60,6 @@ from fx2ait.converters.utils import (
     get_positive_dim,
     identical_elem_tuple_to_int,
     nchw2nhwc,
-    unify_dynamic_shape_name,
 )
 from fx2ait.passes.lower_basic_pass_aten import (
     aten_compose_bmm_2d,
@@ -168,7 +167,6 @@ def aten_binary_ops_add(
     kwargs: Dict[str, Argument],
     name: str,
 ) -> ConverterOutput:
-    unify_dynamic_shape_name(args[0], args[1])
     kwargs = {
         "input": args[0],
         "other": args[1],
@@ -587,7 +585,6 @@ def aten_ops_matmul(
     if len(weight_shape) == 2:
         result = gemm_rrr()(input_val, weight)
     elif len(input_shape) == 3 and len(weight_shape) == 3:
-        unify_dynamic_shape_name(input_val, weight)
         result = bmm_rrr()(input_val, weight)
     else:
         raise NotImplementedError(

--- a/fx2ait/fx2ait/converters/utils.py
+++ b/fx2ait/fx2ait/converters/utils.py
@@ -203,19 +203,3 @@ def ait_ncdhw2ndhwc(ait_tensor: AITTensor) -> AITTensor:
 
 def ait_ndhwc2ncdhw(ait_tensor: AITTensor) -> AITTensor:
     return permute()(ait_tensor, [0, 4, 1, 2, 3])
-
-
-# TODO:  This is a hack to workaround AIT's dynamic shape requirement.
-# Detailed explanation can be found in D41743385 (aten2ait) D41974191(fx2ait).
-# We will throw this one after AIT provides vanilla support.
-def unify_dynamic_shape_name(input_val, weight):
-    input_shape = input_val.shape()
-    weight_shape = weight.shape()
-    if len(input_shape) == len(weight_shape):
-        for a, b in zip(input_shape, weight_shape):
-            if a._attrs["values"] == b._attrs["values"]:
-                if a._attrs["name"] is None:
-                    a._attrs["name"] = b._attrs["name"]
-                elif b._attrs["name"] is None:
-                    b._attrs["name"] = a._attrs["name"]
-    return input_shape, weight_shape


### PR DESCRIPTION
Summary: Symbolic shape support has landed, remove hacks that were used.

Differential Revision: D44482705

