### PR TITLE
Allow split without dim as input

### DIFF
--- a/fx2ait/fx2ait/acc_tracer/ait_acc_ops.py
+++ b/fx2ait/fx2ait/acc_tracer/ait_acc_ops.py
@@ -18,13 +18,15 @@ from fx2ait.acc_tracer.acc_normalizer import register_acc_op
 
 from fx2ait.acc_tracer.ait_acc_ops_registry import ait_register_acc_op_mapping
 
+this_arg_is_optional: bool = True
+
 
 @ait_register_acc_op_mapping(
     op_and_target=("call_method", "split"),
     arg_replacement_tuples=[
         ("tensor", "input"),
         ("split_size_or_sections", "split_size_or_sections"),
-        ("dim", "dim"),
+        ("dim", "dim", this_arg_is_optional),
     ],
 )
 @ait_register_acc_op_mapping(
@@ -32,7 +34,7 @@ from fx2ait.acc_tracer.ait_acc_ops_registry import ait_register_acc_op_mapping
     arg_replacement_tuples=[
         ("tensor", "input"),
         ("split_size_or_sections", "split_size_or_sections"),
-        ("dim", "dim"),
+        ("dim", "dim", this_arg_is_optional),
     ],
 )
 @register_acc_op

--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -1081,6 +1081,9 @@ def ait_acc_ops_split(
             f"Unexpected value for split_size_or_sections in {name}: {split_size_or_sections}"
         )
 
+    if "dim" not in kwargs:
+        return split()(input_val, split_size_or_sections)
+
     dim = kwargs["dim"]
     if not isinstance(dim, int):
         raise ValueError(f"Unexpected value for dim in {name}: {dim}")

--- a/fx2ait/fx2ait/test/converters/test_ait_split.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_split.py
@@ -64,6 +64,46 @@ class TestSplitConverter(AITTestCase):
         ]
         self.run_test(model, inputs, expected_ops={ait_acc_ops.split})
 
+    @parameterized.expand(
+        [
+            [[2, 10], [2, 3, 5]],
+            [[2, 10], 2],
+            [[2, 10], 3],
+        ]
+    )
+    def test_tensor_split_with_dim(
+        self, input_shape: List[int], split_size_or_sections: Union[int, List[int]]
+    ) -> None:
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x.split(split_size_or_sections, dim=1)
+
+        model = TestModule().cuda()
+        inputs = [
+            torch.randn(*input_shape).half().cuda(),
+        ]
+        self.run_test(model, inputs, expected_ops={ait_acc_ops.split})
+
+    @parameterized.expand(
+        [
+            [[10], [2, 3, 5]],
+            [[10], 2],
+            [[10], 3],
+        ]
+    )
+    def test_tensor_split_without_dim(
+        self, input_shape: List[int], split_size_or_sections: Union[int, List[int]]
+    ) -> None:
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x.split(split_size_or_sections)
+
+        model = TestModule().cuda()
+        inputs = [
+            torch.randn(*input_shape).half().cuda(),
+        ]
+        self.run_test(model, inputs, expected_ops={ait_acc_ops.split})
+
     def test_with_dim_dynamic_shape(self) -> None:
         class TestModule(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Summary: To allow split op with no dim as input

Reviewed By: Gavin-Cheng

Differential Revision: D45011263

