### PR TITLE
Build Cache CI Integration

### DIFF
--- a/python/aitemplate/utils/environ.py
+++ b/python/aitemplate/utils/environ.py
@@ -81,3 +81,39 @@ def ait_build_cache_dir() -> Optional[str]:
         or None if not set.
     """
     return os.environ.get("AIT_BUILD_CACHE_DIR", None)
+
+
+def ait_build_cache_skip_percentage() -> int:
+    """
+    When set to a non-empty string, and if AIT_BUILD_CACHE_DIR
+    is set, the build cache will be skipped randomly with
+    a probability correspinding to the specified percentage
+
+    Returns:
+        int: Integer value of AIT_BUILD_CACHE_SKIP_PERCENTAGE environment variable,
+        or 5 if not set.
+    """
+    return int(os.environ.get("AIT_BUILD_CACHE_SKIP_PERCENTAGE", "30"))
+
+
+def ait_build_cache_skip_profiler() -> bool:
+    """
+    boolean value of AIT_BUILD_CACHE_SKIP_PROFILER environment variable.
+    Will return True if that variable is not set, if it is equal to "0",
+    an empty string or "False" ( case insensitive ). Will return True
+    in all other cases.
+    """
+    ret = os.environ.get("AIT_BUILD_CACHE_SKIP_PROFILER", "1")
+    if ret is None or ret == "" or ret == "0" or ret.lower() == "false":
+        return False
+    return True
+
+
+def ait_build_cache_max_mb() -> int:
+    """
+    boolean value of AIT_BUILD_CACHE_MAX_MB environment variable.
+    This determines the maximum size of the artifact data to be cached
+    in MB. For larger (raw, uncompressed) data the build cache will
+    be skipped. Defaults to 30.
+    """
+    return int(os.environ.get("AIT_BUILD_CACHE_MAX_MB", "30"))

--- a/tests/unittest/compiler/test_compilation_failure.py
+++ b/tests/unittest/compiler/test_compilation_failure.py
@@ -17,6 +17,7 @@ import unittest
 from unittest.mock import patch
 
 import jinja2
+from aitemplate.backend.build_cache_base import SkipBuildCache
 
 from aitemplate.compiler import compile_model, ops
 from aitemplate.compiler.base import DynamicProfileStrategy
@@ -67,14 +68,14 @@ class CompilationFailureTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-
-        compile_model(
-            Y,
-            target,
-            f"./tmp/{test_name}",
-            test_name,
-            dynamic_profiling_strategy=DynamicProfileStrategy.HINTS,
-        )
+        with SkipBuildCache():
+            compile_model(
+                Y,
+                target,
+                f"./tmp/{test_name}",
+                test_name,
+                dynamic_profiling_strategy=DynamicProfileStrategy.HINTS,
+            )
 
     def test_compilation_failure_profiler(self):
         target = detect_target().name()

--- a/tests/unittest/compiler/test_transform_permute_to_reshape.py
+++ b/tests/unittest/compiler/test_transform_permute_to_reshape.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import re
 import unittest
 
 import torch
@@ -38,11 +39,15 @@ def _generate_model_name(shape, permutation, is_reshape, dtype, is_complex):
         [
             ("test_permute_complex" if is_complex else "test_permute"),
             ("to_reshape" if is_reshape else "not_to_reshape"),
-            "x".join([str(s) for s in shape]),
-            "".join([str(s) for s in permutation]),
+            "x".join([str(s) for s in shape]),  #  these  can contain characters
+            "".join([str(s) for s in permutation]),  #  unsafe for usage in filenames
             dtype,
         ]
     )
+    # replace non-alphanumeric characters with underscores
+    # The ^ within the [^a-zA-Z0-9_] is a negation of the
+    # character class so it matches every character not in that class,
+    model_name = re.sub(r"[^a-zA-Z0-9_]", "_", model_name)
     return model_name
 
 

--- a/tests/unittest/ops/test_conv_bias_act_few_channels.py
+++ b/tests/unittest/ops/test_conv_bias_act_few_channels.py
@@ -106,7 +106,7 @@ class ConvBiasActFewChannelsTestCase(unittest.TestCase):
         )
         self._test_conv_bias_relu_few_channels(
             copy_op=True,
-            test_name="conv_bias_relu_few_channels_{dtype}_copy_op",
+            test_name=f"conv_bias_relu_few_channels_{dtype}_copy_op",
             dtype=dtype,
         )
 

--- a/tests/unittest/ops/test_conv_bias_add_hardswish.py
+++ b/tests/unittest/ops/test_conv_bias_add_hardswish.py
@@ -112,7 +112,7 @@ class ConvBiasAddHardswishTestCase(unittest.TestCase):
         )
         self._test_conv_bias_add_hardswish(
             copy_op=True,
-            test_name="conv2d_bias_add_hardswish_{dtype}_copy_op",
+            test_name=f"conv2d_bias_add_hardswish_{dtype}_copy_op",
             dtype=dtype,
         )
 


### PR DESCRIPTION
Summary:
See T148695911

With D44229622 we could prove that it should be possible to speed up unit tests and therefore also CI runs considerably.

The task was to integrate the build cache with Sandcastle CI
in order to speed up our CI process.

For reference about considered options, tradeoffs and decision process:

Original design doc at https://docs.google.com/document/d/1GHuhIJ83CsS3hgB8bV53TDTIqavqpPl4guP_kDcWdII/edit
Final design review meeting slides & notes: https://docs.google.com/presentation/d/1bICc-OtCp1kgisL3SOCN7XYN4ZRn9a6JX62eMjFUI68/edit#slide=id.g1e0053f1f88_0_53

Implementation:

 [x] Created a Manifold-based build cache implementation
 [x] incorporated it into the non-OSS part of the codebase, similar to fb/detect_model.py in fb/build_cache.py
 [x] Sets TTL on stored objects. Resets this TTL on read (  asynchronously, no need to wait for this before continuing )
 [x]Archiving and storing of files to be cached happen asynchronously in order not to delay the tests.
 [x]Investigated whether we can get Manifold latency down by creating a new bucket with different settings ( did not work for me)

 Add features and config options to:

 [x] Disabled caching for a compile_model call, entire unit test or globally ( env var )

 [x]Disabled the build cache for profiling only ( env var )
Not use the cache with a certain probability (in order to keep the build system and cache under test)
I
 [x]Incorporated info from question on Manifold Users Workplace group, whether we can use the official Manifold Client for this usecase ( https://fb.workplace.com/groups/ManifoldUsers/permalink/1682913152123392/ )

(Unless we quickly get an answer, the first implementation should use the deprecated manifold client, because that is proven to work and safe in multiprocessing. )

 [x] Does not cache .obj files ( unneccessary, and takes up large amount of storage in many cases )

 [x] Added unit test ( mock Manifold client )

Differential Revision: D44642328

