### PR TITLE
Fix MSVC compiler narrowing conversion errors for cuda/gemm_epilogue_universal

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_universal/common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/common.py
@@ -216,6 +216,7 @@ EXEC_TEMPLATE = jinja2.Template(
 //  TODO: cast to right dtype
 {{indent}}using ElementComputeEpilogue = typename {{instance}}::ElementAccumulator;
 
+{{indent}}using coord_t = cutlass::gemm::GemmCoord::Index;
 {{indent}}typename {{instance}}::Arguments arguments{
 
 {{problem_args}}

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr.py
@@ -48,7 +48,11 @@ ARGS_PARSER_TEMPLATE = jinja2.Template(
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(0)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr) + input_a_offset,          // void const * ptr_A
@@ -71,7 +75,11 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
 PROFILER_PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(0)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr),                           // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias.py
@@ -31,7 +31,11 @@ from aitemplate.backend.cuda.gemm_universal import common, common_bias, gemm_rcr
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(1)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr) + input_a_offset,          // void const * ptr_A
@@ -54,7 +58,11 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
 PROFILER_PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(1)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr),                           // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_fast_gelu.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_fast_gelu.py
@@ -63,7 +63,11 @@ using LinearCombinationFastGELU = LinearCombinationGeneric<GELU_taylor, ElementO
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(1)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr),                           // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_gelu.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_gelu.py
@@ -27,7 +27,11 @@ from aitemplate.backend.cuda.gemm_universal import common, common_bias_activatio
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(1)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr),                           // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_hardswish.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_hardswish.py
@@ -27,7 +27,11 @@ from aitemplate.backend.cuda.gemm_universal import common, common_bias_activatio
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(1)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr),                           // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_relu.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_relu.py
@@ -28,7 +28,11 @@ from aitemplate.backend.cuda.gemm_universal import common, common_bias_activatio
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                                            // GemmUniversalMode mode
-    {M, N, K},                                                                          // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                                                  // GemmCoord problem_size
     split_k,                                                                            // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(1), ElementComputeEpilogue(0)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr),                                                      // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_sigmoid.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_sigmoid.py
@@ -28,7 +28,11 @@ from aitemplate.backend.cuda.gemm_universal import common, common_bias_activatio
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(1)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr),                           // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_swish.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_swish.py
@@ -28,7 +28,11 @@ from aitemplate.backend.cuda.gemm_universal import common, common_bias_activatio
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(1)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr),                           // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_tanh.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_tanh.py
@@ -63,7 +63,11 @@ using LinearCombinationTanh = LinearCombinationGeneric<Tanh, ElementOutput_, Cou
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(1)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr),                           // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_fast_gelu.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_fast_gelu.py
@@ -69,7 +69,11 @@ using LinearCombinationFastGELU = LinearCombinationGeneric<GELU_taylor, ElementO
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(0)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*) a_ptr,                            // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_permute.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_permute.py
@@ -46,7 +46,11 @@ ARGS_PARSER_TEMPLATE = jinja2.Template(
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(0)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr),                           // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rrr.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rrr.py
@@ -46,7 +46,11 @@ ARGS_PARSER_TEMPLATE = jinja2.Template(
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(0)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr),                           // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rrr_permute.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rrr_permute.py
@@ -47,7 +47,11 @@ ARGS_PARSER_TEMPLATE = jinja2.Template(
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                 // GemmUniversalMode mode
-    {M, N, K},                                               // GemmCoord problem_size
+    cutlass::gemm::GemmCoord{
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K)
+    },                                                       // GemmCoord problem_size
     split_k,                                                 // int batch_count
     {ElementComputeEpilogue(1), ElementComputeEpilogue(0)},  // typename EpilogueOutputOp::Params epilogue
     ({{elem_input_type}}*)(a_ptr),                           // void const * ptr_A

--- a/python/aitemplate/backend/cuda/gemm_universal/group_common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/group_common.py
@@ -290,7 +290,7 @@ EXEC_TEMPLATE = jinja2.Template(
 {{indent}}  );
 {{indent}}}
 
-
+{{indent}}using coord_t = cutlass::gemm::GemmCoord::Index;
 {{indent}}typename {{instance}}::Arguments arguments{
 
 {{problem_args}}


### PR DESCRIPTION
Summary: cutlass::gemm::GemmCoord uses int values as coordinates under the hood, while AIT might use int64_t variables in {M, N, K} constructor. So, narrowing conversion is needed.

Differential Revision: D45213076

