### PR TITLE
Ensure safe build dir name

### DIFF
--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -39,6 +39,7 @@ from aitemplate.compiler.transform.name_graph import reset_name_counters
 from aitemplate.compiler.transform.profile import elapsed_dt_sec
 from aitemplate.utils import graph_utils
 from aitemplate.utils.debug_settings import AITDebugSettings
+from aitemplate.utils.io import is_safe_dir_name
 from aitemplate.utils.serialization.serdes_code import dump_program
 
 # pylint: disable=W0102
@@ -173,7 +174,8 @@ def compile_model(
     workdir : str
         A workdir to store profiling and execution source codes, as well as the result .so file.
     test_name : str
-        Name of the test. Used as the name of the subdir which stores the generated .so file.
+        Name of the test. Used as the name of the subdir which stores the generated .so file. May only consist of
+        english alphanumeric characters, underscores, dashes, slashes, commas and dots. No whitespace or special characters permitted.
     profile_devs : List[int], optional
         A list of profiling devices, by default device 0 will be used.
     dynamic_profiling_strategy: DynamicProfileStrategy, optional
@@ -201,6 +203,9 @@ def compile_model(
     Model
         A model object.
     """
+    assert is_safe_dir_name(
+        test_name
+    ), f"The test_name argument has to be a non-empty and valid subdirectory name. Permitted characters are alphanumeric chars, underscore, dash and dot. Current value: '{test_name}'"
     if constants is None:
         constants = {}
 

--- a/python/aitemplate/utils/environ.py
+++ b/python/aitemplate/utils/environ.py
@@ -81,3 +81,39 @@ def ait_build_cache_dir() -> Optional[str]:
         or None if not set.
     """
     return os.environ.get("AIT_BUILD_CACHE_DIR", None)
+
+
+def ait_build_cache_skip_percentage() -> int:
+    """
+    When set to a non-empty string, and if AIT_BUILD_CACHE_DIR
+    is set, the build cache will be skipped randomly with
+    a probability correspinding to the specified percentage
+
+    Returns:
+        int: Integer value of AIT_BUILD_CACHE_SKIP_PERCENTAGE environment variable,
+        or 5 if not set.
+    """
+    return int(os.environ.get("AIT_BUILD_CACHE_SKIP_PERCENTAGE", "30"))
+
+
+def ait_build_cache_skip_profiler() -> bool:
+    """
+    boolean value of AIT_BUILD_CACHE_SKIP_PROFILER environment variable.
+    Will return True if that variable is not set, if it is equal to "0",
+    an empty string or "False" ( case insensitive ). Will return True
+    in all other cases.
+    """
+    ret = os.environ.get("AIT_BUILD_CACHE_SKIP_PROFILER", "1")
+    if ret is None or ret == "" or ret == "0" or ret.lower() == "false":
+        return False
+    return True
+
+
+def ait_build_cache_max_mb() -> int:
+    """
+    boolean value of AIT_BUILD_CACHE_MAX_MB environment variable.
+    This determines the maximum size of the artifact data to be cached
+    in MB. For larger (raw, uncompressed) data the build cache will
+    be skipped. Defaults to 30.
+    """
+    return int(os.environ.get("AIT_BUILD_CACHE_MAX_MB", "30"))

--- a/python/aitemplate/utils/io.py
+++ b/python/aitemplate/utils/io.py
@@ -18,6 +18,7 @@ Util functions to handle file or network io
 import hashlib
 import logging
 import os
+import re
 import tarfile
 import time
 from io import BytesIO, FileIO
@@ -73,6 +74,16 @@ def file_sizes(directory, filter_function=None):
                 total_size += os.path.getsize(file_path)
 
     return total_size
+
+
+def is_safe_dir_name(test_name):
+    # Returns true if test_name is a nonempty string consisting of only alphanumerics,
+    # underscores, hyphens, forward-slash, commas and dots, and is not equal to ".." or "."
+    if not isinstance(test_name, str):
+        return False
+    if test_name in ["..", ".", ""]:
+        return False
+    return re.fullmatch(r"[a-zA-Z0-9_.,\-/]+", test_name) is not None
 
 
 # Utility functions to be used by (not yet existing) distributed cache implementations

--- a/tests/unittest/compiler/test_compilation_failure.py
+++ b/tests/unittest/compiler/test_compilation_failure.py
@@ -17,6 +17,7 @@ import unittest
 from unittest.mock import patch
 
 import jinja2
+from aitemplate.backend.build_cache_base import SkipBuildCache
 
 from aitemplate.compiler import compile_model, ops
 from aitemplate.compiler.base import DynamicProfileStrategy
@@ -67,14 +68,14 @@ class CompilationFailureTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-
-        compile_model(
-            Y,
-            target,
-            f"./tmp/{test_name}",
-            test_name,
-            dynamic_profiling_strategy=DynamicProfileStrategy.HINTS,
-        )
+        with SkipBuildCache():
+            compile_model(
+                Y,
+                target,
+                f"./tmp/{test_name}",
+                test_name,
+                dynamic_profiling_strategy=DynamicProfileStrategy.HINTS,
+            )
 
     def test_compilation_failure_profiler(self):
         target = detect_target().name()

--- a/tests/unittest/compiler/test_compilation_failure.py
+++ b/tests/unittest/compiler/test_compilation_failure.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import logging
 import os
 import unittest
 from unittest.mock import patch
@@ -23,6 +24,8 @@ from aitemplate.compiler import compile_model, ops
 from aitemplate.compiler.base import DynamicProfileStrategy
 from aitemplate.frontend import IntImm, Tensor
 from aitemplate.testing import detect_target
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class _EnableForceProfile:
@@ -96,6 +99,32 @@ class CompilationFailureTestCase(unittest.TestCase):
             mock_gen_function.return_value = "BAD CODE!"
             with self.assertRaisesRegex(RuntimeError, "Build has failed."):
                 self._test_compilation_failure(test_name="compilation_failure_function")
+
+    def test_unsafe_build_dir_failures(self):
+        for test_name in [
+            "contains spaces",
+            "contains$sign",
+            " starts-with-space",
+            "with{curly",
+            "with|pipe",
+            ".",
+            "..",
+            "[8]",
+            "<",
+            ">",
+            "?",
+            "*",
+            "!",
+            "#",
+            r"a\b",
+            "a:b",
+            "",
+        ]:
+            with self.assertRaisesRegex(
+                AssertionError,
+                "The test_name argument has to be a non-empty and valid subdirectory name",
+            ):
+                self._test_compilation_failure(test_name=test_name)
 
 
 if __name__ == "__main__":

--- a/tests/unittest/compiler/test_transform_permute_to_reshape.py
+++ b/tests/unittest/compiler/test_transform_permute_to_reshape.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import re
 import unittest
 
 import torch
@@ -38,11 +39,15 @@ def _generate_model_name(shape, permutation, is_reshape, dtype, is_complex):
         [
             ("test_permute_complex" if is_complex else "test_permute"),
             ("to_reshape" if is_reshape else "not_to_reshape"),
-            "x".join([str(s) for s in shape]),
-            "".join([str(s) for s in permutation]),
+            "x".join([str(s) for s in shape]),  #  these  can contain characters
+            "".join([str(s) for s in permutation]),  #  unsafe for usage in filenames
             dtype,
         ]
     )
+    # replace non-alphanumeric characters with underscores
+    # The ^ within the [^a-zA-Z0-9_] is a negation of the
+    # character class so it matches every character not in that class,
+    model_name = re.sub(r"[^a-zA-Z0-9_]", "_", model_name)
     return model_name
 
 

--- a/tests/unittest/ops/test_conv_bias_act_few_channels.py
+++ b/tests/unittest/ops/test_conv_bias_act_few_channels.py
@@ -106,7 +106,7 @@ class ConvBiasActFewChannelsTestCase(unittest.TestCase):
         )
         self._test_conv_bias_relu_few_channels(
             copy_op=True,
-            test_name="conv_bias_relu_few_channels_{dtype}_copy_op",
+            test_name=f"conv_bias_relu_few_channels_{dtype}_copy_op",
             dtype=dtype,
         )
 

--- a/tests/unittest/ops/test_conv_bias_add_hardswish.py
+++ b/tests/unittest/ops/test_conv_bias_add_hardswish.py
@@ -112,7 +112,7 @@ class ConvBiasAddHardswishTestCase(unittest.TestCase):
         )
         self._test_conv_bias_add_hardswish(
             copy_op=True,
-            test_name="conv2d_bias_add_hardswish_{dtype}_copy_op",
+            test_name=f"conv2d_bias_add_hardswish_{dtype}_copy_op",
             dtype=dtype,
         )
 


### PR DESCRIPTION
Summary:
In D44642328 we saw a test failure related to some test generating a test name which contains characters which might be unsafe for file or directory names ( e.g. curly brackets in that case ). In order to guard against such a thing, this
diff introduces a small safety check in compile_model which assserts that the test_name argument contains only whitelisted characters ( english alphanumeric, underscore, dash, dot ) and that it is a nonempty string which is not one of the special directories "." or "..".

Differential Revision: D44867941

