### PR TITLE
Make utils init empty to solve circular import issue

### DIFF
--- a/python/aitemplate/utils/__init__.py
+++ b/python/aitemplate/utils/__init__.py
@@ -13,17 +13,4 @@
 #  limitations under the License.
 #
 
-# flake8: noqa
-
-from aitemplate.utils import (
-    alignment,
-    environ,
-    graph_utils,
-    import_path,
-    markdown_table,
-    misc,
-    shape_utils,
-    tensor_utils,
-    torch_utils,
-    visualization,
-)
+# Let's keep this file empty to resolve circular import issues


### PR DESCRIPTION
If I try to import `aitemplate.utils.misc` in `aitemplate/backend/target.py` then I get the following error:
```
ImportError: cannot import name 'Target' from partially initialized module 'aitemplate.backend.target' 
(most likely due to a circular import) (/home/ubuntu/workspace/AITemplate/python/aitemplate/backend/target.py)
```

Internally some `aitemplate.utils` submodules import `aitemplate.compiler` which causes circular import issue above.
To solve the issue we can make `utils.__init__.py` empty to stop importing all `utils` sumbodiles upfront.
It will allow us to use `utils.misc` module in any other modules of the project.

Looks like importing `utils` submodules in the `__init__.py` is not actually required. It will be no negative consequences of making `__init__.py` empty.