### PR TITLE
Set skip_on_empty=True from filter_test_cases_by_params

### DIFF
--- a/fx2ait/fx2ait/test/converters/test_ait_unary_ops.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_unary_ops.py
@@ -48,7 +48,7 @@ TestEnvToPrecision: Dict[TestEnv, Set[LowerPrecision]] = {
 
 class TestUnaryOpsConverter(AITTestCase):
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 env: [
                     (

--- a/python/aitemplate/testing/test_utils.py
+++ b/python/aitemplate/testing/test_utils.py
@@ -121,7 +121,7 @@ def filter_test_cases_by_params(params: Dict[TestEnv, List[Tuple[Any]]]):
     """
     target = detect_target()
     test_env = _get_test_env(target)
-    return (
+    input_ = (
         params.get(test_env, [])
         if target.in_ci_env()
         else list(
@@ -132,6 +132,10 @@ def filter_test_cases_by_params(params: Dict[TestEnv, List[Tuple[Any]]]):
             )
         )
     )
+    return {
+        "input": input_,
+        "skip_on_empty": True,
+    }
 
 
 def filter_test_cases_by_test_env(cls: Type[unittest.TestCase]):

--- a/tests/unittest/compiler/test_constant_folding.py
+++ b/tests/unittest/compiler/test_constant_folding.py
@@ -84,7 +84,7 @@ class ConstantFoldingTestCase(unittest.TestCase):
         self._verify_graph(mod, expected_num_constants=1, expected_num_nodes=3)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],
@@ -138,7 +138,7 @@ class ConstantFoldingTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],
@@ -188,7 +188,7 @@ class ConstantFoldingTestCase(unittest.TestCase):
         self._verify_graph(mod, expected_num_constants=1, expected_num_nodes=1)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],
@@ -227,7 +227,7 @@ class ConstantFoldingTestCase(unittest.TestCase):
         self._verify_graph(mod, expected_num_constants=1, expected_num_nodes=1)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],

--- a/tests/unittest/compiler/test_fuse_bmm_permute.py
+++ b/tests/unittest/compiler/test_fuse_bmm_permute.py
@@ -149,8 +149,9 @@ class FuseBmmPermuteCase(unittest.TestCase):
                 {
                     TestEnv.CUDA_LESS_THAN_SM80: ["float16"],
                 }
-            ),
-        )
+            )["input"],
+        ),
+        skip_on_empty=True,
     )
     def test_xxr_to_xxс(self, B, layout_a, layout_b, layout_c, dtype):
         """

--- a/tests/unittest/compiler/test_fuse_mm_elementwise.py
+++ b/tests/unittest/compiler/test_fuse_mm_elementwise.py
@@ -272,7 +272,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
             self.assertTrue(torch.allclose(Y_pt, y, atol=1e-1, rtol=1e-1))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],
@@ -324,7 +324,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
         self.assertTrue(torch.allclose(Y_pt, y, atol=1e-1, rtol=1e-1))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],
@@ -391,7 +391,7 @@ class FuseGemmRcrBiasCase(unittest.TestCase):
         self.assertTrue(torch.allclose(Y_pt, y, atol=1e-1, rtol=1e-1))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],
@@ -1556,7 +1556,7 @@ class FuseBmmCcrAddCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],

--- a/tests/unittest/compiler/test_fuse_permute_bmm.py
+++ b/tests/unittest/compiler/test_fuse_permute_bmm.py
@@ -805,7 +805,7 @@ class FusePermuteBmmCase(unittest.TestCase):
         func(self, test_bias, dtype)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],
@@ -867,7 +867,7 @@ class FusePermuteBmmCase(unittest.TestCase):
         self.assertTrue(torch.allclose(Y_pt, y, atol=1e-1, rtol=1e-1))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],

--- a/tests/unittest/compiler/test_fuse_permute_gemm.py
+++ b/tests/unittest/compiler/test_fuse_permute_gemm.py
@@ -31,7 +31,7 @@ from parameterized import parameterized
 
 class FusePermuteGemmTestCase(unittest.TestCase):
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],
@@ -71,7 +71,7 @@ class FusePermuteGemmTestCase(unittest.TestCase):
             raise RuntimeError("invalid {dtype=}")
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],
@@ -105,7 +105,7 @@ class FusePermuteGemmTestCase(unittest.TestCase):
         torch.testing.assert_close(z_ait, z_pt, atol=1e-1, rtol=1e-1)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],

--- a/tests/unittest/compiler/test_fused_elementwise_complex_dependency.py
+++ b/tests/unittest/compiler/test_fused_elementwise_complex_dependency.py
@@ -289,7 +289,7 @@ class FusedElementwiseComplexDependencyTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(r4, r4_pt, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],
@@ -375,7 +375,7 @@ class FusedElementwiseComplexDependencyTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(r3, r3_pt, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],
@@ -477,7 +477,7 @@ class FusedElementwiseComplexDependencyTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(r4, r4_pt, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],
@@ -591,7 +591,7 @@ class FusedElementwiseComplexDependencyTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(r7, r7_pt, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],

--- a/tests/unittest/compiler/test_fused_elementwise_out_of_order.py
+++ b/tests/unittest/compiler/test_fused_elementwise_out_of_order.py
@@ -36,7 +36,7 @@ from torch import nn
 
 class FusedElementwiseOutOfOrderTestCase(unittest.TestCase):
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],

--- a/tests/unittest/compiler/test_pad_gemm_with_cat.py
+++ b/tests/unittest/compiler/test_pad_gemm_with_cat.py
@@ -37,7 +37,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class PadGemmWithCatTestCase(unittest.TestCase):
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],

--- a/tests/unittest/compiler/test_pad_gemm_with_elementwise.py
+++ b/tests/unittest/compiler/test_pad_gemm_with_elementwise.py
@@ -33,7 +33,7 @@ from parameterized import param, parameterized
 
 class PadGemmWithElementwise(unittest.TestCase):
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [
                     param("static_M_float16", [23], 7, 3, "float16"),
@@ -92,7 +92,7 @@ class PadGemmWithElementwise(unittest.TestCase):
             self.assertTrue(torch.allclose(Y_pt, y, atol=1e-1, rtol=1e-1))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [
                     ("static_shape_float16", [3], [1], 5, 3, "float16"),
@@ -161,7 +161,7 @@ class PadGemmWithElementwise(unittest.TestCase):
             self.assertTrue(torch.allclose(Y_pt, y, atol=1e-1, rtol=1e-1))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [
                     ("static_shape_float16", [3], [1], 5, 3, "float16"),
@@ -234,7 +234,7 @@ class PadGemmWithElementwise(unittest.TestCase):
             self.assertTrue(torch.allclose(Y_pt, y, atol=1e-1, rtol=1e-1))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [
                     param("static_M_float16", [23], 7, 3, "float16"),

--- a/tests/unittest/compiler/test_refine_graph.py
+++ b/tests/unittest/compiler/test_refine_graph.py
@@ -38,7 +38,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class RefineGraphTestCase(unittest.TestCase):
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32")],
@@ -207,7 +207,7 @@ class RefineGraphTestCase(unittest.TestCase):
         return mul_tensor
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32")],
@@ -243,7 +243,7 @@ class RefineGraphTestCase(unittest.TestCase):
         assert sorted_ops[0]._attrs["name"] == sorted_ops[1]._attrs["name"]
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32")],
@@ -300,7 +300,7 @@ class RefineGraphTestCase(unittest.TestCase):
         assert sorted_ops[0]._attrs["name"] != sorted_ops[1]._attrs["name"]
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32")],

--- a/tests/unittest/compiler/test_slice_gemm_fusion.py
+++ b/tests/unittest/compiler/test_slice_gemm_fusion.py
@@ -155,7 +155,7 @@ class SliceGemmFusionTestCase(unittest.TestCase):
     # This is a test for testing cases where we correctly update a/b_alignment
     # based on input_accessors
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float")],

--- a/tests/unittest/compiler/test_slice_view_strided.py
+++ b/tests/unittest/compiler/test_slice_view_strided.py
@@ -44,7 +44,7 @@ class SliceViewStridedOpTestCase(unittest.TestCase):
         torch.manual_seed(0)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],
@@ -101,7 +101,7 @@ class SliceViewStridedOpTestCase(unittest.TestCase):
             torch.testing.assert_close(y, y_pt, **_TOLERANCE_LIMITS[dtype])
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],
@@ -158,7 +158,7 @@ class SliceViewStridedOpTestCase(unittest.TestCase):
             torch.testing.assert_close(y, y_pt, **_TOLERANCE_LIMITS[dtype])
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],
@@ -237,7 +237,7 @@ class SliceViewStridedOpTestCase(unittest.TestCase):
             torch.testing.assert_close(y, y_pt, **_TOLERANCE_LIMITS[dtype])
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],
@@ -310,7 +310,7 @@ class SliceViewStridedOpTestCase(unittest.TestCase):
             torch.testing.assert_close(y, y_pt, **_TOLERANCE_LIMITS[dtype])
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],
@@ -382,7 +382,7 @@ class SliceViewStridedOpTestCase(unittest.TestCase):
             torch.testing.assert_close(y, y_pt, **_TOLERANCE_LIMITS[dtype])
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],

--- a/tests/unittest/compiler/test_strided_view_cat.py
+++ b/tests/unittest/compiler/test_strided_view_cat.py
@@ -139,7 +139,7 @@ class StridedViewCatOpTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],
@@ -380,7 +380,7 @@ class StridedViewCatOpTestCase(unittest.TestCase):
                 torch.testing.assert_close(x, x_pt, **_TOLERANCE_LIMITS[dtype])
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],

--- a/tests/unittest/compiler/test_transform_special_op.py
+++ b/tests/unittest/compiler/test_transform_special_op.py
@@ -123,7 +123,7 @@ class GemmRrrSmallNkTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],
@@ -237,7 +237,7 @@ class BmmRcrN1TestCase(unittest.TestCase):
         self._test_n1_k8(10, [8, 16], 1, 8, dtype="float32")
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],

--- a/tests/unittest/ops/test_activation.py
+++ b/tests/unittest/ops/test_activation.py
@@ -353,7 +353,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         torch.testing.assert_close(x2, x2_pt, atol=1e-2, rtol=1e-2)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -379,7 +379,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         self._test_leaky_relu([63, 63], test_name="leaky_relu_3", dtype=dtype)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -402,7 +402,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -428,7 +428,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -449,7 +449,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -470,7 +470,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -494,7 +494,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -515,7 +515,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -536,7 +536,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -557,7 +557,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -578,7 +578,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -599,7 +599,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -620,7 +620,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -641,7 +641,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -662,7 +662,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -694,7 +694,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -717,7 +717,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],

--- a/tests/unittest/ops/test_attention.py
+++ b/tests/unittest/ops/test_attention.py
@@ -333,13 +333,12 @@ class AttentionTestCase(unittest.TestCase):
                 )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 # Flash attention requires A100
                 TestEnv.CUDA_SM80: [("float16")],
             }
         ),
-        skip_on_empty=True,
     )
     def test_flash_attention(self, dtype):
         self._test_flash_attention(
@@ -444,12 +443,11 @@ class AttentionTestCase(unittest.TestCase):
             _LOGGER.info(f"benchmark compiler model time: {time_per_iter_ms}")
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.ROCM: [("float16")],
             }
         ),
-        skip_on_empty=True,
     )
     def test_attention_rocm(self, dtype):
         self._test_attention(
@@ -699,11 +697,12 @@ class AttentionTestCase(unittest.TestCase):
                     TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                     TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],
                 }
-            ),
+            )["input"],
             [False, True],  # variable_seq_length_kv
             [False, True],  # variable_seq_length_q
             [False, True],  # causal
         ),
+        skip_on_empty=True,
     )
     @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
     def test_mem_eff_attention(
@@ -825,7 +824,7 @@ class AttentionTestCase(unittest.TestCase):
                     # with 'misaligned address' error.
                     TestEnv.CUDA_SM80: [("float16")],
                 }
-            ),
+            )["input"],
             [False, True],  # variable_seq_length_kv
             [False, True],  # variable_seq_length_q
         ),
@@ -980,12 +979,11 @@ class AttentionTestCase(unittest.TestCase):
             torch.testing.assert_close(y, y_pt.to(torch_dtype), atol=atol, rtol=rtol)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_SM80: [("float16"), ("float32"), ("bfloat16")],
             }
         ),
-        skip_on_empty=True,
     )
     def test_cross_attention(self, dtype):
         if dtype == "bfloat16":

--- a/tests/unittest/ops/test_batched_dense_vec_jagged_2d_mul.py
+++ b/tests/unittest/ops/test_batched_dense_vec_jagged_2d_mul.py
@@ -136,7 +136,7 @@ class BatchedDenseVecJagged2DMulTestCase(unittest.TestCase):
         torch.testing.assert_close(result, result_pt, **tolerance_limits)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],

--- a/tests/unittest/ops/test_bmm.py
+++ b/tests/unittest/ops/test_bmm.py
@@ -305,7 +305,7 @@ class BMMTestCase(unittest.TestCase):
         if detect_target().name() == "cuda":
             self._test_ccc([1, 9, 101], M=256, N=64, K=128, test_name="dynamic_b")
 
-    @parameterized.expand(filter_test_cases_by_params(_TEST_PARAMS))
+    @parameterized.expand(**filter_test_cases_by_params(_TEST_PARAMS))
     @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
     def test_bmm_0_dtype(self, dtype):
         self._test_rcr([128], [64], N=8, K=64, test_name=f"static_{dtype}", dtype=dtype)
@@ -332,7 +332,7 @@ class BMMTestCase(unittest.TestCase):
             [1, 9, 11], M=64, N=32, K=16, test_name=f"dynamic_b_{dtype}", dtype=dtype
         )
 
-    @parameterized.expand(filter_test_cases_by_params(_TEST_PARAMS))
+    @parameterized.expand(**filter_test_cases_by_params(_TEST_PARAMS))
     @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
     def test_bmm_1_dtype(self, dtype):
         self._test_rcc([128], [64], N=8, K=64, test_name=f"static_{dtype}", dtype=dtype)
@@ -727,7 +727,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         self._test_ccr([8, 16], [8, 32, 8], "2d_broadcastable_a")
         self._test_ccr([8, 8, 16], [32, 8], "2d_broadcastable_b")
 
-    @parameterized.expand(filter_test_cases_by_params(_TEST_PARAMS))
+    @parameterized.expand(**filter_test_cases_by_params(_TEST_PARAMS))
     def test_bmm_broadcast_0_dtype(self, dtype):
         self._test_rcr([2, 16, 8], [1, 32, 8], f"broadcastable_b_{dtype}", dtype=dtype)
         self._test_rcr([16, 8], [8, 32, 8], f"2d_broadcastable_a_{dtype}", dtype=dtype)
@@ -738,7 +738,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
         self._test_ccr([1, 8, 16], [2, 32, 8], f"broadcastable_a_{dtype}", dtype=dtype)
         self._test_ccr([8, 8, 16], [32, 8], f"2d_broadcastable_b_{dtype}", dtype=dtype)
 
-    @parameterized.expand(filter_test_cases_by_params(_TEST_PARAMS))
+    @parameterized.expand(**filter_test_cases_by_params(_TEST_PARAMS))
     def test_bmm_broadcast_1_dtype(self, dtype):
         self._test_rcc([2, 16, 8], [1, 32, 8], f"broadcastable_b_{dtype}", dtype=dtype)
         self._test_rcc([16, 8], [8, 32, 8], f"2d_broadcastable_a_{dtype}", dtype=dtype)

--- a/tests/unittest/ops/test_bmm_add.py
+++ b/tests/unittest/ops/test_bmm_add.py
@@ -333,7 +333,7 @@ class BMMAddTestCase(unittest.TestCase):
     def test_crc(self):
         self._test_crc(B=32, M=256, K=256, N=512)
 
-    @parameterized.expand(filter_test_cases_by_params(_TEST_PARAMS))
+    @parameterized.expand(**filter_test_cases_by_params(_TEST_PARAMS))
     def test_bmm_add_0_dtype(self, dtype):
         self._test_rrr(B=8, M=32, K=8, N=64, dtype=dtype)
         self._test_ccr(
@@ -344,7 +344,7 @@ class BMMAddTestCase(unittest.TestCase):
             B=8, M=32, N=64, K=16, test_name=f"bmm_rcr_add_{dtype}", dtype=dtype
         )
 
-    @parameterized.expand(filter_test_cases_by_params(_TEST_PARAMS))
+    @parameterized.expand(**filter_test_cases_by_params(_TEST_PARAMS))
     def test_bmm_add_1_dtype(self, dtype):
         self._test_rrc(B=8, M=32, K=8, N=64, dtype=dtype)
         self._test_ccc(
@@ -735,7 +735,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
             test_name="broadcastable_bias3d",
         )
 
-    @parameterized.expand(filter_test_cases_by_params(_TEST_PARAMS))
+    @parameterized.expand(**filter_test_cases_by_params(_TEST_PARAMS))
     def test_bmm_add_broadcast_0_dtype(self, dtype):
         self._test_crr(
             [1, 8, 16],
@@ -766,7 +766,7 @@ class BMMBroadcastTestCase(unittest.TestCase):
             dtype=dtype,
         )
 
-    @parameterized.expand(filter_test_cases_by_params(_TEST_PARAMS))
+    @parameterized.expand(**filter_test_cases_by_params(_TEST_PARAMS))
     def test_bmm_add_broadcast_1_dtype(self, dtype):
         self._test_crc(
             [1, 8, 16],

--- a/tests/unittest/ops/test_conv.py
+++ b/tests/unittest/ops/test_conv.py
@@ -76,7 +76,7 @@ class ConvTestCase(unittest.TestCase):
             torch.testing.assert_close(Y_pt, y_transpose, atol=1.25e-1, rtol=1e-1)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],
@@ -96,7 +96,7 @@ class ConvTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],
@@ -108,7 +108,7 @@ class ConvTestCase(unittest.TestCase):
         self._test_conv1d(dtype=dtype, bias=False)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],

--- a/tests/unittest/ops/test_conv2d_bias_add.py
+++ b/tests/unittest/ops/test_conv2d_bias_add.py
@@ -99,7 +99,7 @@ class ConvBiasAddTestCase(unittest.TestCase):
             torch.testing.assert_close(Y_pt, y_transpose, atol=1.25e-1, rtol=1e-1)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float"), ("bfloat16")],

--- a/tests/unittest/ops/test_conv_bias.py
+++ b/tests/unittest/ops/test_conv_bias.py
@@ -89,7 +89,7 @@ class ConvBiasTestCase(unittest.TestCase):
             torch.testing.assert_close(Y_pt, y_transpose, atol=1.25e-1, rtol=1e-1)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],

--- a/tests/unittest/ops/test_conv_bias_add_hardswish.py
+++ b/tests/unittest/ops/test_conv_bias_add_hardswish.py
@@ -98,7 +98,7 @@ class ConvBiasAddHardswishTestCase(unittest.TestCase):
             self.assertTrue(torch.allclose(Y_pt, y_transpose, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32")],

--- a/tests/unittest/ops/test_conv_bias_add_relu.py
+++ b/tests/unittest/ops/test_conv_bias_add_relu.py
@@ -100,7 +100,7 @@ class ConvBiasAddReluTestCase(unittest.TestCase):
             torch.testing.assert_close(Y_pt, y_transpose, atol=1.25e-1, rtol=1e-1)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],

--- a/tests/unittest/ops/test_conv_bias_hardswish.py
+++ b/tests/unittest/ops/test_conv_bias_hardswish.py
@@ -96,7 +96,7 @@ class ConvBiasHardswishTestCase(unittest.TestCase):
             torch.testing.assert_close(Y_pt, y_transpose, atol=1, rtol=1)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],

--- a/tests/unittest/ops/test_conv_bias_relu.py
+++ b/tests/unittest/ops/test_conv_bias_relu.py
@@ -92,7 +92,7 @@ class ConvBiasReluTestCase(unittest.TestCase):
             torch.testing.assert_close(Y_pt, y_transpose, atol=1.25e-1, rtol=1e-1)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],

--- a/tests/unittest/ops/test_conv_bias_sigmoid.py
+++ b/tests/unittest/ops/test_conv_bias_sigmoid.py
@@ -86,7 +86,7 @@ class ConvBiasSigmoidTestCase(unittest.TestCase):
             torch.testing.assert_close(Y_pt, y_transpose, atol=1.25e-1, rtol=1e-1)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("bfloat16"), ("float32")],

--- a/tests/unittest/ops/test_fused_elementwise.py
+++ b/tests/unittest/ops/test_fused_elementwise.py
@@ -108,7 +108,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         self.assertEqual(X4._attrs["depth"], 2)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -162,7 +162,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
                     self.assertTrue(torch.allclose(x4, x4_pt, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -252,7 +252,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         torch.testing.assert_close(x9, x9_pt, atol=1e-2, rtol=1e-2)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -291,7 +291,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         self.assertEqual(torch.sum(x2 > 1), 0)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -328,7 +328,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(x2, x2_pt, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 # float16 device function is different for SM80 and lower
@@ -369,7 +369,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(x2, x2_pt, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -435,7 +435,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         torch.testing.assert_close(x2, x2_pt, atol=1e-2, rtol=1e-2, equal_nan=True)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -460,7 +460,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         )
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -517,7 +517,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(x1, x1_pt, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -563,7 +563,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(output, output_pt, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],
@@ -597,7 +597,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(output, output_pt, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16"), ("float32")],
                 TestEnv.CUDA_SM80: [("bfloat16")],

--- a/tests/unittest/ops/test_gemm_bias_hardswish.py
+++ b/tests/unittest/ops/test_gemm_bias_hardswish.py
@@ -70,7 +70,7 @@ class GEMMBiasHardSwishTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(Y_pt, y, **_TOLERANCE_LIMITS[dtype]))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],

--- a/tests/unittest/ops/test_gemm_bias_relu.py
+++ b/tests/unittest/ops/test_gemm_bias_relu.py
@@ -66,7 +66,7 @@ class GEMMBiasReluTestCase(unittest.TestCase):
         torch.testing.assert_close(Y_pt, y, **tolerance_limits)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],
@@ -107,7 +107,7 @@ class GEMMBiasReluTestCase(unittest.TestCase):
         torch.testing.assert_close(Y_pt, y, **tolerance_limits)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],

--- a/tests/unittest/ops/test_gemm_bias_sigmoid.py
+++ b/tests/unittest/ops/test_gemm_bias_sigmoid.py
@@ -66,7 +66,7 @@ class GEMMBiasSigmoidTestCase(unittest.TestCase):
         torch.testing.assert_close(Y_pt, y, **_TOLERANCE_LIMITS[dtype])
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],

--- a/tests/unittest/ops/test_gemm_bias_tanh.py
+++ b/tests/unittest/ops/test_gemm_bias_tanh.py
@@ -75,7 +75,7 @@ class GEMMBiasTanhTestCase(unittest.TestCase):
             torch.testing.assert_close(Y_pt, y, **tolerance_limits)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],

--- a/tests/unittest/ops/test_perm021fc_crc_bias.py
+++ b/tests/unittest/ops/test_perm021fc_crc_bias.py
@@ -88,7 +88,7 @@ class Perm021FCCRCBiasTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(Y_pt, y, atol=1e-1, rtol=1e-1))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],

--- a/tests/unittest/ops/test_perm102_bmm_rcr.py
+++ b/tests/unittest/ops/test_perm102_bmm_rcr.py
@@ -39,7 +39,7 @@ from parameterized import parameterized
 @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
 class Perm102BMM_RCR_TestCase(unittest.TestCase):
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],
@@ -75,7 +75,7 @@ class Perm102BMM_RCR_TestCase(unittest.TestCase):
 @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
 class Perm102BMM_RCR_BiasTestCase(unittest.TestCase):
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],

--- a/tests/unittest/ops/test_perm102_bmm_rrr.py
+++ b/tests/unittest/ops/test_perm102_bmm_rrr.py
@@ -39,7 +39,7 @@ from parameterized import parameterized
 @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
 class Perm102BMMTestCase(unittest.TestCase):
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],
@@ -75,7 +75,7 @@ class Perm102BMMTestCase(unittest.TestCase):
 @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
 class Perm102BMMBiasTestCase(unittest.TestCase):
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],

--- a/tests/unittest/ops/test_softmax.py
+++ b/tests/unittest/ops/test_softmax.py
@@ -64,7 +64,7 @@ class SoftmaxTestCase(unittest.TestCase):
             torch.testing.assert_close(y_pt, y, atol=1e-2, rtol=1e-2)
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [
                     ("dim_1_fp16", "float16", (1, 1024), (6,), 1),

--- a/tests/unittest/ops/test_split_getitem.py
+++ b/tests/unittest/ops/test_split_getitem.py
@@ -94,7 +94,7 @@ class SplitGetItemTestCase(unittest.TestCase):
             self.assertTrue(torch.allclose(Y_pt, y, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32")],
@@ -156,7 +156,7 @@ class SplitGetItemTestCase(unittest.TestCase):
             self.assertTrue(torch.allclose(Y_pt, y, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32")],
@@ -246,7 +246,7 @@ class SplitGetItemTestCase(unittest.TestCase):
             self.assertTrue(torch.allclose(Y_pt, y, atol=1e-2, rtol=1e-2))
 
     @parameterized.expand(
-        filter_test_cases_by_params(
+        **filter_test_cases_by_params(
             {
                 TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
                 TestEnv.CUDA_SM80: [("float32")],


### PR DESCRIPTION
Summary:
Currently, if the test env that the tests are running on (in CI) is not found among the keys of the `params` dict argument of the `filter_test_cases_by_params` function, an empty list will be returned by the function:

https://www.internalfb.com/code/fbsource/[db44bc42edbac0af6b277aca542026005759f338]/fbcode/aitemplate/AITemplate/python/aitemplate/testing/test_utils.py?lines=81

When empty list is passed to the `parameterized.expand` decorator, without additionally passing the `skip_on_empty=True` argument, `parameterized.expand` will raise an exception. This is currently not visible, as the tests are running in the test envs that exist in the `params`. However, if we add ROCm or SM90 CI, this will become a problem.

In this diff, the `filter_test_cases_by_params`function is refactored to return a dict of `kwargs` for the `parameterized.expand` decorator instead of mere list for the first (`input`) argument. The `skip_on_empty=True` argument is included into the returned `kwargs` dict, along with the `input`. This will lead to empty `input` list to be processed normally by `parameterized.expand`.

All call sites of `filter_test_cases_by_params` in the unit tests are prepended with `**` to properly pass the `kwargs` to the decorator. Except a few cases where `itertools.product` is applied on the `input` list: in such cases (e.g., in `test_attention.py`) the value of the `"input"` key is fetched from the dict + `skip_on_empty=True` is added manually.

Differential Revision: D45219129

