### PR TITLE
Add SM90 CUTLASS 3.x kernels to gemm_rcr

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_universal/common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/common.py
@@ -123,6 +123,12 @@ using {{name}} = {{config_name}};
 """
 )
 
+INSTANCE_TEMPLATE_CUTLASS_3X = jinja2.Template(
+    """
+{{config}}
+using {{name}} = cutlass::gemm::device::GemmUniversalAdapter<{{config_name}}>;
+"""
+)
 
 SRC_TEMPLATE = jinja2.Template(
     """
@@ -130,6 +136,7 @@ SRC_TEMPLATE = jinja2.Template(
 #include <memory>
 #include <random>
 #include <vector>
+
 #include "cutlass/cutlass.h"
 #include "cutlass/gemm/device/gemm_universal.h"
 #include "cutlass/gemm/kernel/gemm_grouped.h"
@@ -139,6 +146,13 @@ SRC_TEMPLATE = jinja2.Template(
 #include "cutlass/util/reference/host/tensor_fill.h"
 #include "cutlass/util/reference/device/tensor_fill.h"
 #include "cutlass/util/device_memory.h"
+
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
 
 using bfloat16 = nv_bfloat16;
 
@@ -217,11 +231,18 @@ EXEC_TEMPLATE = jinja2.Template(
 {{indent}}using ElementComputeEpilogue = typename {{instance}}::ElementAccumulator;
 
 {{indent}}using coord_t = cutlass::gemm::GemmCoord::Index;
-{{indent}}typename {{instance}}::Arguments arguments{
+{{indent}}typename {{instance}}::Arguments arguments;
 
-{{problem_args}}
-
+{{indent}}if constexpr (cutlass::gemm::detail::IsCutlass3GemmKernel<typename {{instance}}::GemmKernel>::value) {
+{{indent}}arguments = {
+{{problem_args_cutlass_3x}}
 {{indent}}};
+{{indent}}} else {
+{{indent}}arguments = {
+{{problem_args}}
+{{indent}}};
+{{indent}}}
+
 {% if is_profiler %}
 {{indent}}size_t workspace_size = gemm_op.get_workspace_size(arguments);
 {{indent}}cutlass::device_memory::allocation<uint8_t> local_workspace(workspace_size);
@@ -602,7 +623,7 @@ int main(int argc, char** argv) {
 
 KERNEL_KEY_TEMPLATE = jinja2.Template(
     """
-cutlass_{{opcode_class_name}}_{{extended_name}}_{{threadblock}}_{{layout}}_align_{{align_ab}}_{{align_c}}
+cutlass{{prefix}}_{{opcode_class_name}}_{{extended_name}}_{{threadblock}}_{{layout}}_align_{{align_ab}}_{{align_c}}
 """
 )
 
@@ -643,6 +664,27 @@ def get_gemm_instance_template_params(
     return gemm_universal_params
 
 
+def get_tensor_accessor_alignments(func_attrs):
+    """Infer the A, B, and epilogue alignments from the respective TAs."""
+    input_accessors = func_attrs["input_accessors"]
+    a_alignment = tensor_accessor_codegen.find_max_alignment_for_accessor(
+        input_accessors[0]
+    )
+    b_alignment = tensor_accessor_codegen.find_max_alignment_for_accessor(
+        input_accessors[1]
+    )
+    output_accessor = func_attrs["output_accessors"][0]
+    epilogue_alignment = tensor_accessor_codegen.find_max_alignment_for_accessor(
+        output_accessor
+    )
+
+    # if the last dim is dynamic, force align=1
+    if not isinstance(output_accessor.original_shapes[-1], IntImm):
+        epilogue_alignment = 1
+
+    return a_alignment, b_alignment, epilogue_alignment
+
+
 def update_alignments_in_gemm_instance(
     op_def: str,
     func_attrs: Dict[str, Any],
@@ -660,21 +702,9 @@ def update_alignments_in_gemm_instance(
     if for_profiler:
         return op_def
 
-    input_accessors = func_attrs["input_accessors"]
-    a_alignment = tensor_accessor_codegen.find_max_alignment_for_accessor(
-        input_accessors[0]
+    a_alignment, b_alignment, epilogue_alignment = get_tensor_accessor_alignments(
+        func_attrs
     )
-    b_alignment = tensor_accessor_codegen.find_max_alignment_for_accessor(
-        input_accessors[1]
-    )
-    output_accessor = func_attrs["output_accessors"][0]
-    epilogue_alignment = tensor_accessor_codegen.find_max_alignment_for_accessor(
-        output_accessor
-    )
-
-    # if the last dim is dynamic, force align=1
-    if not isinstance(output_accessor.original_shapes[-1], IntImm):
-        epilogue_alignment = 1
 
     gemm_params = get_gemm_instance_template_params(op_def, kernel_config)
     epilogue_align_idx = 11
@@ -706,8 +736,19 @@ def update_alignments_in_gemm_instance(
 
 
 def universal_gemm_instance(
-    op_def: str, func_attrs: Dict[str, Any], for_profiler: bool
+    op_def: str,
+    func_attrs: Dict[str, Any],
+    for_profiler: bool,
+    cutlass_3x: bool = False,
 ) -> str:
+    if cutlass_3x:
+        # We don't need to make any adjustments to the emitted
+        # CUTLASS 3.x op definitions. In particular, the alignments
+        # should not be updated, as the op instances incompatible
+        # with the TA-specified alignments have been removed from
+        # consideration by the filter_cutlass_3x_ops function.
+        return op_def
+
     op_def = update_alignments_in_gemm_instance(op_def, func_attrs, for_profiler)
     tmp = op_def.replace(
         "cutlass::gemm::device::Gemm", "cutlass::gemm::device::GemmUniversal"
@@ -728,7 +769,13 @@ def kernel_name(op):
     layout = op.layout_name()
     align_ab = op.A.alignment
     align_c = op.C.alignment
+    prefix = ""
+    if op.prefix != "":
+        kernel_schedule = library.KernelScheduleSuffixes[op.kernel_schedule]
+        epilogue_schedule = library.EpilogueScheduleSuffixes[op.epilogue_schedule]
+        prefix = f"{op.prefix}{kernel_schedule}{epilogue_schedule}"
     name = KERNEL_KEY_TEMPLATE.render(
+        prefix=prefix,
         threadblock=threadblock,
         extended_name=extended_name,
         opcode_class_name=opcode_class_name,
@@ -748,25 +795,42 @@ def emit_instance(
 ):
     import cutlass_lib
 
-    emitter = cutlass_lib.gemm_operation.EmitGemmInstance()
-    if emit_kernel:
-        emitter = cutlass_lib.gemm_operation.EmitGemmUniversalInstance()
+    cutlass_3x = op.gemm_kind == cutlass_lib.library.GemmKind.Universal3x
+    if cutlass_3x:
+        emitter = cutlass_lib.gemm_operation.EmitGemmUniversal3xInstance()
+    else:
+        emitter = cutlass_lib.gemm_operation.EmitGemmInstance()
+        if emit_kernel:
+            emitter = cutlass_lib.gemm_operation.EmitGemmUniversalInstance()
+
     op_def = emitter.emit(op)
-    op_def = f_instance_convertor(op_def, func_attrs, for_profiler)
+    op_def = f_instance_convertor(
+        op_def=op_def,
+        func_attrs=func_attrs,
+        for_profiler=for_profiler,
+        cutlass_3x=cutlass_3x,
+    )
+
     return op_def
 
 
-def extract_config(f_proc_op, f_kernel_name=kernel_name):
+def extract_config(
+    f_proc_op,
+    f_kernel_name=kernel_name,
+    include_cutlass_3x_ops=False,
+):
     import cutlass_lib
 
     op_kind = cutlass_lib.library.OperationKind.Gemm
-    gemm_kind = cutlass_lib.library.GemmKind.Universal
+    gemm_kinds = {cutlass_lib.library.GemmKind.Universal}
+    if include_cutlass_3x_ops:
+        gemm_kinds.add(cutlass_lib.library.GemmKind.Universal3x)
     gemm_ops = OrderedDict()
     extract_ops = list(Target.current()._operators[op_kind].items())
 
     for _, value in extract_ops:
         op = value[0]
-        if op.gemm_kind == gemm_kind:
+        if op.gemm_kind in gemm_kinds:
             ret = f_proc_op(op)
             if len(ret) > 0:
                 for op_inst in ret:
@@ -775,9 +839,16 @@ def extract_config(f_proc_op, f_kernel_name=kernel_name):
     return gemm_ops
 
 
-def extract_config_name(config):
-    pattern = re.compile(r"\s*using\s(.*?)\s=")
-    decl = config.split("\n")[2]
+def extract_config_name(
+    config,
+    cutlass_3x=False,
+):
+    if cutlass_3x:
+        pattern = re.compile(r"\s*struct\s(.*?)\s:")
+        decl = [line for line in config.split("\n") if "struct " in line][-1]
+    else:
+        pattern = re.compile(r"\s*using\s(.*?)\s=")
+        decl = config.split("\n")[2]
     match = pattern.match(decl)
     if match is None:
         raise RuntimeError("Invalid config: \n" + config)
@@ -799,6 +870,7 @@ def gen_function(
     input_addr_calculator="",
     output_addr_calculator="",
     extra_code="",
+    problem_args_cutlass_3x="",
 ):
     backend_spec = CUDASpec()
     elem_input_type = backend_spec.dtype_to_lib_type(
@@ -813,9 +885,11 @@ def gen_function(
     inst_def_flag = set()
     instances = {}
     instance_decl = ""
+    exec_cond_to_cutlass_3x = {}
     for exec_item in exec_path.values():
         fname = "f" + sha1(exec_item.exec_cond.encode()).hexdigest()
         algo = exec_item.algo
+        cutlass_3x = algo.startswith("cutlass3x")
         if algo not in inst_def_flag:
             config = emit_instance(
                 op_instance[algo],
@@ -827,25 +901,43 @@ def gen_function(
             inst_def_flag.add(algo)
         else:
             config = ""
-        inst = INSTANCE_TEMPLATE.render(
-            config=config, name=fname, config_name=extract_config_name(config)
+        instance_template = (
+            INSTANCE_TEMPLATE_CUTLASS_3X if cutlass_3x else INSTANCE_TEMPLATE
+        )
+        inst = instance_template.render(
+            config=config,
+            name=fname,
+            config_name=extract_config_name(
+                config,
+                cutlass_3x=cutlass_3x,
+            ),
         )
         instances[exec_item.exec_cond] = inst
+        exec_cond_to_cutlass_3x[exec_item.exec_cond] = cutlass_3x
         instance_decl += inst
     shape_eval_func = gemm_common.gen_shape_eval_code(
         indent=1, dtype="int64_t", dim_info_dict=dim_info_dict, is_ptr=True
     )
 
     exec_paths = ""
-    for key in instances:
-        fname = "f" + sha1(key.encode()).hexdigest()
+    for exec_cond in instances:
+        fname = "f" + sha1(exec_cond.encode()).hexdigest()
+        cutlass_3x = exec_cond_to_cutlass_3x[exec_cond]
         program = EXEC_TEMPLATE.render(
             indent="    ",
             instance=fname,
-            problem_args=problem_args,
+            # need to omit irrelevant problem_args here as in
+            # non-templated function both CUTLASS 2.x and 3.x
+            # code branches are syntactically checked
+            problem_args=(problem_args if not cutlass_3x else ""),
+            problem_args_cutlass_3x=(problem_args_cutlass_3x if cutlass_3x else ""),
             support_split_k=support_split_k,
         )
-        exec_inst = exec_cond_template.render(indent="  ", cond=key, program=program)
+        exec_inst = exec_cond_template.render(
+            indent="  ",
+            cond=exec_cond,
+            program=program,
+        )
         exec_paths += exec_inst
     input_output_checks = INPUT_OUTPUT_CHECKS_TEMPLATE.render(
         input_ndims=input_ndims,
@@ -913,6 +1005,45 @@ def add_profiler(file_pairs, workdir, op_type, output_name, code):
         file_pairs.append((src_path, obj_path))
 
 
+def filter_cutlass_3x_ops(op_instance, func_attrs):
+    """Filter out CUTLASS 3.x ops with incompatible alignment requirements.
+
+    The CUTLASS 3.x ops have stricter alignment requirements compared to
+    the CUTLASS 2.x ops (due to TMA). These alignment requirements are used
+    to initially filter them out in the `function_filter` below. However, the
+    required alignments of the GEMM op inputs and outputs may change due to
+    TensorAccessor-related optimizations, which are introduced to the model
+    graph *after* the initial filtering.
+
+    In this function, the (possible) TA-related alignment updates are checked
+    once again and the CUTLASS 3.x ops not satisfying these requirements are
+    filtered out. Importantly, due to input/output alignment flexibilit of the
+    CUTLASS 2.x ops, their alignment requirements are corrected using the
+    TA-imposed alignments in the `update_alignments_in_gemm_instance` function
+    above. But this correction is not possible for the CUTLASS 3.x ops, as they
+    won't work with the lower alignment values. That's why the CUTLASS 3.x ops
+    are filtered out by this function in such cases.
+    """
+    import cutlass_lib
+
+    a_alignment, b_alignment, epilogue_alignment = get_tensor_accessor_alignments(
+        func_attrs
+    )
+
+    result = {}
+    for op_name, op in op_instance.items():
+        if op.gemm_kind == cutlass_lib.library.GemmKind.Universal3x:
+            if (
+                op.A.alignment > a_alignment
+                or op.B.alignment > b_alignment
+                or op.C.alignment > epilogue_alignment
+            ):
+                continue
+        result[op_name] = op
+
+    return result
+
+
 def gen_profiler(
     func_attrs,
     workdir,
@@ -925,9 +1056,14 @@ def gen_profiler(
     output_addr_calculator="",
     bias_ptr_arg=None,
     extra_code="",
+    problem_args_template_cutlass_3x=None,
 ):
+    import cutlass_lib
+
     op_type = func_attrs["op"]
     op_instance = func_attrs["op_instance"]
+    op_instance = filter_cutlass_3x_ops(op_instance, func_attrs)
+
     backend_spec = CUDASpec()
     elem_input_type = backend_spec.dtype_to_lib_type(
         func_attrs["inputs"][0]._attrs["dtype"]
@@ -957,6 +1093,14 @@ def gen_profiler(
             elem_input_type=elem_input_type,
             elem_output_type=elem_output_type,
         ),
+        problem_args_cutlass_3x=(
+            problem_args_template_cutlass_3x.render(
+                elem_input_type=elem_input_type,
+                elem_output_type=elem_output_type,
+            )
+            if problem_args_template_cutlass_3x is not None
+            else ""
+        ),
     )
     input_output_checks = INPUT_OUTPUT_CHECKS_TEMPLATE.render(
         input_ndims=ndims,
@@ -969,11 +1113,19 @@ def gen_profiler(
     benchmark_instances = []
     for instance_idx, (op_name, op) in enumerate(op_instance.items()):
         config = emit_instance(op, for_profiler=True)
-        config_name = extract_config_name(config)
         instance_name = f"{instance_name_base}_{instance_idx}"
         gemm_op = f"gemm_op_{instance_idx}"
-        instance = INSTANCE_TEMPLATE.render(
-            config_name=config_name, name=instance_name, config=config
+        cutlass_3x = op.gemm_kind == cutlass_lib.library.GemmKind.Universal3x
+        instance_template = (
+            INSTANCE_TEMPLATE_CUTLASS_3X if cutlass_3x else INSTANCE_TEMPLATE
+        )
+        instance = instance_template.render(
+            config_name=extract_config_name(
+                config,
+                cutlass_3x=cutlass_3x,
+            ),
+            name=instance_name,
+            config=config,
         )
         benchmark_instance = BENCHMARK_INSTANCE_TEMPLATE.render(
             indent="  ",
@@ -1152,6 +1304,7 @@ def default_fproc(
         cutlass_lib.library.DataTypeTag[op.A.element] == data_type
         and cutlass_lib.library.DataTypeTag[op.B.element] == data_type
         and cutlass_lib.library.DataTypeTag[op.C.element] == data_type
+        and cutlass_lib.library.DataTypeTag[op.D.element] == data_type
         and op.accumulator_type() == acc_type
         and op.A.layout == a_layout
         and op.B.layout == b_layout
@@ -1160,6 +1313,7 @@ def default_fproc(
         op = copy.deepcopy(op)
         # set output major
         op.C.layout = c_layout
+        op.D.layout = c_layout
         # set epilogue
         op.epilogue_functor = cutlass_lib.library.EpilogueFunctorName[epilogue_name]
         op.element_epilogue = acc_type
@@ -1167,16 +1321,21 @@ def default_fproc(
             op.permute_layout = cutlass_lib.library.EpiloguePermuteLayoutName[
                 permute_layout
             ]
-        # set C alignment
+        # set C and D alignment
         alignments = alignment.get_alignments(dtype)
         for i in alignments:
             op = copy.deepcopy(op)
             op.C.alignment = i
+            op.D.alignment = i
             ret.append(op)
     return ret
 
 
-def make_fproc(func_attrs, layout):
+def make_fproc(
+    func_attrs,
+    layout,
+    include_cutlass_3x_ops=False,
+):
     """
     This function sets a callback for processing the epilogue of the kernel
     associated with func_attrs.
@@ -1193,7 +1352,10 @@ def make_fproc(func_attrs, layout):
             epilogue_name=func_attrs["epilogue"],
         )
 
-    func_attrs["op_instance"] = extract_config(fproc)
+    func_attrs["op_instance"] = extract_config(
+        f_proc_op=fproc,
+        include_cutlass_3x_ops=include_cutlass_3x_ops,
+    )
 
 
 def function_filter(cfg, func_attrs, ab_alignment):

--- a/python/aitemplate/backend/cuda/gemm_universal/common_bias_broadcast.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/common_bias_broadcast.py
@@ -350,6 +350,7 @@ def gemm_bias_broadcast_instance(
     binary_op2,
     unary_op2,
     elem_type,
+    cutlass_3x=False,
 ):
     """
     adjust gemm instance with respect to input_accessors, layout and epilogue ops

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr.py
@@ -71,6 +71,30 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
 )
 
 
+PROBLEM_ARGS_TEMPLATE_CUTLASS_3X = jinja2.Template(
+    """
+    cutlass::gemm::GemmUniversalMode::kGemm,                     // GemmUniversalMode mode
+    {
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K),
+        static_cast<coord_t>(1)
+    },                                                           // ProblemShape problem_shape
+    ({{elem_input_type}}*)(a_ptr) + input_a_offset,              // ElementA const* ptr_A
+    {input_a_stride, cute::Int<1>{}, cute::Int<0>{}},            // StrideA dA
+    ({{elem_input_type}}*)(b_ptr) + input_b_offset,              // ElementB const* ptr_B
+    {input_b_stride, cute::Int<1>{}, cute::Int<0>{}},            // StrideB dB
+    {
+        {ElementComputeEpilogue(1), ElementComputeEpilogue(0)},  // typename ThreadEpilogueOp::Params thread
+        ({{elem_output_type}}*)(c_ptr) + output_offset,          // ElementC const* ptr_C
+        {output_stride, cute::Int<1>{}, cute::Int<0>{}},         // StrideC dC
+        ({{elem_output_type}}*)(c_ptr) + output_offset,          // ElementD const* ptr_D
+        {output_stride, cute::Int<1>{}, cute::Int<0>{}},         // StrideD dD
+    },                                                           // EpilogueArguments epilogue
+"""
+)
+
+
 # for profiler, no need to include TensorAccessor
 PROFILER_PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
@@ -98,9 +122,33 @@ PROFILER_PROBLEM_ARGS_TEMPLATE = jinja2.Template(
 )
 
 
+PROFILER_PROBLEM_ARGS_TEMPLATE_CUTLASS_3X = jinja2.Template(
+    """
+    cutlass::gemm::GemmUniversalMode::kGemm,                     // GemmUniversalMode mode
+    {
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K),
+        static_cast<coord_t>(1)
+    },                                                           // ProblemShape problem_shape
+    ({{elem_input_type}}*)(a_ptr),                               // ElementA const* ptr_A
+    {K, cute::Int<1>{}, cute::Int<0>{}},                         // StrideA dA
+    ({{elem_input_type}}*)(b_ptr),                               // ElementB const* ptr_B
+    {K, cute::Int<1>{}, cute::Int<0>{}},                         // StrideB dB
+    {
+        {ElementComputeEpilogue(1), ElementComputeEpilogue(0)},  // typename ThreadEpilogueOp::Params thread
+        ({{elem_output_type}}*)(c_ptr),                          // ElementC const* ptr_C
+        {N, cute::Int<1>{}, cute::Int<0>{}},                     // StrideC dC
+        ({{elem_output_type}}*)(c_ptr) + output_offset,          // ElementD const* ptr_D
+        {output_stride, cute::Int<1>{}, cute::Int<0>{}},         // StrideD dD
+    },                                                           // EpilogueArguments epilogue
+"""
+)
+
+
 @registry.reg("cuda.gemm_rcr.config")
 def gemm_rcr_config(func_attrs, dtype="float16"):
-    common.make_fproc(func_attrs, RCR)
+    common.make_fproc(func_attrs, RCR, include_cutlass_3x_ops=True)
 
 
 def common_gen_profiler(
@@ -110,6 +158,7 @@ def common_gen_profiler(
     dim_info_dict,
     src_template,
     problem_args_template,
+    problem_args_template_cutlass_3x=None,
     bias_ptr_arg=None,
     extra_code="",
 ):
@@ -117,13 +166,14 @@ def common_gen_profiler(
         stride_dim="*b_dim0"
     )
     return common.gen_profiler(
-        func_attrs,
-        workdir,
-        profiler_filename,
-        dim_info_dict,
-        src_template,
-        problem_args_template,
-        ARGS_PARSER_TEMPLATE,
+        func_attrs=func_attrs,
+        workdir=workdir,
+        profiler_filename=profiler_filename,
+        dim_info_dict=dim_info_dict,
+        src_template=src_template,
+        problem_args_template=problem_args_template,
+        problem_args_template_cutlass_3x=problem_args_template_cutlass_3x,
+        args_parser_template=ARGS_PARSER_TEMPLATE,
         support_split_k=True,
         output_addr_calculator=output_addr_calculator,
         bias_ptr_arg=bias_ptr_arg,
@@ -134,12 +184,13 @@ def common_gen_profiler(
 @registry.reg("cuda.gemm_rcr.gen_profiler")
 def gen_profiler(func_attrs, workdir, profiler_filename, dim_info_dict):
     return common_gen_profiler(
-        func_attrs,
-        workdir,
-        profiler_filename,
-        dim_info_dict,
-        common.SRC_TEMPLATE,
-        PROFILER_PROBLEM_ARGS_TEMPLATE,
+        func_attrs=func_attrs,
+        workdir=workdir,
+        profiler_filename=profiler_filename,
+        dim_info_dict=dim_info_dict,
+        src_template=common.SRC_TEMPLATE,
+        problem_args_template=PROFILER_PROBLEM_ARGS_TEMPLATE,
+        problem_args_template_cutlass_3x=PROFILER_PROBLEM_ARGS_TEMPLATE_CUTLASS_3X,
     )
 
 
@@ -196,19 +247,25 @@ def gen_function(
         elem_input_type=elem_input_type,
         elem_output_type=elem_output_type,
     )
+    problem_args_cutlass_3x = PROBLEM_ARGS_TEMPLATE_CUTLASS_3X.render(
+        elem_input_type=elem_input_type,
+        elem_output_type=elem_output_type,
+    )
     return common.gen_function(
-        func_attrs,
-        common.SRC_TEMPLATE,
-        exec_cond_template,
-        problem_args,
-        input_ndims,
-        weight_ndims,
-        output_ndims,
-        dim_info_dict,
+        func_attrs=func_attrs,
+        src_template=common.SRC_TEMPLATE,
+        exec_cond_template=exec_cond_template,
+        problem_args=problem_args,
+        problem_args_cutlass_3x=problem_args_cutlass_3x,
+        input_ndims=input_ndims,
+        weight_ndims=weight_ndims,
+        output_ndims=output_ndims,
+        dim_info_dict=dim_info_dict,
         support_split_k=True,
         input_addr_calculator=input_addr_calculator,
         output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(
-            stride_dim="N", output_accessor=func_attrs["output_accessors"][0]
+            stride_dim="N",
+            output_accessor=func_attrs["output_accessors"][0],
         ),
     )
 

--- a/python/aitemplate/backend/cuda/gemm_universal/group_common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/group_common.py
@@ -766,7 +766,12 @@ def update_alignments_in_group_gemm_instance(
     return "\n".join(instance_lines)
 
 
-def group_gemm_instance(op_def: str, func_attrs: Dict[str, Any], for_profiler: bool):
+def group_gemm_instance(
+    op_def: str,
+    func_attrs: Dict[str, Any],
+    for_profiler: bool,
+    cutlass_3x: bool = False,
+):
     # TODO: This is a dirty thing need to add an extra emitter to clean this up
     op_def = update_alignments_in_group_gemm_instance(op_def, func_attrs, for_profiler)
     tmp = op_def.replace("DefaultGemmUniversal", "DefaultGemmGrouped")

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_common.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_common.py
@@ -509,6 +509,11 @@ class gemm(Operator):
             output_shape = self._attrs["output_accessors"][0].original_shapes
             self._extract_epilogue_alignment(output_shape, dynamic_profiling_strategy)
 
+        if not self._attrs["op_instance"]:
+            raise RuntimeError(
+                f"No GEMM op instances were generated for {self._attrs['op']}."
+            )
+
         filter_func = registry.get(func_key)
         # run compile-time filter
         new_op_instance = OrderedDict(
@@ -522,6 +527,12 @@ class gemm(Operator):
             f"to {len(new_op_instance)}",
         )
         self._attrs["op_instance"] = new_op_instance
+
+        if not self._attrs["op_instance"]:
+            raise RuntimeError(
+                f"No GEMM op instances are left after filtering for {self._attrs['op']}. "
+                "This is probably due to incompatible alignment requirements."
+            )
 
         build_profiler = self._should_build_profiler(workloads, new_op_instance)
         if build_profiler:

--- a/tests/unittest/ops/test_gemm.py
+++ b/tests/unittest/ops/test_gemm.py
@@ -21,6 +21,7 @@ from aitemplate.compiler import compile_model, ops
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
+    env_variables,
     filter_test_cases_by_test_env,
     get_random_torch_tensor,
     get_torch_empty_tensor,
@@ -347,6 +348,68 @@ class GEMMTestCase(unittest.TestCase):
         self._test_3d_2d_rrr(
             [2, 34, 48], [1, 3, 5], 256, 16, "dynamic3_bfloat16", dtype="bfloat16"
         )
+
+    def test_rcr_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_rcr(
+                    ms=[1, 1024],
+                    k=252,
+                    n=512,
+                    test_name="dynamic_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_rcr(
+                ms=[1, 1024],
+                k=256,
+                n=512,
+                test_name="dynamic_force_sm90",
+                dtype="float16",
+            )
+
+            self._test_rcr_dynamic_n(
+                ms=[16, 1 * 29, 64],
+                k=256,
+                ns=[100000, 300000],
+                test_name="einsum_dynamic_n_force_sm90",
+                dtype="float16",
+            )
+            self._test_3d_2d_rcr(
+                m0s=[1, 99, 1024],
+                m1s=[1, 2],
+                k=128,
+                n=8,
+                test_name="dynamic3_force_sm90",
+                dtype="float16",
+            )
+            self._test_h_rcr(
+                ait_dtype="float16",
+                test_name="float16_force_sm90",
+            )
+
+            self._test_rcr(
+                ms=[1024],
+                k=256,
+                n=512,
+                test_name="static_float_forse_sm90",
+                dtype="float32",
+            )
+            self._test_rcr(
+                ms=[1024],
+                k=256,
+                n=512,
+                test_name="static_bfloat16_forse_sm90",
+                dtype="bfloat16",
+            )
 
 
 filter_test_cases_by_test_env(GEMMTestCase)


### PR DESCRIPTION
Summary: CUTLASS 3.x SM90 kernel support added to the `gemm_rcr` op. Infrastructure for gradual adoption of the SM90 kernels is established in the CUDA GEMM backend (mostly, `backend/cuda/gemm_universal/common.py`. Enabling SM90 kernel support for the following ops is supposed to reuse (and, possibly extend) this infrastructure.

Differential Revision: D45193614

