### PR TITLE
Update fuse_split_linear_add

### DIFF
--- a/fx2ait/fx2ait/tools/common_fx2ait.py
+++ b/fx2ait/fx2ait/tools/common_fx2ait.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 #
 import copy
+import logging
 import time
 import unittest
 
@@ -29,13 +30,15 @@ from fx2ait.ait_module import AITModule
 from fx2ait.fx2ait import AITInterpreter
 from fx2ait.tensor_spec import TensorSpec
 
+logger: logging.Logger = logging.getLogger(__name__)
+
 OSS_AITModel = False
 try:
     torch.ops.load_library("//deeplearning/ait:AITModel")
-    print("===Load non-OSS AITModel===")
+    logging.info("===Load non-OSS AITModel===")
 except Exception:
     torch.ops.load_library("build/libait_model.so")
-    print("===Load OSS AITModel===")
+    logging.info("===Load OSS AITModel===")
     OSS_AITModel = True
 
 


### PR DESCRIPTION
Summary:
Currently, `fuse_split_linear_add` only supports cases when the split op kwarg uses a `slice`. This diff extends the fusion to support cases when the split op kwarg uses `int`s. The graph change can seen as follows:

* Before optimization: {F933055696}
* After optimization: {F933058824}

In particular, the optimization targets nodes `split_5` and `split_7` specifically.

Additionally, modified `common_fx2ait` to use `logger` instead of `print`, as the print statement causes buck tests to crash.

Differential Revision: D44359231

