### PR TITLE
Fix "Profiler is not executable" error

### DIFF
--- a/python/aitemplate/backend/build_cache_base.py
+++ b/python/aitemplate/backend/build_cache_base.py
@@ -54,6 +54,8 @@ source_filenames = {
     "makefile"
 }
 
+source_filename_prefixes = ["makefile"]
+
 # File extensions of files to be considered cache artifacts ( unless they are considered source files )
 cache_extensions = {"obj", "so", "dll", "exe", ""}
 
@@ -91,7 +93,11 @@ def is_source(filename: str) -> bool:
         bool: Whether the filename is a source file
     """
     file_basename, file_ext = filename_norm_split(filename)
-    return (file_basename in source_filenames) or (file_ext in source_extensions)
+    return (
+        (file_basename in source_filenames)
+        or (file_ext in source_extensions)
+        or any(file_basename.startswith(p) for p in source_filename_prefixes)
+    )
 
 
 def is_cache_artifact(filename: str) -> bool:
@@ -181,7 +187,7 @@ def create_dir_hash(
                 continue
             hash_object.update(str(fpath).encode("utf-8"))
             fullpath = str(basepath / fpath)
-            if fpath.name.lower() == "makefile":
+            if fpath.name.lower().startswith("makefile"):
                 makefile_content = (basepath / fpath).read_bytes()
                 makefile_content = makefile_normalizer(makefile_content)
                 hash_object.update(makefile_content)

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_common.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_common.py
@@ -25,7 +25,8 @@ from dataclasses import dataclass
 from enum import Enum
 from hashlib import sha1
 from operator import itemgetter
-from typing import Any, Dict, List, Union
+from time import sleep
+from typing import Any, Callable, Dict, List, Union
 
 import jinja2
 
@@ -177,6 +178,22 @@ def _to_list(elem):
         return list(elem)
     else:
         return [elem]
+
+
+def _check_with_retries(
+    condition: Callable[[], bool],
+    max_attempts: int = 3,
+    delay_seconds: int = 5,
+) -> bool:
+    """Check a condition with retries."""
+    attempts = 0
+    while True:
+        if condition():
+            return True
+        attempts += 1
+        if attempts >= max_attempts:
+            return False
+        sleep(delay_seconds)
 
 
 class gemm(Operator):
@@ -526,8 +543,13 @@ class gemm(Operator):
         self, profiler_prefix, profiler_filename, exec_key, fbuild_cmd
     ):
         exe_path = os.path.join(profiler_prefix, profiler_filename)
-        if not os.access(exe_path, os.X_OK):
+        if not _check_with_retries(
+            condition=lambda: os.access(exe_path, os.X_OK),
+            max_attempts=3,
+            delay_seconds=5,
+        ):
             raise RuntimeError("Profiler %s is not executable" % exe_path)
+
         cmd_args = fbuild_cmd(exec_key)
         cmd = [exe_path]
         # mnk


### PR DESCRIPTION
Summary:
Previously, the same `Makefile` was used (and reused) for building all different kinds of profilers for different ops and op configurations. This has caused an issue when running parallel unit tests in a local environment, as contention for the same `./tmp/profiler/Makefile` has led to different tests rewriting it before being read by others.

As a result, the tests were building each others' profilers and were left without their own. The latter manifested itself in the following error, as the profiler executable that should have been built wouldn't have been there by the time the compilation would have ended:

```
Profiler ./tmp/profiler/gemm_rcr/gemm_rcr_9e46850d5286ecc7e078b5b7f76afbcac62967b4_3 is not executable
```

In this diff, the built profiler target names are included in the per-profiler `Makefile` name, hence excluding the possibility of different tests rewriting each other profiler `Makefile`s. This resolves the issue and the above error is no longer raised. Importantly, it is acceptable for the tests to rewrite the `Makefile` of the same profiler targets, as the content will also be the same.

Differential Revision: D44788627

