### PR TITLE
Carry over check_sequence_lengths in dedup_make_jagged_ops pass

### DIFF
--- a/python/aitemplate/compiler/transform/dedup_make_jagged_ops.py
+++ b/python/aitemplate/compiler/transform/dedup_make_jagged_ops.py
@@ -205,6 +205,9 @@ def _apply_make_jagged_to_inputs(
         new_make_jagged_op = make_jagged(
             batch_dim=data.jagged_int_var.batch_dim(),
             jagged_dims=data.jagged_int_var.jagged_dims(),
+            check_sequence_lengths=all(
+                d.op._attrs["check_sequence_lengths"] for d in make_jagged_group
+            ),
         )
         jagged_tensors = new_make_jagged_op(
             source=sources_list,


### PR DESCRIPTION
Summary: The `check_sequence_lengths` attribute of the `make_jagged` ops is not carried over in the `dedup_make_jagged_ops` from the old ops to the new one. This is a bug that causes problems in the setting where `check_sequence_lengths` is set to `False` in the existing ops, as the default value is `True`. The diff fixes the bug by carrying over the attribute in the pass.

Differential Revision: D44808132

