### PR TITLE
Support models with 2GB+ params

### DIFF
--- a/python/aitemplate/backend/target.py
+++ b/python/aitemplate/backend/target.py
@@ -18,6 +18,7 @@ Target object for AITemplate.
 import logging
 import os
 import pathlib
+import platform
 import shutil
 import tempfile
 from enum import IntEnum
@@ -172,7 +173,15 @@ class Target:
         A command that turns a raw binary file into an object file that
         can be linked into the executable.
         """
-        return "ld -r -b binary -o {target} {src}"
+        cmd = "ld -r -b binary -o {target} {src}"
+        # Support models with >2GB constants on Linux only
+        if platform.system() == "Linux":
+            cmd += (
+                " && objcopy --rename-section"
+                " .data=.lrodata,alloc,load,readonly,data,contents"
+                " {target} {target}"
+            )
+        return cmd
 
     def compile_options(self) -> str:
         """Options for compiling the target.


### PR DESCRIPTION
I tried to compile test model having 2GB+ params.
Large (>2GB) `constants.obj` was generated successfully, but `model.so` creation failed. (Linux x86_64 platform)

Currently we convert `constants.bin` to `constants.obj` using 
```
ld -r -b binary -o constants.obj constants.bin
```

`objdump` shows that `_binary_constants_bin` array was placed to `.data` section.
`.data` and `.rodata` sections can not allocate more that 2GB.

To solve the issue with 2GB limit we can put `_binary_constants_bin` array to `.lrodata` read-only section. It does not have 2GB limit.
We can do it by using 
```
objcopy --rename-section .data=.lrodata,alloc,load,readonly,data,contents constants.obj constants.obj
```
to rename `.data` section in `constants.obj` file to `.lrodata`.

Before
```
$ objdump -x constants_old.obj

architecture: i386:x86-64, flags 0x00000010:
HAS_SYMS
start address 0x0000000000000000

Sections:
Idx Name          Size      VMA               LMA               File off  Algn
  0 .data         8b8577e0  0000000000000000  0000000000000000  00000040  2**0
                  CONTENTS, ALLOC, LOAD, DATA
SYMBOL TABLE:
0000000000000000 l    d  .data	0000000000000000 .data
000000008b8577e0 g       *ABS*	0000000000000000 _binary_constants_bin_size
000000008b8577e0 g       .data	0000000000000000 _binary_constants_bin_end
0000000000000000 g       .data	0000000000000000 _binary_constants_bin_start
```

After:
```
$ objdump -x constants.obj

architecture: i386:x86-64, flags 0x00000010:
HAS_SYMS
start address 0x0000000000000000

Sections:
Idx Name          Size      VMA               LMA               File off  Algn
  0 .lrodata      8b8577e0  0000000000000000  0000000000000000  00000040  2**0
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
SYMBOL TABLE:
0000000000000000 l    d  .lrodata	0000000000000000 .lrodata
000000008b8577e0 g       *ABS*	0000000000000000 _binary_constants_bin_size
000000008b8577e0 g       .lrodata	0000000000000000 _binary_constants_bin_end
0000000000000000 g       .lrodata	0000000000000000 _binary_constants_bin_start
```

Large (>2GB) `model.so`
```
-rwxrwxr-x 1 ubuntu ubuntu 2.2G Mar 30 06:24 my_model.so

```

Related Links:
- [Embedding Binary Blobs With GCC](https://www.burtonini.com/blog/2007/07/13/embedding-binary-blobs-with-gcc/)
- [TVM PR - [LLVM] Support CodeGenBlob for large >2GB models](https://github.com/apache/tvm/pull/10882)

