### PR TITLE
append the name to the front of each op

### DIFF
--- a/python/aitemplate/compiler/base.py
+++ b/python/aitemplate/compiler/base.py
@@ -1248,4 +1248,5 @@ class Operator(Node):
         args = self._pseudo_code_helper(self._args_for_pseudo_code(), with_shape)
         inputs = self._pseudo_code_helper(self._inputs_for_pseudo_code(), with_shape)
         outputs = self._pseudo_code_helper(self._outputs_for_pseudo_code(), with_shape)
-        return f"({outputs}) \n= {self._attrs['op']}({args})(\n{inputs})\n"
+        name = self._attrs.get("name", None)
+        return f"# {name}\n({outputs}) \n= {self._attrs['op']}({args})(\n{inputs})\n"


### PR DESCRIPTION
With the change, we will have something like:

(Tensor(name=elementwise_1_0, shape=[batch_size, 1920])) = gemm_rcr_bias()(
   ...
)

This change would make it much easier to map the pseudo code to the profiling results.