### PR TITLE
Fix acc_ops converter on std when keepdim=False

### DIFF
--- a/fx2ait/fx2ait/acc_tracer/acc_ops.py
+++ b/fx2ait/fx2ait/acc_tracer/acc_ops.py
@@ -1382,7 +1382,7 @@ def std_mapper(node, mod):
         mean_kwargs = {
             "input": input_node,
             "dim": dim,
-            "keepdim": keepdim,
+            "keepdim": True,
         }
         mean_node = node.graph.call_function(mean, kwargs=mean_kwargs)
         mean_node.meta["type"] = torch.Tensor
@@ -1400,7 +1400,7 @@ def std_mapper(node, mod):
         }
         pow_node = node.graph.call_function(pow, kwargs=pow_kwargs)
         pow_node.meta["type"] = torch.Tensor
-        # sum(pow(X-mean(X))))/N
+        # mean(pow(X-mean(X)))
         post_mean_kwargs = {
             "input": pow_node,
             "dim": dim,
@@ -1408,7 +1408,7 @@ def std_mapper(node, mod):
         }
         post_mean_node = node.graph.call_function(mean, kwargs=post_mean_kwargs)
         post_mean_node.meta["type"] = torch.Tensor
-        # sqrt(sum(pow(X-mean(X))))/N)
+        # sqrt( mean(pow(X-mean(X))) )
         sqrt_kwargs = {
             "input": post_mean_node,
         }

--- a/fx2ait/fx2ait/test/converters/test_ait_reduce.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_reduce.py
@@ -92,3 +92,24 @@ class TestMeanConverter(AITTestCase):
         model = TestModule().cuda()
         inputs = [torch.randn(2, 3, 5).half().cuda() + 1] * 2
         self.run_test(model, inputs, expected_ops={acc_ops.mean})
+
+    @parameterized.expand(
+        [
+            ["keepdim_false", (1,), False],
+            ["keepdim_true", (1,), True],
+            ["keepdim_false", (0,), False],
+            ["keepdim_true", (2,), True],
+        ]
+    )
+    # std is a combo of basic binary and mean ops
+    def test_std(self, name, dim, keepdim) -> None:
+        class TestModule(torch.nn.Module):
+            def forward(self, input: torch.Tensor) -> torch.Tensor:
+                return torch.std(input, dim=dim, keepdim=keepdim)
+
+        model = TestModule().cuda()
+        self.run_test(
+            model,
+            [torch.randn(2, 3, 4).half().cuda()],
+            expected_ops={},
+        )


### PR DESCRIPTION
Summary:
As titled. std in fx2ait is represented by combinations of arithmetic ops and 2 reduce ops.:
```
Y = sqrt( mean(pow(X-mean(X))) )
```

However issue occurs when the first deduce op uses `keepdim=False`. It caused issue with subsequent sub op where X has old dimension while mean(X) only has 1 dim less than that.

Also, it seems there is no unittest for acc_ops when tracing std. This diff added the test

Differential Revision: D45105942

