### PR TITLE
Add SM90 kernel foundations

### DIFF
--- a/python/aitemplate/backend/cuda/elementwise/custom_math.cuh
+++ b/python/aitemplate/backend/cuda/elementwise/custom_math.cuh
@@ -15,12 +15,12 @@
 #ifndef CUSTOM_MATH
 #define CUSTOM_MATH
 
-#ifndef __HALF2_TO_UI
-#define __HALF2_TO_UI(var) *(reinterpret_cast<unsigned int*>(&(var)))
+#ifndef __TO_UI
+#define __TO_UI(var) *(reinterpret_cast<unsigned int*>(&(var)))
 #endif
 
-#ifndef __HALF_TO_US
-#define __HALF_TO_US(var) *(reinterpret_cast<unsigned short*>(&(var)))
+#ifndef __TO_US
+#define __TO_US(var) *(reinterpret_cast<unsigned short*>(&(var)))
 #endif
 
 #define NOT_IMPLEMENTED() assert(0 && __PRETTY_FUNCTION__)
@@ -92,8 +92,8 @@ __device__ half2 fast_tanh(half2 x) {
     (__CUDA_ARCH__ >= 750)
 
   asm volatile("tanh.approx.f16x2 %0, %1;"
-               : "=r"(__HALF2_TO_UI(x))
-               : "r"(__HALF2_TO_UI(x)));
+               : "=r"(__TO_UI(x))
+               : "r"(__TO_UI(x)));
   return x;
 
 #else
@@ -106,9 +106,7 @@ __device__ half fast_tanh(half x) {
 #if defined(__CUDA_ARCH__) && (__CUDACC_VER_MAJOR__ >= 11) && \
     (__CUDA_ARCH__ >= 750)
 
-  asm volatile("tanh.approx.f16 %0, %1;"
-               : "=h"(__HALF_TO_US(x))
-               : "h"(__HALF_TO_US(x)));
+  asm volatile("tanh.approx.f16 %0, %1;" : "=h"(__TO_US(x)) : "h"(__TO_US(x)));
   return x;
 
 #else
@@ -121,8 +119,8 @@ __device__ bfloat16_2 fast_tanh(bfloat16_2 x) {
     (__CUDA_ARCH__ >= 900)
 
   asm volatile("tanh.approx.bf16x2 %0, %1;"
-               : "=r"(__HALF_TO_UI(x))
-               : "r"(__HALF_TO_UI(x)));
+               : "=r"(__TO_UI(x))
+               : "r"(__TO_UI(x)));
   return x;
 
 #elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
@@ -136,9 +134,7 @@ __device__ bfloat16_2 fast_tanh(bfloat16_2 x) {
 __device__ bfloat16 fast_tanh(bfloat16 x) {
 #if defined(__CUDA_ARCH__) && (__CUDACC_VER_MAJOR__ >= 11) && \
     (__CUDA_ARCH__ >= 900)
-  asm volatile("tanh.approx.bf16 %0, %1;"
-               : "=h"(__HALF_TO_US(x))
-               : "h"(__HALF_TO_US(x)));
+  asm volatile("tanh.approx.bf16 %0, %1;" : "=h"(__TO_US(x)) : "h"(__TO_US(x)));
   return x;
 
 #elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)

--- a/python/aitemplate/backend/cuda/target_def.py
+++ b/python/aitemplate/backend/cuda/target_def.py
@@ -355,6 +355,11 @@ class FBCUDA(CUDA):
                 for arg in pp_args:
                     fb_include.write(pipes.quote(arg) + "\n")
 
+            nvcc_arch = self._arch
+            if nvcc_arch == "90":
+                # required by CUTLASS SM90 TMA kernels
+                nvcc_arch = "90a"
+
             options = (
                 self.nvcc_options_json["args"]
                 + ["-I" + path for path in cutlass_path]
@@ -373,7 +378,7 @@ class FBCUDA(CUDA):
                     "-w",
                     "--expt-relaxed-constexpr",
                     "--use_fast_math",
-                    f"-gencode=arch=compute_{self._arch},code=[sm_{self._arch},compute_{self._arch}]",
+                    f"-gencode=arch=compute_{nvcc_arch},code=[sm_{nvcc_arch},compute_{nvcc_arch}]",
                     "-Xcompiler=-Wconversion",
                     environ.get_compiler_opt_level(),
                     "-std=c++17",

--- a/python/aitemplate/backend/cuda/utils.py
+++ b/python/aitemplate/backend/cuda/utils.py
@@ -18,7 +18,10 @@ Util functions for CUDA codegen.
 import logging
 
 from aitemplate.backend import registry
-
+from aitemplate.utils.environ import (
+    allow_cutlass_sm90_kernels,
+    force_cutlass_sm90_kernels,
+)
 from aitemplate.utils.mk_cutlass_lib.mk_cutlass_lib import mk_cutlass_lib
 
 # pylint: disable=C0103,C0415,W0707
@@ -53,16 +56,29 @@ def gen_ops(arch):
 
     args = Args(arch)
     manifest = cutlass_lib.manifest.Manifest(args)
-    try:
-        func = getattr(cutlass_lib.generator, "GenerateSM" + arch)
-        func(manifest, args.cuda_version)
-    except AttributeError as e:
-        raise NotImplementedError(
-            "Arch " + arch + " is not supported by current cutlass lib."
-        ) from e
-    try:
-        func = getattr(cutlass_lib.extra_operation, "GenerateSM" + arch)
-        func(manifest, args)
-    except AttributeError:
-        _LOGGER.warning("Arch " + arch + " is not supported by extra ops.")
+
+    if arch == "90":
+        if force_cutlass_sm90_kernels():
+            cutlass_lib.generator.GenerateSM90(manifest, cuda_version="12.0.0")
+        elif allow_cutlass_sm90_kernels():
+            cutlass_lib.generator.GenerateSM90(manifest, cuda_version="12.0.0")
+            cutlass_lib.generator.GenerateSM80(manifest, args.cuda_version)
+            cutlass_lib.extra_operation.GenerateSM80(manifest, args)
+        else:
+            cutlass_lib.generator.GenerateSM80(manifest, args.cuda_version)
+            cutlass_lib.extra_operation.GenerateSM80(manifest, args)
+    else:
+        try:
+            func = getattr(cutlass_lib.generator, "GenerateSM" + arch)
+            func(manifest, args.cuda_version)
+        except AttributeError as e:
+            raise NotImplementedError(
+                "Arch " + arch + " is not supported by current cutlass lib."
+            ) from e
+        try:
+            func = getattr(cutlass_lib.extra_operation, "GenerateSM" + arch)
+            func(manifest, args)
+        except AttributeError:
+            _LOGGER.warning("Arch " + arch + " is not supported by extra ops.")
+
     return manifest.operations

--- a/python/aitemplate/utils/environ.py
+++ b/python/aitemplate/utils/environ.py
@@ -117,3 +117,24 @@ def ait_build_cache_max_mb() -> int:
     be skipped. Defaults to 30.
     """
     return int(os.environ.get("AIT_BUILD_CACHE_MAX_MB", "30"))
+
+
+def allow_cutlass_sm90_kernels() -> bool:
+    """
+    Whether the SM90 CUTLASS kernels should to be considered
+    alongside the SM80 CUTLASS kernels on the CUDA arch 90
+    (for the CUDA back-end of the GEMM ops). Default: False.
+    """
+    return (
+        force_cutlass_sm90_kernels()
+        or os.getenv("AIT_ALLOW_CUTLASS_SM90_KERNELS", "0") == "1"
+    )
+
+
+def force_cutlass_sm90_kernels() -> bool:
+    """
+    Whether only the SM90 CUTLASS kernels (and not the SM80 ones)
+    should be considered on the CUDA arch 90 (for the CUDA
+    back-end of the GEMM ops). Default: False.
+    """
+    return os.getenv("AIT_FORCE_CUTLASS_SM90_KERNELS", "0") == "1"


### PR DESCRIPTION
Summary: Initial foundations are added for further support of the CUTLASS SM90 kernels. With these changes, under CUDA 12 (arch 90), the SM90 kernels will be generated, but not considered anywhere in the GEMM back-end (due to the special `GemmKind.Universal3x` not being matched against).

Differential Revision: D44985884

