### PR TITLE
Build cache: Do not cache failed builds

### DIFF
--- a/python/aitemplate/backend/builder.py
+++ b/python/aitemplate/backend/builder.py
@@ -162,7 +162,7 @@ def _run_make_cmds(cmds, timeout, build_dir, allow_cache=True):
         )
         try:
             out, err = proc.communicate(timeout)
-            if store_cache_key is not None:
+            if proc.returncode == 0 and store_cache_key is not None:
                 build_cache.BUILD_CACHE.store_build_cache(
                     cmds, build_dir, store_cache_key
                 )


### PR DESCRIPTION
Summary:
Currently the build cache is also caching the results of failed builds. While not neccessarily wrong, the fact that build errors are not shown on repeated invocation is both irritating and a problem when attempting to pinpoint errors.

This is a minor code change which fixes that.

Reviewed By: aakhundov

Differential Revision: D45043453

