### PR TITLE
Add dynamic_seq_len and dynamic_num_head support in b2b bmm.

### DIFF
--- a/python/aitemplate/backend/codegen.py
+++ b/python/aitemplate/backend/codegen.py
@@ -682,7 +682,12 @@ class ModelContainerGenerator:
 
         batch_dim_name = jagged_int_var.batch_dim()._attrs["name"]
         if batch_dim_name not in self.visited_dims:
-            self.dim_decl.append(self.f_var_decl(batch_dim_name, 0))
+            batch_dim_value = (
+                0
+                if not isinstance(jagged_int_var.batch_dim(), IntImm)
+                else jagged_int_var.batch_dim().value()
+            )
+            self.dim_decl.append(self.f_var_decl(batch_dim_name, batch_dim_value))
             self.visited_dims.add(batch_dim_name)
 
     def _process_dims_for_tensor(self, node: Tensor) -> None:

--- a/python/aitemplate/backend/common/elementwise_common.py
+++ b/python/aitemplate/backend/common/elementwise_common.py
@@ -682,7 +682,8 @@ def get_dynamic_dims(*shapes: List[List[IntVar]]) -> List[IntVar]:
                     # may not be present directly in other input / output shapes,
                     # so we're adding it here separately
                     batch_dim = dim.batch_dim()
-                    res[batch_dim._attrs["name"]] = batch_dim
+                    if not isinstance(batch_dim, IntImm):
+                        res[batch_dim._attrs["name"]] = batch_dim
                     for jagged_dim in dim.jagged_dims():
                         min_value = jagged_dim.min_value()
                         if not isinstance(min_value, IntImm):

--- a/python/aitemplate/backend/cuda/b2b_bmm/classic_b2b_bmm.py
+++ b/python/aitemplate/backend/cuda/b2b_bmm/classic_b2b_bmm.py
@@ -80,6 +80,9 @@ void check_status(cutlass::Status status, int64_t m0, int64_t k0, const std::str
   ElementCompute alpha0 = ElementCompute({{alpha0}});
   ElementCompute beta0 = ElementCompute(1);
   ElementCompute activation_alpha = ElementCompute({{alpha1}});
+  {% if alpha1_divide_by_seq_len %}
+  activation_alpha = activation_alpha / (ElementCompute)(static_cast<int32_t>(m0));
+  {% endif %}
   ElementCompute alpha1 = ElementCompute(1);
   ElementCompute beta1 = ElementCompute(0);
 
@@ -253,6 +256,9 @@ def classic_b2b_bmm_gen_function(func_attrs: Dict[str, Any]) -> str:
         ),
         alpha0=str(func_attrs["alpha0"]),
         alpha1=str(func_attrs["alpha1"]),
+        alpha1_divide_by_seq_len="true"
+        if func_attrs["alpha1_divide_by_seq_len"]
+        else "false",
         epilogue_math=epilogue_math,
     )
 

--- a/python/aitemplate/compiler/base.py
+++ b/python/aitemplate/compiler/base.py
@@ -504,11 +504,6 @@ class JaggedIntVar(IntVar):
                 "total_length must be dynamic (IntVar), "
                 f"but given {type(total_length).__name__}."
             )
-        if batch_dim is None or type(batch_dim) != IntVar:
-            raise TypeError(
-                "batch_dim must be dynamic (IntVar), "
-                f"but given {type(batch_dim).__name__}."
-            )
         if not jagged_dims or not all(
             isinstance(dim, JaggedDim) for dim in jagged_dims
         ):

--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -123,7 +123,8 @@ def _mark_isolated_int_vars(sorted_graph: List[Tensor]):
                 int_vars[name] = dim
                 if isinstance(dim, JaggedIntVar):
                     batch_dim = dim.batch_dim()
-                    int_vars[batch_dim._attrs["name"]] = batch_dim
+                    if not isinstance(batch_dim, IntImm):
+                        int_vars[batch_dim._attrs["name"]] = batch_dim
                     total_length = dim.total_length()
                     int_vars[total_length._attrs["name"]] = total_length
                     for jagged_dim in dim.jagged_dims():

--- a/python/aitemplate/compiler/ops/common/view_ops.py
+++ b/python/aitemplate/compiler/ops/common/view_ops.py
@@ -696,11 +696,6 @@ class make_jagged(_view):
         jagged_dims: List[JaggedDim],
         check_sequence_lengths: bool = True,
     ) -> None:
-        if type(batch_dim) != IntVar:
-            raise TypeError(
-                "batch_dim must be dynamic (IntVar), "
-                f"but given {type(batch_dim).__name__}."
-            )
         if not jagged_dims or not all(
             isinstance(dim, JaggedDim) for dim in jagged_dims
         ):


### PR DESCRIPTION
Summary:
ATT.
Also updated b2b bmm kernels to support alpha1_divide_by_seq_len.

Differential Revision: D44451037

