### PR TITLE
arange as model param

### DIFF
--- a/fx2ait/fx2ait/tools/common_fx2ait.py
+++ b/fx2ait/fx2ait/tools/common_fx2ait.py
@@ -87,6 +87,7 @@ class AITTestCase(TestCase):
         passes: List[Callable] = [],  # noqa: B006
         leaf_module: Callable = None,  # one leaf module
         apply_passes_to_lowered_module_only=False,
+        use_fp16_acc=True,
     ):
         # TODO: add precision to interpreter once AIT supports multiple precision level
         # TODO: @qxy11 remove permute options once AIT supports channels-first format
@@ -119,6 +120,7 @@ class AITTestCase(TestCase):
             inputs,
             "/tmp",
             f"test-fx2ait-{uuid.uuid1()}",
+            use_fp16_acc=use_fp16_acc,
         )
         with torch.no_grad():
             cuda_inputs = []

--- a/python/aitemplate/frontend/nn/ldm/embeddings.py
+++ b/python/aitemplate/frontend/nn/ldm/embeddings.py
@@ -15,58 +15,12 @@
 import math
 
 from aitemplate.compiler import ops
-from aitemplate.frontend import nn, Tensor
+from aitemplate.frontend import nn
 
 
 def get_shape(x):
     shape = [it.value() for it in x._attrs["shape"]]
     return shape
-
-
-def get_timestep_embedding(
-    timesteps: Tensor,
-    embedding_dim: int,
-    flip_sin_to_cos: bool = False,
-    downscale_freq_shift: float = 1,
-    scale: float = 1,
-    max_period: int = 10000,
-):
-    """
-    This matches the implementation in Denoising Diffusion Probabilistic Models: Create sinusoidal timestep embeddings.
-
-    :param timesteps: a 1-D Tensor of N indices, one per batch element.
-                      These may be fractional.
-    :param embedding_dim: the dimension of the output. :param max_period: controls the minimum frequency of the
-    embeddings. :return: an [N x dim] Tensor of positional embeddings.
-    """
-    assert len(get_shape(timesteps)) == 1, "Timesteps should be a 1d-array"
-
-    half_dim = embedding_dim // 2
-
-    exponent = (-math.log(max_period)) * Tensor(
-        shape=[half_dim], dtype="float16", name="arange"
-    )
-
-    exponent = exponent * (1.0 / (half_dim - downscale_freq_shift))
-
-    emb = ops.exp(exponent)
-    emb = ops.reshape()(timesteps, [-1, 1]) * ops.reshape()(emb, [1, -1])
-
-    # scale embeddings
-    emb = scale * emb
-
-    # concat sine and cosine embeddings
-    if flip_sin_to_cos:
-        emb = ops.concatenate()(
-            [ops.cos(emb), ops.sin(emb)],
-            dim=-1,
-        )
-    else:
-        emb = ops.concatenate()(
-            [ops.sin(emb), ops.cos(emb)],
-            dim=-1,
-        )
-    return emb
 
 
 class TimestepEmbedding(nn.Module):
@@ -90,12 +44,34 @@ class Timesteps(nn.Module):
         self.num_channels = num_channels
         self.flip_sin_to_cos = flip_sin_to_cos
         self.downscale_freq_shift = downscale_freq_shift
+        self.scale = 1
+        self.max_period = 10000
+        half_dim = self.num_channels // 2
+        self.arange = nn.Parameter(shape=[half_dim], dtype="float16", name="arange")
 
     def forward(self, timesteps):
-        t_emb = get_timestep_embedding(
-            timesteps,
-            self.num_channels,
-            flip_sin_to_cos=self.flip_sin_to_cos,
-            downscale_freq_shift=self.downscale_freq_shift,
-        )
-        return t_emb
+        assert len(get_shape(timesteps)) == 1, "Timesteps should be a 1d-array"
+
+        half_dim = self.num_channels // 2
+
+        exponent = (-math.log(self.max_period)) * self.arange.tensor()
+        exponent = exponent * (1.0 / (half_dim - self.downscale_freq_shift))
+
+        emb = ops.exp(exponent)
+        emb = ops.reshape()(timesteps, [-1, 1]) * ops.reshape()(emb, [1, -1])
+
+        # scale embeddings
+        emb = self.scale * emb
+
+        # concat sine and cosine embeddings
+        if self.flip_sin_to_cos:
+            emb = ops.concatenate()(
+                [ops.cos(emb), ops.sin(emb)],
+                dim=-1,
+            )
+        else:
+            emb = ops.concatenate()(
+                [ops.sin(emb), ops.cos(emb)],
+                dim=-1,
+            )
+        return emb


### PR DESCRIPTION
Summary: Refactoring "arange" tensor used in time embeddings to be model parameter.

Differential Revision: D44903108

