### PR TITLE
Add doc for missing compile_model parameters. Fix typos

### DIFF
--- a/python/aitemplate/backend/cuda/target_def.py
+++ b/python/aitemplate/backend/cuda/target_def.py
@@ -369,7 +369,7 @@ class FBCUDA(CUDA):
             res = f.read()
             return res
 
-    def in_ci_env(self):
+    def in_ci_env(self) -> bool:
         return (
             os.environ.get("INSIDE_RE_WORKER", None) == "1" and not self.trick_ci_env()
         )

--- a/python/aitemplate/backend/target.py
+++ b/python/aitemplate/backend/target.py
@@ -22,7 +22,7 @@ import platform
 import shutil
 import tempfile
 from enum import IntEnum
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 from aitemplate.backend import registry
 from aitemplate.backend.profiler_cache import ProfileCacheDB
@@ -249,13 +249,13 @@ class Target:
         """
         return os.environ.get("TRICK_CI_ENV", None) == "1"
 
-    def in_ci_env(self) -> Union[None, str]:
+    def in_ci_env(self) -> bool:
         """Check if the current environment is CI.
 
         Returns
         -------
-        Union[None, str]
-            CI environment name if in CI environment, otherwise None.
+        bool
+            Returns True if env CI_FLAG=CIRCLECI and TRICK_CI_ENV is not set (or 0).
         """
         return os.environ.get("CI_FLAG", None) == "CIRCLECI" and not self.trick_ci_env()
 

--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -93,7 +93,7 @@ def _verify_outputs_still_in_graph(sorted_graph: List[Tensor], outputs: List[Ten
     for tensor, was_seen in seen.items():
         if not was_seen:
             raise ValueError(
-                f"Output {tensor} was not found in the graph after opitmizations."
+                f"Output {tensor} was not found in the graph after optimizations."
             )
 
 
@@ -183,10 +183,17 @@ def compile_model(
         How many runtimes should be stored in the internal pool. This
         determines how many inferences can happen concurrently. By
         default, set to 1. Must be positive.
+    profile_dir: str
+        The base dir to generate profiling source codes. By default, workdir/test_name
+    constants: Dict[str, TorchTensor], optional
+        User-provided constants to bind to the graph. The constants can be folded and packaged into
+        the final *.so.
     allocator_kind: AITemplateAllocatorKind, optional
         The GPU allocator to use. If none is specified, use the default allocator.
     debug_settings: AITDebugSettings
         specify debug settings such as where to dump AITemplate model Python file, etc.
+    do_optimize_graph: bool
+        Apply full list of graph optimizations. Default: True
 
     Returns
     -------


### PR DESCRIPTION
Fixes:
- Add doc for missing `compile_model()` parameters
- Fix output type of `in_ci_env()`
- Fix op**it**mizations typo