### PR TITLE
Fix MSVC compiler narrowing conversion errors for cuda/gemm_epilogue_vistor

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/bmm_rcr_softmax.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/bmm_rcr_softmax.py
@@ -59,7 +59,11 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
         N, S: (B, block_num, M) (RowMajor)
     */
 
-    {M, N, K},                                                                                                                             // cutlass::gemm::GemmCoord problem_size
+    {
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                                                                                                     // cutlass::gemm::GemmCoord problem_size
     B,                                                                                                                                     // int32_t batch_count_
     {reinterpret_cast<{{elem_input_type}}*>(a_ptr), LayoutA(K)},                                                                           // TensorRefA ref_A_
     {reinterpret_cast<{{elem_input_type}}*>(b_ptr), LayoutB(K)},                                                                           // TensorRefB ref_B_

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/common_dual_gemm.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/common_dual_gemm.py
@@ -94,6 +94,7 @@ EXEC_TEMPLATE = jinja2.Template(
 //{{indent}}using ElementComputeEpilogue = typename {{instance}}::ElementAccumulator;
 {{indent}}using ElementCompute = typename {{instance}}::DualGemmKernel::Epilogue0::OutputOp::ElementCompute;
 
+{{indent}}using coord_t = cutlass::gemm::GemmCoord::Index;
 {{indent}}typename {{instance}}::Arguments arguments{
 
 {{problem_args}}

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/common_softmax.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/common_softmax.py
@@ -125,6 +125,7 @@ EXEC_TEMPLATE = jinja2.Template(
 {{indent}}{{instance}} gemm_op;
 {% endif %}
 
+{{indent}}using coord_t = cutlass::gemm::GemmCoord::Index;
 {{indent}}typename {{instance}}::Arguments arguments{
 {{problem_args}}
 {{indent}}};

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/dual_bmm_rrr_div.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/dual_bmm_rrr_div.py
@@ -31,7 +31,11 @@ from aitemplate.backend.cuda.gemm_universal.layout import RRR
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::DualGemmMode::kBatched,         // DualGemmMode mode
-    cutlass::gemm::GemmCoord{M, N, K},             // GemmCoord problem_size_
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                             // GemmCoord problem_size_
     {({{elem_input_type}}*)a_ptr, LayoutA(K)},     // TensorRef<ElementA const, LayoutA> ref_A0_
     {({{elem_input_type}}*)b_ptr, LayoutB(N)},     // TensorRef<ElementB const, LayoutB0> ref_B0_
     nullptr_ref,                                   // TensorRef<ElementC const, LayoutC> ref_C0_

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/dual_gemm_rcr_fast_gelu.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/dual_gemm_rcr_fast_gelu.py
@@ -32,7 +32,11 @@ from aitemplate.backend.cuda.gemm_universal.layout import RCR
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::DualGemmMode::kGemm,            // DualGemmMode mode
-    cutlass::gemm::GemmCoord{M, N, K},             // GemmCoord problem_size_
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                             // GemmCoord problem_size_
     {({{elem_input_type}}*)a_ptr, LayoutA(K)},     // TensorRef<ElementA const, LayoutA> ref_A0_
     {({{elem_input_type}}*)b_ptr, LayoutB(K)},     // TensorRef<ElementB const, LayoutB0> ref_B0_
     ref_B0,                                        // TensorRef<ElementC const, LayoutC> ref_C0_

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/dual_gemm_rcr_silu.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/dual_gemm_rcr_silu.py
@@ -32,7 +32,11 @@ from aitemplate.backend.cuda.gemm_universal.layout import RCR
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::DualGemmMode::kGemm,            // DualGemmMode mode
-    cutlass::gemm::GemmCoord{M, N, K},             // GemmCoord problem_size_
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                             // GemmCoord problem_size_
     {({{elem_input_type}}*)a_ptr, LayoutA(K)},     // TensorRef<ElementA const, LayoutA> ref_A0_
     {({{elem_input_type}}*)b_ptr, LayoutB(K)},     // TensorRef<ElementB const, LayoutB0> ref_B0_
     ref_B0,                                        // TensorRef<ElementC const, LayoutC> ref_C0_

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/gemm_rcr_bias_softmax.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/gemm_rcr_bias_softmax.py
@@ -40,7 +40,11 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
         N, S: (block_num, M) (RowMajor)
     */
 
-    {M, N, K},                                                                                                                     // cutlass::gemm::GemmCoord problem_size
+    {
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                                                                                             // cutlass::gemm::GemmCoord problem_size
     1,                                                                                                                             // int32_t batch_count_
     {reinterpret_cast<{{elem_input_type}}*>(a_ptr), LayoutA(K)},                                                                   // TensorRefA ref_A_
     {reinterpret_cast<{{elem_input_type}}*>(b_ptr), LayoutB(K)},                                                                   // TensorRefB ref_B_

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/gemm_rcr_softmax.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/gemm_rcr_softmax.py
@@ -53,7 +53,11 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
         N, S: (block_num, M) (RowMajor)
     */
 
-    {M, N, K},                                                                                                                     // cutlass::gemm::GemmCoord problem_size
+    {
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                                                                                             // cutlass::gemm::GemmCoord problem_size
     1,                                                                                                                             // int32_t batch_count_
     {reinterpret_cast<{{elem_input_type}}*>(a_ptr), LayoutA(K)},                                                                   // TensorRefA ref_A_
     {reinterpret_cast<{{elem_input_type}}*>(b_ptr), LayoutB(K)},                                                                   // TensorRefB ref_B_


### PR DESCRIPTION
Summary: cutlass::gemm::GemmCoord uses int values as coordinates under the hood, while AIT might use int64_t variables in {M, N, K} constructor. So, narrowing conversion is needed.

Differential Revision: D44814784

