### PR TITLE
Accept multiple sources in make_jagged

### DIFF
--- a/python/aitemplate/compiler/ops/common/view_ops.py
+++ b/python/aitemplate/compiler/ops/common/view_ops.py
@@ -629,7 +629,7 @@ class unsqueeze(squeeze):
 
 class make_jagged(_view):
     """
-    Creates a jagged Tensor from a normal Tensor, offsets, and metadata.
+    Creates jagged Tensors from normal Tensors, offsets, and metadata.
 
     Jagged Tensors are normal Tensors with the first dynamic dimensions
     represented with a JaggedIntVar instance (as opposed to a vanilla
@@ -668,12 +668,14 @@ class make_jagged(_view):
             docstrings for the details.
 
     __call__ Args:
-        source : Tensor
-            The source Tensor of the jagged Tensor created by this op.
-            The jagged Tensor is a view of the source Tensor. The main
-            difference is that the resulting jagged Tensor's first
-            dimension is set to a JaggedIntVar, constructed from the
-            batch_dim, jagged_dims, and the offsets_list.
+        source : Union[Tensor, List[Tensor]]
+            One or more source Tensors of the jagged Tensor(s) created by this op.
+            The jagged Tensor is a view of the source Tensor. The main difference
+            is that the resulting jagged Tensor's first dimension is set to a
+            JaggedIntVar, constructed from the batch_dim, jagged_dims, and the
+            offsets_list. The same JaggedIntVar instance is set as the first
+            dimension of every resulting jagged Tensor: one for each source
+            Tensor in the `source`.
         offsets_list : List[Tensor]
             The list of rank-1 offsets Tensors describing the variable-length
             layout of each of the jagged_dims. There must be exactly as many
@@ -681,6 +683,11 @@ class make_jagged(_view):
             the jagged_dims list. Each offsets Tensor is associated with the
             corresponding JaggedDim before constructing a JaggedIntVar from
             them for the resulting jagged Tensor.
+
+    Returns:
+        Union[Tensor, List[Tensor]]
+            The resulting jagged Tensor or a list thereof, depending on whether
+            the `source` argument is a Tensor or a List[Tensor].
     """
 
     def __init__(
@@ -722,18 +729,37 @@ class make_jagged(_view):
                     )
             jagged_dim._attrs["offsets"] = offsets
 
-    def _infer_shapes(self, source: Tensor) -> List[IntVar]:
-        jagged_int_var = JaggedIntVar(
-            batch_dim=self._attrs["batch_dim"],
-            jagged_dims=self._attrs["jagged_dims"],
-            total_length=source._attrs["shape"][0],
-        )
+    def __call__(
+        self,
+        source: Union[Tensor, List[Tensor]],
+        offsets_list: List[Tensor],
+    ) -> Tensor:
+        sources_list = [source] if isinstance(source, Tensor) else source
 
-        return [jagged_int_var] + source._attrs["shape"][1:]
+        if not sources_list:
+            raise ValueError("There must be at least one source Tensor in the list.")
 
-    def __call__(self, source: Tensor, offsets_list: List[Tensor]) -> Tensor:
-        if source.is_jagged():
-            # already a jagged Tensor
+        for s in sources_list:
+            if len(s._attrs["shape"]) == 0:
+                raise ValueError(
+                    "The source Tensors must be at least rank-1, but given rank-0."
+                )
+            if type(s._attrs["shape"][0]) != IntVar:
+                raise ValueError(
+                    "The source Tensor's first dim (total_length) must be "
+                    f"dynamic (IntVar), but given {s._attrs['shape']=}."
+                )
+
+        total_length = sources_list[0]._attrs["shape"][0]
+        for s in sources_list[1:]:
+            if s._attrs["shape"][0] != total_length:
+                raise ValueError(
+                    "All source Tensors must have the same first (total_length) dimension, "
+                    f"but got {s[0]._attrs['shape']=}, {s._attrs['shape']=}."
+                )
+
+        if isinstance(total_length, JaggedIntVar):
+            # already jagged Tensors
             return source
 
         jagged_dims = self._attrs["jagged_dims"]
@@ -752,28 +778,31 @@ class make_jagged(_view):
                     "The offsets Tensors can be either int32 or int64, "
                     f"but given the Tensor of type {offsets._attrs['dtype']}."
                 )
-        if len(source._attrs["shape"]) == 0:
-            raise ValueError(
-                "The source Tensor must be at least rank-1, but given rank-0."
-            )
-        if type(source._attrs["shape"][0]) != IntVar:
-            raise ValueError(
-                "The source Tensor's first dim (total_length) must be dynamic (IntVar), "
-                f"but given {type(source._attrs['shape'][0]).__name__}."
-            )
 
-        self._attrs["inputs"] = [source, *offsets_list]
+        self._attrs["num_sources"] = len(sources_list)
+        self._attrs["inputs"] = sources_list + offsets_list
         self._set_depth()
         self._set_jagged_dim_offsets(offsets_list)
-        output_shape = self._infer_shapes(source)
-        output = Tensor(
-            shape=output_shape,
-            src_ops={self},
-            is_view_of=source,
-        )
-        self._attrs["outputs"] = [output]
 
-        return output
+        jagged_int_var = JaggedIntVar(
+            batch_dim=self._attrs["batch_dim"],
+            jagged_dims=self._attrs["jagged_dims"],
+            total_length=total_length,
+        )
+
+        outputs = [
+            Tensor(
+                shape=[jagged_int_var] + s._attrs["shape"][1:],
+                src_ops={self},
+                is_view_of=s,
+            )
+            for s in sources_list
+        ]
+        self._attrs["outputs"] = outputs
+        if isinstance(source, Tensor):
+            outputs = outputs[0]
+
+        return outputs
 
     def _get_op_attributes(self):
         return {

--- a/tests/unittest/ops/test_make_jagged.py
+++ b/tests/unittest/ops/test_make_jagged.py
@@ -124,13 +124,13 @@ class MakeJaggedTestCase(unittest.TestCase):
     def test_make_jagged(self):
         self._test_make_jagged(
             check_sequence_lengths=True,
-            test_name="make_jagged",
+            test_name="test_make_jagged",
         )
 
     def test_make_jagged_no_seq_len_check(self):
         self._test_make_jagged(
             check_sequence_lengths=False,
-            test_name="make_jagged_no_seq_len_check",
+            test_name="test_make_jagged_no_seq_len_check",
         )
 
     def test_make_jagged_with_dynamic_bounds(
@@ -229,6 +229,114 @@ class MakeJaggedTestCase(unittest.TestCase):
         model.run_with_tensors(inputs, [result])
 
         torch.testing.assert_close(result, result_pt)
+
+    def test_make_jagged_multiple_sources(
+        self,
+        num_sources=3,
+        dtype="float16",
+        offsets_dtype="int32",
+    ):
+        B = 4
+        N = 3
+        D = 64
+
+        batch_dim = IntVar(name="batch_size", values=[1, B])
+        max_seq_dim = IntImm(name="max_seq_len", value=N)
+        embedding_dim = IntImm(name="embedding", value=D)
+
+        total_length_dim = IntVar(name="total_length", values=[0, B * N])
+        offsets_dim = IntVar(name="offsets_size", values=[2, B + 1])
+
+        SOURCES = [
+            Tensor(
+                shape=[
+                    total_length_dim,
+                    embedding_dim,
+                ],
+                name=f"source_{i}",
+                dtype=dtype,
+                is_input=True,
+            )
+            for i in range(num_sources)
+        ]
+        OFFSETS_LIST = [
+            Tensor(
+                shape=[
+                    offsets_dim,
+                ],
+                name="offsets",
+                dtype=offsets_dtype,
+                is_input=True,
+            )
+        ]
+        DENSE = Tensor(
+            shape=[
+                batch_dim,
+                max_seq_dim,
+                embedding_dim,
+            ],
+            name="dense",
+            dtype=dtype,
+            is_input=True,
+        )
+
+        JAGGEDS = ops.make_jagged(
+            batch_dim=batch_dim,
+            jagged_dims=[
+                JaggedDim(
+                    min_value=0,
+                    max_value=max_seq_dim,
+                )
+            ],
+        )(
+            source=SOURCES,
+            offsets_list=OFFSETS_LIST,
+        )
+
+        RESULT = DENSE
+        for JAGGED in JAGGEDS:
+            RESULT = ops.elementwise(FuncEnum.ADD)(JAGGED, RESULT)
+
+        assert all(not SOURCE.is_jagged() for SOURCE in SOURCES)
+        assert not DENSE.is_jagged()
+        assert all(JAGGED.is_jagged() for JAGGED in JAGGEDS)
+        assert RESULT.is_jagged()
+
+        RESULT._attrs["name"] = "result"
+        RESULT._attrs["is_output"] = True
+
+        model = compile_model(
+            [RESULT],
+            detect_target(),
+            "./tmp",
+            "test_make_jagged_multiple_sources",
+        )
+
+        offsets = [0, 1, 4, 6, 7]
+        torch_offsets_type = string_to_torch_dtype(offsets_dtype)
+        offsets_pt = torch.tensor(offsets, dtype=torch_offsets_type).cuda()
+        sources_pt = {
+            f"source_{i}": get_random_torch_tensor([offsets[-1], D], dtype=dtype)
+            for i in range(num_sources)
+        }
+        dense_pt = get_random_torch_tensor([B, N, D], dtype=dtype)
+
+        sources_list_pt = list(sources_pt.values())
+        summed_sources_pt = torch.clone(sources_list_pt[0])
+        for source_pt in sources_list_pt[1:]:
+            summed_sources_pt += source_pt
+        result_pt = add_jagged_dense_ref(
+            jagged=summed_sources_pt,
+            offsets_list=[offsets_pt],
+            jagged_max_shape=[B, N, D],
+            dense=dense_pt,
+        )
+        result = torch.empty_like(result_pt)
+
+        inputs = {**sources_pt, "offsets": offsets_pt, "dense": dense_pt}
+        model.run_with_tensors(inputs, [result])
+
+        torch.testing.assert_close(result, result_pt, rtol=1e-2, atol=1e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
`make_jagged` currently accepts only a single `source` and `offsets_list`, returning a jagged Tensor made from those. This may be inefficient for the cases where there are multiple jagged Tensors in the graph with the same `total_length` dimension / same offsets (e.g., in the group b2b bmm). In this case, `make_jagged` would have to be invoked as many times, doing the same offset validation on the GPU in every run. The latter is a waste of time.

In this diff, `make_jagged` is extended to accept multiple source Tensors (with the same first `total_length` dimension) and convert each to a jagged Tensor.

The extension is necessary for the upcoming graph transformation pass eliminating multiple `make_jagged` ops within the graph by pulling them upstream / applying `make_jagged` to the sets of source input Tensors with the same `total_length` first dimension. The pass will be added in a follow-up diff.

Differential Revision: D44508562

