### PR TITLE
Fix reduce ops with last input dim IntVar

### DIFF
--- a/python/aitemplate/backend/cuda/reduce/reduce_small_axis.py
+++ b/python/aitemplate/backend/cuda/reduce/reduce_small_axis.py
@@ -313,7 +313,12 @@ def _get_read_vector_type(input_shape, input_type, force_min_vec_type=False) -> 
         raise NotImplementedError("Unsupported vector size: {}".format(sz_in_byte))
 
     reduction_axis = -1
-    assert isinstance(input_shape[reduction_axis], IntImm)
+
+    if not isinstance(input_shape[reduction_axis], IntImm):
+        # the last dimension is IntVar, so the best we can do in
+        # terms of the read vector type is the input_type iteself
+        return input_type
+
     rank = len(input_shape)
     reduction_dim_val = input_shape[reduction_axis]._attrs["values"][0]
     input_type_sz_in_bit = type_to_size_in_bit.get(input_type)

--- a/tests/unittest/ops/test_reduce.py
+++ b/tests/unittest/ops/test_reduce.py
@@ -99,7 +99,7 @@ class ReduceTestCase(unittest.TestCase):
         atol=1e-2,
     ):
         self._run_reduce(
-            test_name="reduce_sum",
+            test_name=f"reduce_sum_{input_type}_{output_type}",
             reduce_op=ops.reduce_sum,
             torch_reduce_op=torch.sum,
             dim=dim,
@@ -219,7 +219,7 @@ class ReduceTestCase(unittest.TestCase):
         output_type=None,
     ):
         self._run_reduce(
-            test_name="reduce_mean",
+            test_name=f"reduce_mean_{input_type}_{output_type}",
             reduce_op=ops.reduce_mean,
             torch_reduce_op=torch.mean,
             dim=dim,
@@ -231,7 +231,11 @@ class ReduceTestCase(unittest.TestCase):
 
     def test_reduce_mean(self):
         self._run_reduce_mean(
-            dim=0, input_shape=[1], keepdim=True, input_type="float16", output_type=None
+            dim=0,
+            input_shape=[1],
+            keepdim=True,
+            input_type="float16",
+            output_type=None,
         )
         self._run_reduce_mean(
             dim=1,
@@ -445,7 +449,7 @@ class ReduceTestCase(unittest.TestCase):
         output_type=None,
     ):
         self._run_batched_reduce(
-            test_name="reduce_sum_batched",
+            test_name=f"reduce_sum_batched_{input_type}_{output_type}",
             reduce_op=ops.reduce_sum,
             torch_reduce_op=torch.sum,
             dim=dim,


### PR DESCRIPTION
Summary:
The `recude_*` ops seem to fail [this assertion](https://github.com/facebookincubator/AITemplate/blob/main/python/aitemplate/backend/cuda/reduce/reduce_small_axis.py#L316) when the last input dimension is `IntVar`. The problem seems to be that the reduction axis is assumed to be -1 in the `_get_read_vector_type` function, even if it's actually not. Hence the check [here](https://github.com/facebookincubator/AITemplate/blob/main/python/aitemplate/backend/cuda/reduce/reduce_small_axis.py#L413) against the actual reduction axis passes, but the subsequent aforementioned assertion fails.

This diff replaces the assertion by using the `input_type` as the `read_vector_type` if the last input dim is `IntVar`, as the `IntVar` reduction dim's value can be odd in the runtime. Instead of failing the assertion the code compilation successfully completes.

Differential Revision: D44915126

