### PR TITLE
Increase tolerance of test_make_jagged_dedup

### DIFF
--- a/tests/unittest/ops/test_make_jagged.py
+++ b/tests/unittest/ops/test_make_jagged.py
@@ -491,7 +491,7 @@ class MakeJaggedTestCase(unittest.TestCase):
         result = torch.empty_like(result_pt)
         model.run_with_tensors(inputs, [result])
 
-        torch.testing.assert_close(result, result_pt, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(result, result_pt, rtol=5e-2, atol=5e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
`test_make_jagged_dedup` fails in some CircleCI jobs (mostly `main`), due to a minor discrepancy:

```
AssertionError: Tensor-likes are not close!

Mismatched elements: 1 / 224 (0.4%)
Greatest absolute difference: 0.01708984375 at index (0, 16) (up to 0.01 allowed)
Greatest relative difference: 0.03127792672028597 at index (0, 16) (up to 0.01 allowed)
```

The error, probably, accumulates due to the two gemm ops being applied back-to-back in the test. Here we increase the tolerance to `5e-2` to avoid the test failure in CircleCI.

Differential Revision: D44815979

