### PR TITLE
Accept JaggedIntVar in padded_dense_to_jagged

### DIFF
--- a/python/aitemplate/compiler/ops/tensor/padded_dense_to_jagged.py
+++ b/python/aitemplate/compiler/ops/tensor/padded_dense_to_jagged.py
@@ -20,7 +20,7 @@ from typing import List
 
 from aitemplate.backend import registry
 from aitemplate.backend.target import Target
-from aitemplate.compiler.base import IntVar, JaggedDim, Operator, Tensor
+from aitemplate.compiler.base import IntVar, JaggedDim, JaggedIntVar, Operator, Tensor
 from aitemplate.compiler.ops import make_jagged
 
 
@@ -43,6 +43,12 @@ class padded_dense_to_jagged(Operator):
         self,
         total_length: IntVar,
     ):
+        if isinstance(total_length, JaggedIntVar):
+            # the total_length dimension may be fetched from the
+            # jagged tensor's shape[0]. in such cases, the total_length
+            # would already be a JaggedIntVar and we fetch the real
+            # total_length from inside it.
+            total_length = total_length.total_length()
         if type(total_length) != IntVar:
             raise TypeError(
                 f"total_length must be IntVar, but got {type(total_length).__name__}."


### PR DESCRIPTION
Summary: It may happen that `total_length` passed to the `padded_dense_to_jagged` op is actually a `JaggedIntVar`. In such cases, the `total_length` is fetched from the `shape[0]` of a tensor that already happens to be jagged. Before this diff, this has caused an exception in the `padded_dense_to_jagged` front-end validation. The diff fixes this by fetching the `total_length` from within the passed `JaggedIntVar`.

Differential Revision: D44997496

