### PR TITLE
naively split test_bmm_dtype and test_bmm_broadcast_dtype

### DIFF
--- a/tests/unittest/compiler/test_fuse_mm_elementwise.py
+++ b/tests/unittest/compiler/test_fuse_mm_elementwise.py
@@ -32,6 +32,13 @@ from aitemplate.utils import shape_utils
 from parameterized import parameterized
 
 
+def custom_name_func(testcase_func, param_num, param):
+    return "%s_%s_sm80" % (
+        testcase_func.__name__[:-5],
+        param.args[-2],
+    )
+
+
 class FuseGemmRcrBiasCase(unittest.TestCase):
     def _build_gemm_rcr_bias(self, M, N, K, decomposed, dtype):
         X_shape = [M, K]
@@ -761,44 +768,96 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
         )
 
     @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
-    def test_gemm_rcr_bias_add_float_sm80(self):
-        self._test_gemm_rcr_bias(
-            [8], 16, 8, True, "gemm_rcr_bias_basic_decomposed_float", dtype="float"
-        )
-        self._test_gemm_rcr_bias_add(
-            [8], 16, 8, False, "gemm_rcr_bias_add_basic_float", dtype="float"
-        )
-        self._test_gemm_rcr_bias_add_add(
-            [8, 32], 16, 8, False, "gemm_rcr_bias_add_add_dynamic_float", dtype="float"
-        )
-        self._test_gemm_rcr_bias_add_add_relu(
-            [8],
-            16,
-            3,
-            False,
-            "gemm_rcr_bias_add_add_relu_need_align_float",
-            dtype="float",
-        )
-        self._test_gemm_rcr_bias_add_relu(
-            [8],
-            16,
-            8,
-            True,
-            "gemm_rcr_bias_add_relu_basic_decomposed_float",
-            dtype="float",
-        )
-        self._test_gemm_rcr_bias_tanh(
-            [8], 16, 8, False, "gemm_rcr_bias_tanh_basic_float", dtype="float"
-        )
-        self._test_gemm_rcr_bias_mul(
-            [8, 32], 16, 8, False, "gemm_rcr_bias_mul_dynamic_float", dtype="float"
-        )
-        self._test_gemm_rcr_bias_mul_add(
-            [8], 16, 3, False, "gemm_rcr_bias_mul_add_need_align_float", dtype="float"
-        )
-        self._test_gemm_rcr_bias_mul_tanh(
-            [8], 16, 3, False, "gemm_rcr_bias_mul_tanh_need_align_float", dtype="float"
-        )
+    @parameterized.expand(
+        [
+            (
+                _test_gemm_rcr_bias,
+                [8],
+                16,
+                8,
+                True,
+                "gemm_rcr_bias_basic_decomposed_float",
+                "float",
+            ),
+            (
+                _test_gemm_rcr_bias_add_add,
+                [8],
+                16,
+                8,
+                False,
+                "gemm_rcr_bias_add_basic_float",
+                "float",
+            ),
+            (
+                _test_gemm_rcr_bias_add_add,
+                [8, 32],
+                16,
+                8,
+                False,
+                "gemm_rcr_bias_add_add_dynamic_float",
+                "float",
+            ),
+            (
+                _test_gemm_rcr_bias_add_add_relu,
+                [8],
+                16,
+                3,
+                False,
+                "gemm_rcr_bias_add_add_relu_need_align_float",
+                "float",
+            ),
+            (
+                _test_gemm_rcr_bias_add_relu,
+                [8],
+                16,
+                8,
+                True,
+                "gemm_rcr_bias_add_relu_basic_decomposed_float",
+                "float",
+            ),
+            (
+                _test_gemm_rcr_bias_tanh,
+                [8],
+                16,
+                8,
+                False,
+                "gemm_rcr_bias_tanh_basic_float",
+                "float",
+            ),
+            (
+                _test_gemm_rcr_bias_mul,
+                [8, 32],
+                16,
+                8,
+                False,
+                "gemm_rcr_bias_mul_dynamic_float",
+                "float",
+            ),
+            (
+                _test_gemm_rcr_bias_mul_add,
+                [8],
+                16,
+                3,
+                False,
+                "gemm_rcr_bias_mul_add_need_align_float",
+                "float",
+            ),
+            (
+                _test_gemm_rcr_bias_mul_tanh,
+                [8],
+                16,
+                3,
+                False,
+                "gemm_rcr_bias_mul_tanh_need_align_float",
+                "float",
+            ),
+        ],
+        name_func=custom_name_func,
+    )
+    def test_gemm_rcr_bias_add_float_sm80(
+        self, func, Ms, N, K, decomposed, testname, dtype
+    ):
+        func(self, Ms, N, K, decomposed, testname, dtype)
 
 
 filter_test_cases_by_test_env(FuseGemmRcrBiasCase)
@@ -1144,63 +1203,89 @@ class FuseGemmRcrBiasActivationCase(unittest.TestCase):
         )
 
     @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
-    def test_gemm_rcr_bias_float_sm80(self):
-        self._test_gemm_rcr_bias_activation(
-            [8],
-            16,
-            8,
-            "relu",
-            "gemm_rcr_bias_relu",
-            True,
-            "gemm_rcr_bias_relu_basic_decomposed_float",
-            dtype="float",
-        )
-        self._test_gemm_rcr_bias_activation(
-            [8],
-            16,
-            8,
-            "sigmoid",
-            "gemm_rcr_bias_sigmoid",
-            False,
-            "gemm_rcr_bias_sigmoid_basic_float",
-            dtype="float",
-        )
-        self._test_gemm_rcr_bias_sigmoid_mul(
-            [8],
-            16,
-            8,
-            False,
-            "gemm_rcr_bias_sigmoid_mul_basic_float",
-            dtype="float",
-        )
-        self._test_gemm_rcr_bias_sigmoid_mul_tanh(
-            [8],
-            16,
-            3,
-            False,
-            "gemm_rcr_bias_sigmoid_mul_tanh_need_align_float",
-            dtype="float",
-        )
-        self._test_gemm_rcr_bias_activation(
-            [8],
-            16,
-            8,
-            "tanh",
-            "gemm_rcr_bias_tanh",
-            False,
-            "gemm_rcr_bias_tanh_basic_float",
-            dtype="float",
-        )
-        self._test_gemm_rcr_bias_activation(
-            [8, 32],
-            16,
-            8,
-            "fast_gelu",
-            "gemm_rcr_bias_fast_gelu",
-            True,
-            "gemm_rcr_bias_fast_gelu_basic_decomposed_float",
-            dtype="float",
-        )
+    @parameterized.expand(
+        [
+            (
+                _test_gemm_rcr_bias_activation,
+                [8],
+                16,
+                8,
+                True,
+                "gemm_rcr_bias_relu_basic_decomposed_float",
+                "float",
+                "relu",
+                "gemm_rcr_bias_relu",
+            ),
+            (
+                _test_gemm_rcr_bias_activation,
+                [8],
+                16,
+                8,
+                False,
+                "gemm_rcr_bias_sigmoid_basic_float",
+                "float",
+                "sigmoid",
+                "gemm_rcr_bias_sigmoid",
+            ),
+            (
+                _test_gemm_rcr_bias_sigmoid_mul,
+                [8],
+                16,
+                8,
+                False,
+                "gemm_rcr_bias_sigmoid_mul_basic_float",
+                "float",
+            ),
+            (
+                _test_gemm_rcr_bias_sigmoid_mul_tanh,
+                [8],
+                16,
+                3,
+                False,
+                "gemm_rcr_bias_sigmoid_mul_tanh_need_align_float",
+                "float",
+            ),
+            (
+                _test_gemm_rcr_bias_activation,
+                [8],
+                16,
+                8,
+                False,
+                "gemm_rcr_bias_tanh_basic_float",
+                "float",
+                "tanh",
+                "gemm_rcr_bias_tanh",
+            ),
+            (
+                _test_gemm_rcr_bias_activation,
+                [8, 32],
+                16,
+                8,
+                True,
+                "gemm_rcr_bias_fast_gelu_basic_decomposed_float",
+                "float",
+                "fast_gelu",
+                "gemm_rcr_bias_fast_gelu",
+            ),
+        ],
+        name_func=custom_name_func,
+    )
+    def test_gemm_rcr_bias_float_sm80(
+        self,
+        func,
+        Ms,
+        N,
+        K,
+        decomposed,
+        testname,
+        dtype,
+        activation=None,
+        target_ait=None,
+    ):
+        if activation and target_ait:
+            func(self, Ms, N, K, activation, target_ait, decomposed, testname, dtype)
+        else:
+            func(self, Ms, N, K, decomposed, testname, dtype)
 
 
 filter_test_cases_by_test_env(FuseGemmRcrBiasActivationCase)

--- a/tests/unittest/ops/test_bmm.py
+++ b/tests/unittest/ops/test_bmm.py
@@ -307,7 +307,7 @@ class BMMTestCase(unittest.TestCase):
 
     @parameterized.expand(filter_test_cases_by_params(_TEST_PARAMS))
     @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
-    def test_bmm_dtype(self, dtype):
+    def test_bmm_0_dtype(self, dtype):
         self._test_rcr([128], [64], N=8, K=64, test_name=f"static_{dtype}", dtype=dtype)
         self._test_rcr(
             [1, 5, 77, 128],
@@ -332,6 +332,9 @@ class BMMTestCase(unittest.TestCase):
             [1, 9, 11], M=64, N=32, K=16, test_name=f"dynamic_b_{dtype}", dtype=dtype
         )
 
+    @parameterized.expand(filter_test_cases_by_params(_TEST_PARAMS))
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_bmm_1_dtype(self, dtype):
         self._test_rcc([128], [64], N=8, K=64, test_name=f"static_{dtype}", dtype=dtype)
         self._test_rcc(
             [1, 5, 77, 128],
@@ -725,7 +728,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         self._test_ccr([8, 8, 16], [32, 8], "2d_broadcastable_b")
 
     @parameterized.expand(filter_test_cases_by_params(_TEST_PARAMS))
-    def test_bmm_broadcast_dtype(self, dtype):
+    def test_bmm_broadcast_0_dtype(self, dtype):
         self._test_rcr([2, 16, 8], [1, 32, 8], f"broadcastable_b_{dtype}", dtype=dtype)
         self._test_rcr([16, 8], [8, 32, 8], f"2d_broadcastable_a_{dtype}", dtype=dtype)
         self._test_crr([1, 8, 16], [2, 8, 32], f"broadcastable_a_{dtype}", dtype=dtype)
@@ -735,6 +738,8 @@ class BMMBroadcastTestCase(unittest.TestCase):
         self._test_ccr([1, 8, 16], [2, 32, 8], f"broadcastable_a_{dtype}", dtype=dtype)
         self._test_ccr([8, 8, 16], [32, 8], f"2d_broadcastable_b_{dtype}", dtype=dtype)
 
+    @parameterized.expand(filter_test_cases_by_params(_TEST_PARAMS))
+    def test_bmm_broadcast_1_dtype(self, dtype):
         self._test_rcc([2, 16, 8], [1, 32, 8], f"broadcastable_b_{dtype}", dtype=dtype)
         self._test_rcc([16, 8], [8, 32, 8], f"2d_broadcastable_a_{dtype}", dtype=dtype)
         self._test_crc([1, 8, 16], [2, 8, 32], f"broadcastable_a_{dtype}", dtype=dtype)

--- a/tests/unittest/ops/test_gemm_bias_broadcast.py
+++ b/tests/unittest/ops/test_gemm_bias_broadcast.py
@@ -25,6 +25,15 @@ from aitemplate.testing.test_utils import (
     get_torch_empty_tensor,
 )
 
+from parameterized import parameterized
+
+
+def custom_name_func(testcase_func, param_num, param):
+    return "%s_%s_sm80" % (
+        testcase_func.__name__[:-5],
+        str(param.args[0].__name__),
+    )
+
 
 class GEMMBiasBroadcastTestCase(unittest.TestCase):
     def _init_tensors(self, m, k, n, m0=None, m1=None, dtype="float16"):
@@ -322,29 +331,38 @@ class GEMMBiasBroadcastTestCase(unittest.TestCase):
     def test_bias_rcr_mul_tanh_rocm(self):
         self._test_bias_rcr_mul_tanh(8, None, None, 8, 8)
 
-    def test_gemm_bias_broadcast_float32_sm80(self):
-        self._test_bias_rcr_mul_add(None, 2, 32, 256, 128, dtype="float32")
-        self._test_bias_rcr_sigmoid_mul(None, 2, 32, 256, 128, dtype="float32")
-        self._test_bias_rcr_sigmoid_mul_tanh(None, 2, 32, 256, 128, dtype="float32")
-        self._test_bias_rcr_add(None, 2, 32, 256, 128, dtype="float32")
-        self._test_bias_rcr_add_relu(None, 2, 32, 256, 128, dtype="float32")
-        self._test_bias_rcr_add_relu(None, 2, 32, 256, 128, dtype="float32")
-        self._test_bias_rcr_add_add_relu(None, 2, 32, 256, 128, dtype="float32")
-        self._test_bias_rcr_mul(None, 2, 32, 256, 128, dtype="float32")
-        self._test_bias_rcr_add_add(None, 2, 32, 256, 128, dtype="float32")
-        self._test_bias_rcr_mul_tanh(None, 2, 32, 256, 128, dtype="float32")
+    @parameterized.expand(
+        [
+            (_test_bias_rcr_mul_add, None, 2, 32, 256, 128, "float32"),
+            (_test_bias_rcr_sigmoid_mul, None, 2, 32, 256, 128, "float32"),
+            (_test_bias_rcr_sigmoid_mul_tanh, None, 2, 32, 256, 128, "float32"),
+            (_test_bias_rcr_add, None, 2, 32, 256, 128, "float32"),
+            (_test_bias_rcr_add_relu, None, 2, 32, 256, 128, "float32"),
+            (_test_bias_rcr_add_add_relu, None, 2, 32, 256, 128, "float32"),
+            (_test_bias_rcr_mul, None, 2, 32, 256, 128, "float32"),
+            (_test_bias_rcr_add_add, None, 2, 32, 256, 128, "float32"),
+            (_test_bias_rcr_mul_tanh, None, 2, 32, 256, 128, "float32"),
+        ],
+        name_func=custom_name_func,
+    )
+    def test_gemm_bias_broadcast_float32_sm80(self, func, m, m0, m1, k, n, dtype):
+        func(self, m, m0, m1, k, n, dtype)
 
-    def test_gemm_bias_broadcast_bfloat16_bf16(self):
-        self._test_bias_rcr_mul_add(None, 2, 32, 256, 128, dtype="bfloat16")
-        self._test_bias_rcr_sigmoid_mul(None, 2, 32, 256, 128, dtype="bfloat16")
-        self._test_bias_rcr_sigmoid_mul_tanh(None, 2, 32, 256, 128, dtype="bfloat16")
-        self._test_bias_rcr_add(None, 2, 32, 256, 128, dtype="bfloat16")
-        self._test_bias_rcr_add_relu(None, 2, 32, 256, 128, dtype="bfloat16")
-        self._test_bias_rcr_add_relu(None, 2, 32, 256, 128, dtype="bfloat16")
-        self._test_bias_rcr_add_add_relu(None, 2, 32, 256, 128, dtype="bfloat16")
-        self._test_bias_rcr_mul(None, 2, 32, 256, 128, dtype="bfloat16")
-        self._test_bias_rcr_add_add(None, 2, 32, 256, 128, dtype="bfloat16")
-        self._test_bias_rcr_mul_tanh(None, 2, 32, 256, 128, dtype="bfloat16")
+    @parameterized.expand(
+        [
+            (_test_bias_rcr_mul_add, None, 2, 32, 256, 128, "bfloat16"),
+            (_test_bias_rcr_sigmoid_mul, None, 2, 32, 256, 128, "bfloat16"),
+            (_test_bias_rcr_sigmoid_mul_tanh, None, 2, 32, 256, 128, "bfloat16"),
+            (_test_bias_rcr_add, None, 2, 32, 256, 128, "bfloat16"),
+            (_test_bias_rcr_add_relu, None, 2, 32, 256, 128, "bfloat16"),
+            (_test_bias_rcr_add_add_relu, None, 2, 32, 256, 128, "bfloat16"),
+            (_test_bias_rcr_mul, None, 2, 32, 256, 128, "bfloat16"),
+            (_test_bias_rcr_add_add, None, 2, 32, 256, 128, "bfloat16"),
+            (_test_bias_rcr_mul_tanh, None, 2, 32, 256, 128, "bfloat16"),
+        ],
+    )
+    def test_gemm_bias_broadcast_bfloat16_bf16(self, func, m, m0, m1, k, n, dtype):
+        func(self, m, m0, m1, k, n, dtype)
 
     def test_gemm_bias_broadcast_use_fp16_acc_sm80(self):
         self._test_bias_rcr_mul(


### PR DESCRIPTION
Summary: This would help to reduce the test duration

Differential Revision: D44782015

