### PR TITLE
Fix _fuse_strided_op_and_cat: no GEMM+concat fusion with dim>=rank

### DIFF
--- a/python/aitemplate/compiler/transform/transform_strided_ops_utils.py
+++ b/python/aitemplate/compiler/transform/transform_strided_ops_utils.py
@@ -78,8 +78,14 @@ def gemm_stride_checker(
 
     # Need to make sure that the new stride dim doesn't break
     # last dim's continuity.
-    # This is because CUTLASS gemm API assumes that gemm stride
-    # only operates on the last dim.
+    # This is because CUTLASS GEMM API assumes that GEMM stride
+    # only operates on the last dim for row-major output.
+    # For example, concatenations of GEMMs along dimensions to the right of the
+    # original shape can't be fused. A particular case of this is when GEMM
+    # output of shape (M, N) is unsqueezed to (M, N, 1) and concatenated with
+    # another (M, N, 1).
+    if not original_ta.is_rightmost_dim_contiguous(dim):
+        return False
 
     if get_stride_at_dim is None:
         # The dim before the last dim

--- a/tests/unittest/compiler/test_strided_view_cat.py
+++ b/tests/unittest/compiler/test_strided_view_cat.py
@@ -97,6 +97,24 @@ class StridedViewCatOpTestCase(unittest.TestCase):
                 expected_num_tensors=14,
                 expected_num_ops=9,
             ),
+            param(
+                # Concat along rightmost unsqueezed dim - not fusible.
+                "gemm_reshape_cat_non_fusible_stride_dim_rightmost_unsqueezed",
+                n=2,
+                new_shape=[-1, 2, 2, 1],
+                cat_dim=3,
+                expected_num_tensors=16,
+                expected_num_ops=9,
+            ),
+            param(
+                # Concat along inner unsqueezed dim - fusible.
+                "gemm_reshape_cat_fusible_stride_dim_inner_unsqueezed",
+                n=2,
+                new_shape=[-1, 2, 1, 2],
+                cat_dim=2,
+                expected_num_tensors=10,
+                expected_num_ops=9,
+            ),
         ],
         name_func=custom_name_func,
     )


### PR DESCRIPTION
Summary:
`_fuse_strided_op_and_cat` pass inside `transform_strided_ops` shouldn't fuse GEMM and concat if concatenation is happening along a dimension >= rank of the original shape. This happens, for example, when GEMM output of shape `(M, N)` is unsqueezed to `(M, N, 1)` and concatenated with another `(M, N, 1)`. Such fusion would require GEMM to write the last dimension into memory in a non-contiguous way, which is not supported for row-major output (only one stride is supported).
However, fusion is possible when unsqueezed dimension is internal - e.g. when final shape is `(M, 1, N)`.
Function `_dim_is_inside_original_shape` checks if fusion is possible based on these criteria.

Differential Revision: D44747795

