### PR TITLE
classic_b2b_bmm: add multi-head and strides

### DIFF
--- a/python/aitemplate/backend/cuda/b2b_bmm/classic_b2b_bmm.py
+++ b/python/aitemplate/backend/cuda/b2b_bmm/classic_b2b_bmm.py
@@ -113,9 +113,9 @@ void check_status(cutlass::Status status, int64_t m0, int64_t k0, const std::str
     >;
 
   using B2bGemmBatched = cutlass::gemm::device::B2bGemmBatched<
-    cutlass::half_t,
+    ElementCompute,
     cutlass::layout::RowMajor,
-    cutlass::half_t,
+    ElementCompute,
     cutlass::layout::ColumnMajor,
     cutlass::layout::RowMajor,
     ElementOutput,
@@ -137,24 +137,51 @@ void check_status(cutlass::Status status, int64_t m0, int64_t k0, const std::str
 
   cutlass::gemm::GemmCoord problem_size_0(m0, {{n0}}, k0);
   cutlass::gemm::GemmCoord problem_size_1(m0, {{n1}}, {{n0}});
+
+  // Assuming BMHD dim ordering for inputs and outputs, like in FHMA style op
+  // B = batch size
+  // M = sequence len
+  // H = num heads
+  // D = embedding dims per head
+  // --- Tensor shapes:
+  // GEMM PROBLEM 0:
+  // A=query : [ batch_size, M0, num_heads, K0 ]
+  // B=key : [ batch_size, N0, num_heads, K0 ]
+  // C0=bias : [ batch_size, num_heads, M0, N0 ] # Where the batch size, head and M0 dimension may be broadcasted over
+  // GEMM PROBLEM 1:
+  // B1=value : [ batch_size, K1==N0, num_heads, N1 ]
+  // C1=unused:  [ N1 ]
+  // D1=output : [ batch_size, M1==M0, num_heads, N1 ]
+
+  // Required equalities for B2B gemm:
+  // M1 = M0;
+  // K1 = N0;
+
   typename B2bGemmBatched::Arguments arguments{
-    problem_size_0,
-    problem_size_1,
-    {static_cast<ElementCompute*>(query), typename B2bGemmBatched::LayoutA::Stride(problem_size_0.k())},
-    problem_size_0.m() * problem_size_0.k(),
-    {static_cast<ElementCompute*>(key), typename B2bGemmBatched::LayoutB::Stride(problem_size_0.k())},
-    problem_size_0.n() * problem_size_0.k(),
-    {static_cast<ElementCompute*>(bias), typename B2bGemmBatched::LayoutC::Stride(problem_size_0.n())},
-    problem_size_0.m() * problem_size_0.n(),
-    {static_cast<ElementCompute*>(value), typename B2bGemmBatched::LayoutB1::Stride(problem_size_1.n())},
-    problem_size_1.n() * problem_size_1.k(),
-    {static_cast<ElementCompute*>(nullptr), typename B2bGemmBatched::LayoutScaleBias::Stride(0)},
-    0,
-    {static_cast<ElementOutput*>(output), typename B2bGemmBatched::LayoutC::Stride(problem_size_1.n())},
-    problem_size_1.m() * problem_size_1.n(),
-    batch_size,
-    {alpha0, beta0, activation_alpha},
-    {alpha1, beta1},
+    problem_size_0, // = GemmCoord problem_size_0;
+    problem_size_1, // = GemmCoord problem_size_1;
+    {static_cast<ElementCompute*>(query), typename B2bGemmBatched::LayoutA::Stride(num_heads * problem_size_0.k())},    // TensorRef<ElementA const, LayoutA> ref_A0;
+    problem_size_0.k(),                                                                                                 // int64_t head_stride_A0;
+    num_heads * problem_size_0.m() * problem_size_0.k(),                                                                // int64_t batch_stride_A0;
+    {static_cast<ElementCompute*>(key), typename B2bGemmBatched::LayoutB::Stride(num_heads * problem_size_0.k())},      // TensorRef<ElementB const, LayoutB> ref_B0;
+    problem_size_0.k(),                                                                                                 // int64_t head_stride_B0;
+    num_heads * problem_size_0.n() * problem_size_0.k(),                                                                // int64_t batch_stride_B0;
+    {static_cast<ElementCompute*>(bias), typename B2bGemmBatched::LayoutC::Stride({{bias_stride_n}})},                  // TensorRef<ElementC const, LayoutC> ref_C0;
+    {{bias_stride_mn}},                                                                                                 // int64_t head_stride_C0;
+    {{bias_stride_hmn}},                                                                                                // int64_t batch_stride_C0;
+    {static_cast<ElementCompute*>(value), typename B2bGemmBatched::LayoutB1::Stride(num_heads * problem_size_1.n())},   // TensorRef<ElementC const, LayoutC> ref_B1;
+    problem_size_1.n(),                                                                                                 // int64_t head_stride_B1;                                                                    //
+    num_heads * problem_size_1.n() * problem_size_1.k(),                                                                // int64_t batch_stride_B1;
+    {static_cast<ElementCompute*>(nullptr), typename B2bGemmBatched::LayoutScaleBias::Stride(0)},                       // Not used due to ScaleType::Nothing for output op 1
+    0,                                                                                                                  // not used: int64_t head_stride_C1;
+    0,                                                                                                                  // not used: int64_t batch_stride_C1;
+    {static_cast<ElementOutput*>(output), typename B2bGemmBatched::LayoutC::Stride(num_heads * problem_size_1.n())},    // TensorRef<ElementC, LayoutC> ref_D1;
+    problem_size_1.n(),                                                                                                 // int64_t head_stride_output;
+    num_heads * problem_size_1.m() * problem_size_1.n(),                                                                // int64_t batch_stride_output;
+    batch_size,                                                                                                         // int batch_count;
+    num_heads,                                                                                                          // int num_heads
+    {alpha0, beta0, activation_alpha},                                                                                  // typename EpilogueOutputOp0::Params epilogue0;
+    {alpha1, beta1},                                                                                                    // typename EpilogueOutputOp1::Params epilogue1;
   };
 
   B2bGemmBatched b2b_gemm_op;
@@ -186,6 +213,7 @@ void {{func_name}}(void* output,
                    void* value,
                    void* bias,
                    int64_t batch_size,
+                   int64_t num_heads,
                    int64_t m0,
                    int64_t k0,
                    cudaStream_t stream)
@@ -204,6 +232,7 @@ FUNC_CALL_TEMPLATE = jinja2.Template(
 {{indent}}    {{output}},
 {{indent}}    {{query}}, {{key}}, {{value}}, {{bias}},
 {{indent}}    {{batch_size}},
+{{indent}}    {{num_heads}},
 {{indent}}    {{m0}},
 {{indent}}    {{k0}},
 {{indent}}    stream /* default stream */
@@ -216,13 +245,18 @@ FUNC_CALL_TEMPLATE = jinja2.Template(
 def classic_b2b_bmm_gen_function(func_attrs: Dict[str, Any]) -> str:
     """the function for generating attention kernel"""
     q, k, v, bias = func_attrs["inputs"]
-    n0 = k._attrs["shape"][1]
-    n1 = v._attrs["shape"][2]
+    seq_len_dim = 1
+    n0 = k._attrs["shape"][seq_len_dim]
+    n1 = v._attrs["shape"][-1]
     if not isinstance(n0, IntImm) or not isinstance(n1, IntImm):
         raise RuntimeError(
             f"n0 and n1 must be static dims. {func_attrs['name']=}, {n0=}, {n1=}"
         )
     backend_spec = CUDASpec()
+    if func_attrs["inputs"][0]._attrs["dtype"] != "float16":
+        raise NotImplementedError(
+            "only float16 dtype supported for now in classic_b2b_bmm op"
+        )
     elem_input_type = backend_spec.dtype_to_lib_type(
         func_attrs["inputs"][0]._attrs["dtype"]
     )
@@ -243,6 +277,37 @@ def classic_b2b_bmm_gen_function(func_attrs: Dict[str, Any]) -> str:
         cutlass_lib.library.EpilogueMathName[func_attrs["epilogue_math_name"]]
     ]
 
+    bias_shape = bias._attrs["shape"]
+    bias_broadcast = [s == IntImm(1) for s in bias_shape]
+    if len(bias_broadcast) == 3:
+        # single head case: Add num heads dimension of size 1
+        bias_broadcast = [bias_broadcast[0], True, bias_broadcast[1], bias_broadcast[2]]
+    assert (
+        len(bias_broadcast) == 4
+    ), f"Bias shape should be of length 4, got {len(bias_broadcast)=}"
+
+    # Calculate stride expressions for bias tensor
+    # Last dimension of bias has implicit stride of 1,
+    # so cannot be broadcasted over
+    bias_stride_n = "problem_size_0.n()"
+    bias_shape_expr = [bias_stride_n]
+
+    # build stride expressions
+    if not bias_broadcast[-2]:
+        bias_shape_expr.append("problem_size_0.m()")
+    bias_stride_mn = "*".join(bias_shape_expr)
+    if not bias_broadcast[-3]:
+        bias_shape_expr.append("num_heads")
+    bias_stride_hmn = "*".join(bias_shape_expr)  # batch stride
+
+    # Strides for broadcasted dimensions are zero
+    if bias_broadcast[0]:  # query sequence len stride
+        bias_stride_hmn = "0"
+    if bias_broadcast[1]:  # head stride
+        bias_stride_mn = "0"
+    if bias_broadcast[2]:  # query sequence length stride
+        bias_stride_n = "0"
+
     return FUNC_TEMPLATE.render(
         func_name=func_attrs["name"],
         func_signature=FUNC_SIGNATURE.render(func_name=func_attrs["name"]),
@@ -260,6 +325,9 @@ def classic_b2b_bmm_gen_function(func_attrs: Dict[str, Any]) -> str:
         if func_attrs["alpha1_divide_by_seq_len"]
         else "false",
         epilogue_math=epilogue_math,
+        bias_stride_n=bias_stride_n,
+        bias_stride_mn=bias_stride_mn,
+        bias_stride_hmn=bias_stride_hmn,
     )
 
 
@@ -283,10 +351,19 @@ def classic_b2b_bmm_gen_function_call(func_attrs, indent="  "):
     bias_name = func_attrs["inputs"][3]._attrs["name"]
 
     q_shape = func_attrs["inputs"][0]._attrs["shape"]
-    batch_size = q_shape[0]._attrs["name"]
-    m0 = q_shape[1]._attrs["name"]
-    k0 = q_shape[2]._attrs["name"]
 
+    batch_size = q_shape[0]._attrs["name"]
+    seq_len_dim = 1
+    head_dim = -2
+    m0 = q_shape[seq_len_dim]._attrs["name"]
+
+    if len(q_shape) == 3:
+        # single head case
+        k0 = q_shape[2]._attrs["name"]
+        num_heads = "1"
+    elif len(q_shape) == 4:
+        k0 = q_shape[3]._attrs["name"]
+        num_heads = q_shape[head_dim]._attrs["name"]
     return FUNC_CALL_TEMPLATE.render(
         func_name=func_attrs["name"],
         output=output_name,
@@ -295,6 +372,7 @@ def classic_b2b_bmm_gen_function_call(func_attrs, indent="  "):
         value=v_name,
         bias=bias_name,
         batch_size=batch_size,
+        num_heads=num_heads,
         m0=m0,
         k0=k0,
         indent=indent,

--- a/python/aitemplate/compiler/ops/b2b_bmm/classic_b2b_bmm.py
+++ b/python/aitemplate/compiler/ops/b2b_bmm/classic_b2b_bmm.py
@@ -17,18 +17,33 @@
 Back-to-back batched gemm fused kernel.
 Computes bmm(causal_mask(alpha1 * (activation(alpha0 * bmm(Q, K) + bias))), V),
 
-where:
+Notation:
+B: batch size
+H: number of heads
+
+If inputs/outputs have three dims ( singlehead case ):
 Q: [B, M0, K0] (row_major),
 K: [B, N0, K0] (column_major),
 V: [B, N0, N1] (row_major),
 bias: [B, M0, N0] (row_major).
-Layouts are fixed for now.
+output: [ B, M0, N1 ]
 
-Only supports NO_CAUSAL or LOWER_LEFT_EMPTY for now.
+If inputs/outputs have four dims ( multihead case ),
+the head dim is located at the dimension with index 2
+
+dimension order of the parameters is
+
+Q: [B, M0, H, K0] (row_major),
+K: [B, N0, H, K0] (column_major),
+V: [B, N0, H, N1] (row_major),
+bias: [B, H, M0, N0] (row_major).
+Output: [ B, M0, H, N1 ]
+
+Only supports NO_CAUSAL or LOWER_LEFT_EMPTY causal mask types.
 When causal_mask is enabled, M0 must be equal to N0.
 
 Internally, it stores the results of Q@K in registers without writing them to shared memory, which is faster.
-However, N0 / N1 must be <= 512.
+However, N0 and N1 must be <= 512.
 """
 
 from aitemplate.backend import registry, target
@@ -37,8 +52,6 @@ from aitemplate.compiler.ops.b2b_bmm.b2b_bmm_base import b2b_bmm_base, CausalTyp
 
 
 class classic_b2b_bmm(b2b_bmm_base):
-    """See comments at the head of this file."""
-
     def __init__(
         self,
         causal_type: CausalType,
@@ -47,9 +60,20 @@ class classic_b2b_bmm(b2b_bmm_base):
         alpha1: float,
         alpha1_divide_by_seq_len: bool = False,
     ) -> None:
-        """Initialize classic_b2b_bmm op.
-        Check aitemplate.compiler.ops.b2b_bmm.b2b_bmm_base for more details
-        about these args.
+        r"""Back-to-back batched gemm fused kernels.
+
+        More detailed documentation at the top of this file.
+
+        Args:
+        * causal_type (CausalType): Type of causal_mask. See comments above.
+        * epilogue_math_name (str): Name of the activation function.
+        Supported epilogue functions can be found from
+        python/aitemplate/utils/mk_cutlass_lib/extra_enum.py.
+        * alpha0 (float): See the math function above.
+        * alpha1 (float): See the math function above.
+        * alpha1_divide_by_seq_len (bool) Whether divide alpha1 by seq_len.
+        Useful when seq_len is a dynamic value so that alpah1 cannot be
+        computed in advance.
         """
         super().__init__(
             causal_type, epilogue_math_name, alpha0, alpha1, alpha1_divide_by_seq_len
@@ -69,32 +93,35 @@ class classic_b2b_bmm(b2b_bmm_base):
         q_shape = q._attrs["shape"]
         k_shape = k._attrs["shape"]
         v_shape = v._attrs["shape"]
+        head_dim = 2
+        seq_dim = 1
         if len(q_shape) != len(k_shape) or len(q_shape) != len(v_shape):
             raise RuntimeError(
                 f"QKV ranks must be the same! QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}."
             )
-        if len(q_shape) != 3:
+        if len(q_shape) != 3 and len(k_shape) != 4:
             raise RuntimeError(
-                f"QKV must have rank == 3! Current rank: {len(q_shape)}, QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}."
+                f"QKV must have rank 3 or 4! Current rank: {len(q_shape)}, QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}."
             )
 
         if q_shape[0] != k_shape[0] or q_shape[0] != v_shape[0]:
             raise RuntimeError(
                 f"QKV must have same batch size! QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}."
             )
+
         batch_size = q_shape[0]
-        M0 = q_shape[1]
-        K0 = q_shape[2]
-        if K0 != k_shape[2]:
+        M0 = q_shape[seq_dim]
+        K0 = q_shape[-1]
+        if K0 != k_shape[-1]:
             raise RuntimeError(
                 f"Q K shapes are not compatible! QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}."
             )
-        N0 = k_shape[1]
-        if N0 != v_shape[1]:
+        N0 = k_shape[seq_dim]
+        if N0 != v_shape[seq_dim]:
             raise RuntimeError(
                 f"K V shapes are not compatible! QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}."
             )
-        N1 = v_shape[2]
+        N1 = v_shape[-1]
         if N0.upper_bound() > 512 or N1.upper_bound() > 512:
             raise RuntimeError(
                 f"classic_b2b_bmm only supports <=512 N0 / N1. Current length: {N0=}, {N1=}"
@@ -108,16 +135,48 @@ class classic_b2b_bmm(b2b_bmm_base):
                 raise RuntimeError(
                     f"When causal_type is enabled, M0 must be equal to N0. Current {M0=}, {N0=}."
                 )
-
-        output_shape = [batch_size, M0, N1]
-
         bias_shape = bias._attrs["shape"]
-        if bias_shape != [batch_size, M0, N0]:
-            raise RuntimeError(
-                f"bias shape is not compatible with Q K! "
-                f"QKV shapes: {q_shape=}, {k_shape=}, {v_shape=}, "
-                f"bias shapes: {bias_shape=}."
-            )
+
+        is_multihead = len(q_shape) == 4
+        if is_multihead:
+            num_heads = q_shape[head_dim]
+
+            output_shape = [batch_size, M0, num_heads, N1]
+            if len(bias_shape) != 4:
+                raise RuntimeError(
+                    f"Was expecting 4-dimensional bias based on q dimensionality. {len(bias_shape)=} {len(q_shape)=}"
+                )
+            for bias_dim, expected_dim in zip(
+                bias_shape, [batch_size, num_heads, M0, N0]
+            ):
+                if bias_dim != IntImm(1) and bias_dim != expected_dim:
+                    raise RuntimeError(
+                        f"bias shape is not compatible with Q K! "
+                        f"QKV shapes: {q_shape=}, {num_heads=}, {k_shape=}, {v_shape=}, "
+                        f"bias shapes: {bias_shape=}."
+                    )
+            # key sequence length is identical to last shape dim of bias tensor
+            # so if it is also constant 1, it is not a real broadcast and permissible
+            if bias_shape[-1] == IntImm(1) and k_shape[seq_dim] != IntImm(1):
+                raise RuntimeError(
+                    "classic_b2b_bmm op does not support broadcasting of last dimension of bias tensor (e.g. over sequence length of key and value ). Use the expand op to emulate this broadcast behavior if you need it."
+                )
+        else:
+            num_heads = IntImm(1)
+            self._attrs["num_heads"] = num_heads
+            output_shape = [batch_size, M0, N1]
+            if len(bias_shape) != 3:
+                raise RuntimeError(
+                    f"Was expecting 3-dimensional bias based on q dimensionality. {len(bias_shape)=} {len(q_shape)=}"
+                )
+            for bias_dim, expected_dim in zip(bias_shape, [batch_size, M0, N0]):
+                if bias_dim != IntImm(1) and bias_dim != expected_dim:
+                    raise RuntimeError(
+                        f"bias shape is not compatible with Q K! "
+                        f"QKV shapes: {q_shape=}, {num_heads=}, {k_shape=}, {v_shape=}, "
+                        f"bias shapes: {bias_shape=}."
+                    )
+
         return output_shape
 
     def __call__(
@@ -129,16 +188,18 @@ class classic_b2b_bmm(b2b_bmm_base):
     ) -> Tensor:
         """call the op
 
+        Note: [H,] means optional num-heads,
+        if it exists for one input tensor, all need to have it,
         Parameters
         ----------
-        q: Tensor, shape(B, M0, K0)
-        k: Tensor, shape(B, N0, K0)
-        v: Tensor, shape(B, N0, N1)
-        bias: Tensor, shape(B, M0, N0)
+        q: Tensor, shape(B, M0, [H,] K0)
+        k: Tensor, shape(B, N0, [H,] K0)
+        v: Tensor, shape(B, N0, [H,] N1)
+        bias: Tensor, shape(B, [H,] M0, N0)
 
         Returns
         ----------
-        Tensor, shape(B, M0, N1)
+        Tensor, shape(B, M0, [H,], N1)
         """
 
         self._attrs["inputs"] = [q, k, v, bias]

--- a/static/include/kernels/classic_b2b_bmm/device/b2b_batched_gemm.h
+++ b/static/include/kernels/classic_b2b_bmm/device/b2b_batched_gemm.h
@@ -204,18 +204,25 @@ class B2bGemmBatched {
     GemmCoord problem_size_0;
     GemmCoord problem_size_1;
     TensorRef<ElementA const, LayoutA> ref_A0;
-    int64_t stride_A0;
+    int64_t head_stride_A0;
+    int64_t batch_stride_A0;
     TensorRef<ElementB const, LayoutB> ref_B0;
-    int64_t stride_B0;
+    int64_t head_stride_B0;
+    int64_t batch_stride_B0;
     TensorRef<ElementC const, LayoutC> ref_C0;
-    int64_t stride_C0;
+    int64_t head_stride_C0;
+    int64_t batch_stride_C0;
     TensorRef<ElementB const, LayoutB1> ref_B1;
-    int64_t stride_B1;
+    int64_t head_stride_B1;
+    int64_t batch_stride_B1;
     TensorRef<ElementC const, LayoutC> ref_C1;
-    int64_t stride_C1;
+    int64_t head_stride_C1;
+    int64_t batch_stride_C1;
     TensorRef<ElementC, LayoutC> ref_D1;
-    int64_t stride_D1;
+    int64_t head_stride_D1;
+    int64_t batch_stride_D1;
     int batch_count;
+    int num_heads;
     typename EpilogueOutputOp0::Params epilogue0;
     typename EpilogueOutputOp1::Params epilogue1;
 
@@ -235,18 +242,25 @@ class B2bGemmBatched {
       GemmCoord problem_size_0_,
       GemmCoord problem_size_1_,
       TensorRef<ElementA const, LayoutA> ref_A0_,
-      int64_t stride_A0_,
+      int64_t head_stride_A0_,
+      int64_t batch_stride_A0_,
       TensorRef<ElementB const, LayoutB> ref_B0_,
-      int64_t stride_B0_,
+      int64_t head_stride_B0_,
+      int64_t batch_stride_B0_,
       TensorRef<ElementC const, LayoutC> ref_C0_,
-      int64_t stride_C0_,
+      int64_t head_stride_C0_,
+      int64_t batch_stride_C0_,
       TensorRef<ElementB const, LayoutB1> ref_B1_,
-      int64_t stride_B1_,
+      int64_t head_stride_B1_,
+      int64_t batch_stride_B1_,
       TensorRef<ElementC const, LayoutC> ref_C1_,
-      int64_t stride_C1_,
+      int64_t head_stride_C1_,
+      int64_t batch_stride_C1_,
       TensorRef<ElementC, LayoutC> ref_D1_,
-      int64_t stride_D1_,
+      int64_t head_stride_D1_,
+      int64_t batch_stride_D1_,
       int batch_count_,
+      int num_heads_,
       typename EpilogueOutputOp0::Params epilogue0_ =
         typename EpilogueOutputOp0::Params(),
       typename EpilogueOutputOp1::Params epilogue1_ =
@@ -255,18 +269,25 @@ class B2bGemmBatched {
       problem_size_0(problem_size_0_),
       problem_size_1(problem_size_1_),
       ref_A0(ref_A0_),
-      stride_A0(stride_A0_),
+      head_stride_A0(head_stride_A0_),
+      batch_stride_A0(batch_stride_A0_),
       ref_B0(ref_B0_),
-      stride_B0(stride_B0_),
+      head_stride_B0(head_stride_B0_),
+      batch_stride_B0(batch_stride_B0_),
       ref_C0(ref_C0_),
-      stride_C0(stride_C0_),
+      head_stride_C0(head_stride_C0_),
+      batch_stride_C0(batch_stride_C0_),
       ref_B1(ref_B1_),
-      stride_B1(stride_B1_),
+      head_stride_B1(head_stride_B1_),
+      batch_stride_B1(batch_stride_B1_),
       ref_C1(ref_C1_),
-      stride_C1(stride_C1_),
+      head_stride_C1(head_stride_C1_),
+      batch_stride_C1(batch_stride_C1_),
       ref_D1(ref_D1_),
-      stride_D1(stride_D1_),
+      head_stride_D1(head_stride_D1_),
+      batch_stride_D1(batch_stride_D1_),
       batch_count(batch_count_),
+      num_heads(num_heads_),
       epilogue0(epilogue0_),
       epilogue1(epilogue1_) {
 
@@ -318,7 +339,7 @@ public:
     cutlass::gemm::GemmCoord grid_shape = threadblock_swizzle.get_tiled_shape(
       args.problem_size_0,
       {ThreadblockShape0::kM, ThreadblockShape0::kN, ThreadblockShape0::kK},
-      args.batch_count);
+      args.batch_count * args.num_heads);
 
     // Initialize the Params structure
     params_ = typename B2bGemmBatchedKernel::Params{
@@ -326,18 +347,25 @@ public:
       args.problem_size_1,
       grid_shape,
       args.ref_A0.non_const_ref(),
-      args.stride_A0,
+      args.head_stride_A0,
+      args.batch_stride_A0,
       args.ref_B0.non_const_ref(),
-      args.stride_B0,
+      args.head_stride_B0,
+      args.batch_stride_B0,
       args.ref_C0.non_const_ref(),
-      args.stride_C0,
+      args.head_stride_C0,
+      args.batch_stride_C0,
       args.ref_B1.non_const_ref(),
-      args.stride_B1,
+      args.head_stride_B1,
+      args.batch_stride_B1,
       args.ref_C1.non_const_ref(),
-      args.stride_C1,
+      args.head_stride_C1,
+      args.batch_stride_C1,
       args.ref_D1,
-      args.stride_D1,
+      args.head_stride_D1,
+      args.batch_stride_D1,
       args.batch_count,
+      args.num_heads,
       args.epilogue0,
       args.epilogue1
     };

--- a/tests/unittest/ops/test_b2b_bmm.py
+++ b/tests/unittest/ops/test_b2b_bmm.py
@@ -23,6 +23,7 @@ from typing import List, Tuple
 import torch
 
 from aitemplate.compiler import compile_model, ops
+from aitemplate.compiler.base import IntImm
 from aitemplate.compiler.ops.b2b_bmm.b2b_bmm_base import CausalType
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
@@ -202,6 +203,243 @@ class ClassicB2bBmmTestCase(unittest.TestCase):
     detect_target().name() == "cuda" and int(detect_target()._arch) < 80,
     "Not supported by CUDA < SM80.",
 )
+class ClassicMultiheadB2bBmmTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        torch.manual_seed(0)
+
+    def _test_classic_multihead_b2b_bmm(
+        self,
+        batch_sizes: Tuple[int, List[int]] = 1024,
+        m=256,
+        k0=128,
+        n0=256,
+        n1=256,
+        num_heads=2,
+        epilogue_math_name="Identity",
+        causal_type=CausalType.NO_CAUSAL,
+        dtype="float16",
+        test_name="classic_b2b_bmm",
+        copy_op=True,
+        atol=1e-2,
+        rtol=1e-2,
+        bias_broadcast=(False, False, False, False),
+    ):
+        # Initialize AIT classic_b2b_bmm operator.
+        assert len(bias_broadcast) == 4
+        assert (
+            bias_broadcast[3] is False
+        ), "Classic b2b bmm cannot broadcast bias on last dimension."
+        if isinstance(batch_sizes, int):
+            batch_sizes = [batch_sizes]
+        alpha0 = 1.0 / (k0**0.5)
+        alpha1 = 1.0
+        batch_size_dim = shape_utils.gen_int_var_min_max(batch_sizes, "batch_size")
+
+        Q = Tensor(
+            shape=[batch_size_dim, m, num_heads, k0],
+            dtype=dtype,
+            name="q",
+            is_input=True,
+        )
+        K = Tensor(
+            shape=[batch_size_dim, n0, num_heads, k0],
+            dtype=dtype,
+            name="k",
+            is_input=True,
+        )
+        V = Tensor(
+            shape=[batch_size_dim, n0, num_heads, n1],
+            dtype=dtype,
+            name="v",
+            is_input=True,
+        )
+        bias_shape_full = [batch_size_dim, num_heads, m, n0]
+        bias_shape = [
+            IntImm(1) if bias_broadcast[i] else bias_shape_full[i] for i in range(4)
+        ]
+        Bias = Tensor(
+            shape=bias_shape,
+            dtype=dtype,
+            name="bias",
+            is_input=True,
+        )
+        classic_b2b_bmm_op = ops.classic_b2b_bmm(
+            causal_type=causal_type,
+            alpha0=alpha0,
+            alpha1=alpha1,
+            alpha1_divide_by_seq_len=True,
+            epilogue_math_name=epilogue_math_name,
+        )
+        if copy_op:
+            classic_b2b_bmm_op = ops.classic_b2b_bmm(
+                **classic_b2b_bmm_op._get_op_attributes()
+            )
+        Y = classic_b2b_bmm_op(Q, K, V, Bias)
+        Y._attrs["is_output"] = True
+        Y._attrs["name"] = "output"
+
+        target = detect_target(use_fp16_acc=True)
+        module = compile_model(Y, target, "./tmp", test_name)
+
+        # Run tests.
+        torch_dtype = string_to_torch_dtype(dtype)
+        for batch_size in batch_sizes:
+            # Initialize inputs
+            # Initialized in BMHD dim order
+            q_pt = torch.rand(batch_size, m, num_heads, k0, dtype=torch_dtype).cuda()
+            k_pt = torch.rand(batch_size, n0, num_heads, k0, dtype=torch_dtype).cuda()
+            v_pt = torch.rand(batch_size, n0, num_heads, n1, dtype=torch_dtype).cuda()
+            bias_shape_full_pt = (batch_size, num_heads, m, n0)
+            bias_shape_pt = (
+                1 if bias_broadcast[i] else bias_shape_full_pt[i] for i in range(4)
+            )
+            bias_pt = torch.rand(*bias_shape_pt, dtype=torch_dtype).cuda()
+
+            # Permute to BHMD dim order
+            q_pt_hf = torch.permute(q_pt, [0, 2, 1, 3])
+            k_pt_hf = torch.permute(k_pt, [0, 2, 1, 3])
+            v_pt_hf = torch.permute(v_pt, [0, 2, 1, 3])
+
+            # Run PT reference.
+            attn = alpha0 * (q_pt_hf @ k_pt_hf.transpose(-2, -1)) + bias_pt
+            attn = epilogue_math_name_to_torch_fn(epilogue_math_name)(attn)
+            attn = alpha1 / m * attn
+            invalid_attn_mask = get_attn_mask_per_causal_type(
+                m, n0, causal_type, torch_dtype
+            )
+            attn = attn * invalid_attn_mask
+            second_mm = attn @ v_pt_hf
+            output = torch.permute(
+                second_mm, [0, 2, 1, 3]
+            )  # permute back to original dim order
+            y_pt = output.detach()
+
+            # Run AIT.
+            inputs = {"q": q_pt, "k": k_pt, "v": v_pt, "bias": bias_pt}
+            y = torch.empty(
+                [batch_size, m, num_heads, n1],
+                dtype=torch_dtype,
+                device="cuda",
+            )
+            module.run_with_tensors(inputs, [y])
+            torch.testing.assert_close(y, y_pt.to(torch_dtype), atol=atol, rtol=rtol)
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_classic_multihead1_b2b_bmm(self):
+        self._test_classic_multihead_b2b_bmm(
+            test_name="classic_multihead1_b2b_bmm_fp16_basic",
+            dtype="float16",
+            batch_sizes=1,
+            num_heads=1,
+        )
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_classic_multihead2_b2b_bmm(self):
+        self._test_classic_multihead_b2b_bmm(
+            test_name="classic_multihead2_b2b_bmm_fp16_basic",
+            dtype="float16",
+            batch_sizes=1,
+            num_heads=2,
+        )
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_classic_multihead1_b2b_bmm_bias_broadcast1(self):
+        self._test_classic_multihead_b2b_bmm(
+            test_name="classic_multihead1_b2b_bmm_broadcast1_fp16_basic",
+            dtype="float16",
+            batch_sizes=1,
+            num_heads=1,
+            bias_broadcast=[True, True, False, False],
+        )
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_classic_multihead2_b2b_bmm_bias_broadcast1(self):
+        self._test_classic_multihead_b2b_bmm(
+            test_name="classic_multihead2_b2b_bmm_broadcast1_fp16_basic",
+            dtype="float16",
+            batch_sizes=1,
+            num_heads=2,
+            bias_broadcast=[True, True, False, False],
+        )
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_classic_multihead2_b2b_bmm_bias_broadcast2(self):
+        self._test_classic_multihead_b2b_bmm(
+            test_name="classic_multihead2_b2b_bmm_broadcast2_fp16_basic",
+            dtype="float16",
+            batch_sizes=1,
+            num_heads=2,
+            bias_broadcast=[True, True, True, False],
+        )
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_classic_multihead2_b2b_bmm_bias_broadcast3(self):
+        self._test_classic_multihead_b2b_bmm(
+            test_name="classic_multihead2_b2b_bmm_broadcast3_fp16_basic",
+            dtype="float16",
+            batch_sizes=1,
+            num_heads=2,
+            bias_broadcast=[True, False, False, False],
+        )
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_classic_multihead4_b2b_bmm(self):
+        self._test_classic_multihead_b2b_bmm(
+            test_name="classic_multihead4_b2b_bmm_fp16_dynamic_batch",
+            dtype="float16",
+            batch_sizes=[3, 8, 10],
+            num_heads=4,
+        )
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_classic_multihead16_b2b_bmm(self):
+        self._test_classic_multihead_b2b_bmm(
+            test_name="classic_multihead16_b2b_bmm_fp16_rectangular",
+            dtype="float16",
+            batch_sizes=[2],
+            m=512,
+            n0=128,
+            n1=128,
+            num_heads=16,
+        )
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_classic_multihead3_b2b_bmm(self):
+        self._test_classic_multihead_b2b_bmm(
+            test_name="classic_multihead3_b2b_bmm_fp16_causal",
+            dtype="float16",
+            batch_sizes=5,
+            causal_type=CausalType.LOWER_LEFT_EMPTY,
+            num_heads=3,
+        )
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_classic_multihead8_b2b_bmm(self):
+        self._test_classic_multihead_b2b_bmm(
+            test_name="classic_multihead8_b2b_bmm_fp16_sigmoid",
+            dtype="float16",
+            batch_sizes=[1, 4],
+            epilogue_math_name="Sigmoid",
+            num_heads=8,
+        )
+
+    @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
+    def test_classic_multihead1_relu_b2b_bmm(self):
+        self._test_classic_multihead_b2b_bmm(
+            test_name="classic_multihead1_b2b_bmm_fp16_complex",
+            dtype="float16",
+            batch_sizes=[1, 4],
+            epilogue_math_name="ReLu",
+            causal_type=CausalType.LOWER_LEFT_EMPTY,
+            num_heads=1,
+        )
+
+
+@unittest.skipIf(
+    detect_target().name() == "cuda" and int(detect_target()._arch) < 80,
+    "Not supported by CUDA < SM80.",
+)
 class FMHAStyleB2bBmmTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -260,6 +498,7 @@ class FMHAStyleB2bBmmTestCase(unittest.TestCase):
             name="v",
             is_input=True,
         )
+
         Bias = None
         if has_bias:
             shape = [batch_size_dim, num_heads_dim, seq_lens_dim, seq_lens_kv_dim]
@@ -280,6 +519,7 @@ class FMHAStyleB2bBmmTestCase(unittest.TestCase):
             alpha1_divide_by_seq_len=True,
             epilogue_math_name=epilogue_math_name,
         )
+
         if copy_op:
             fmha_style_b2b_bmm_op = ops.fmha_style_b2b_bmm(
                 **fmha_style_b2b_bmm_op._get_op_attributes()
@@ -308,12 +548,12 @@ class FMHAStyleB2bBmmTestCase(unittest.TestCase):
                 batch_size, seq_len_kv, num_head, n1, dtype=torch_dtype
             ).cuda()
             shape = [batch_size, num_head, seq_len, seq_len_kv]
-            if bias_broadcast:
-                for i, broadcast in enumerate(bias_broadcast):
-                    if broadcast:
-                        shape[i] = 1
-            bias_pt = torch.rand(shape, dtype=torch_dtype).cuda()
-
+            if has_bias:
+                if bias_broadcast:
+                    for i, broadcast in enumerate(bias_broadcast):
+                        if broadcast:
+                            shape[i] = 1
+                bias_pt = torch.rand(shape, dtype=torch_dtype).cuda()
             # Run PT reference.
             attn = alpha0 * (
                 q_pt.transpose(1, 2) @ k_pt.transpose(1, 2).transpose(-2, -1)
@@ -361,11 +601,13 @@ class FMHAStyleB2bBmmTestCase(unittest.TestCase):
             test_name="fmha_style_b2b_bmm_fp16_dynamic_seq_len",
             dtype="float16",
             seq_lens=[128, 256],
+            # dynamic sequence length not supported by classic op
         )
         self._test_fmha_style_b2b_bmm(
             test_name="fmha_style_b2b_bmm_fp16_dynamic_seq_len_kv",
             dtype="float16",
             seq_lens_kv=[128, 256],
+            # dynamic sequence length not supported by classic op
         )
         self._test_fmha_style_b2b_bmm(
             test_name="fmha_style_b2b_bmm_fp16_dynamic_num_heads",
@@ -385,6 +627,7 @@ class FMHAStyleB2bBmmTestCase(unittest.TestCase):
             dtype="float16",
             batch_sizes=2,
             causal_type=CausalType.UPPER_RIGHT_EMPTY,
+            # CausalType.UPPER_RIGHT_EMPTY not supported by classic op
         )
         self._test_fmha_style_b2b_bmm(
             test_name="fmha_style_b2b_bmm_fp16_causal_lower_left_empty",
@@ -404,6 +647,13 @@ class FMHAStyleB2bBmmTestCase(unittest.TestCase):
             batch_sizes=3,
             has_bias=True,
             bias_broadcast=[False, True, False, False],
+        )
+        self._test_fmha_style_b2b_bmm(
+            test_name="fmha_style_b2b_bmm_fp16_bias_broadcast_relative_pos",
+            dtype="float16",
+            batch_sizes=[1, 11],
+            has_bias=True,
+            bias_broadcast=[True, True, False, False],
         )
         self._test_fmha_style_b2b_bmm(
             test_name="fmha_style_b2b_bmm_fp16_sigmoid",


### PR DESCRIPTION
Summary:
The classic b2b bmm op was missing support for multi-head and dimension reordering through explicit strides. This diff ports the changes Rahul made in his private codebase ( D43946388 ) into AIT and adapts the classic_b2b_bmm op to support multihead input/output as well as strided inputs.

Note: There seem to be preexisting issues with the classic b2b bmm op, which this diff does not address yet. I noticed them while developing this diff.

See https://www.internalfb.com/diff/D45308351

Differential Revision: D45049609

