### PR TITLE
Add SM90 CUTLASS 3.x kernels to bmm_xxx and bmm_xxx_add

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_universal/bmm_rcr_permute.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/bmm_rcr_permute.py
@@ -114,6 +114,7 @@ def gen_function(
     )
     (
         problem_args,
+        _,  # problem_args_cutlass_3x
         input_addr_calculator,
         output_addr_calculator,
     ) = bmm_common.make_function_strided_args(

--- a/python/aitemplate/backend/cuda/gemm_universal/bmm_rrr_permute.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/bmm_rrr_permute.py
@@ -114,6 +114,7 @@ def gen_function(
     )
     (
         problem_args,
+        _,  # problem_args_cutlass_3x
         input_addr_calculator,
         output_addr_calculator,
     ) = bmm_common.make_function_strided_args(

--- a/python/aitemplate/backend/cuda/gemm_universal/bmm_xxx.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/bmm_xxx.py
@@ -38,6 +38,9 @@ def _get_problem_args(a_layout, b_layout, c_layout):
         "ldb": "K" if b_layout == "c" else "N",
         "ldbias": "M" if c_layout == "c" else "N",
         "ldc": "M" if c_layout == "c" else "N",
+        "a_row_major": a_layout == "r",
+        "b_row_major": b_layout == "r",
+        "c_row_major": c_layout == "r",
     }
 
 
@@ -64,7 +67,10 @@ def get_config(a_layout, b_layout, c_layout):
                 epilogue_name=func_attrs["epilogue"],
             )
 
-        func_attrs["op_instance"] = common.extract_config(fproc)
+        func_attrs["op_instance"] = common.extract_config(
+            f_proc_op=fproc,
+            include_cutlass_3x_ops=True,
+        )
 
     return config
 
@@ -105,17 +111,22 @@ def get_gen_function(a_layout, b_layout, c_layout):
         )
         (
             problem_args,
+            problem_args_cutlass_3x,
             input_addr_calculator,
             output_addr_calculator,
         ) = bmm_common.make_function_strided_args(
-            func_attrs, dim_info_dict, default_mm_info, is_permute=False
+            func_attrs=func_attrs,
+            dim_info_dict=dim_info_dict,
+            default_mm_info=default_mm_info,
+            is_permute=False,
         )
 
         return bmm_common.gen_function(
-            func_attrs,
-            exec_cond_template,
-            problem_args,
-            dim_info_dict,
+            func_attrs=func_attrs,
+            exec_cond_template=exec_cond_template,
+            problem_args=problem_args,
+            problem_args_cutlass_3x=problem_args_cutlass_3x,
+            dim_info_dict=dim_info_dict,
             input_addr_calculator=input_addr_calculator,
             output_addr_calculator=output_addr_calculator,
         )

--- a/python/aitemplate/backend/cuda/gemm_universal/bmm_xxx_add.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/bmm_xxx_add.py
@@ -49,16 +49,22 @@ def get_gen_function(a_layout, b_layout, c_layout):
         )
         (
             problem_args,
+            problem_args_cutlass_3x,
             input_addr_calculator,
             output_addr_calculator,
         ) = bmm_common.make_function_strided_args(
-            func_attrs, dim_info_dict, default_mm_info, is_permute=False
+            func_attrs=func_attrs,
+            dim_info_dict=dim_info_dict,
+            default_mm_info=default_mm_info,
+            is_permute=False,
         )
+
         return bmm_common.gen_function(
-            func_attrs,
-            exec_cond_template,
-            problem_args,
-            dim_info_dict,
+            func_attrs=func_attrs,
+            exec_cond_template=exec_cond_template,
+            problem_args=problem_args,
+            problem_args_cutlass_3x=problem_args_cutlass_3x,
+            dim_info_dict=dim_info_dict,
             input_addr_calculator=input_addr_calculator,
             output_addr_calculator=output_addr_calculator,
         )

--- a/python/aitemplate/backend/cuda/gemm_universal/perm021fc_crc.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm021fc_crc.py
@@ -24,7 +24,9 @@ from aitemplate.backend.cuda.gemm_universal import bmm_common, common
 
 def _get_problem_info(**kwargs):
     problem_args = {
-        "problem_size": "{N, M, K}",
+        "problem_dim_0": "N",
+        "problem_dim_1": "M",
+        "problem_dim_2": "K",
         "bias_ptr": "c_ptr",
         "a_batch_stride": "0",
         "b_batch_stride": "K * M",

--- a/python/aitemplate/backend/cuda/gemm_universal/perm021fc_crc_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm021fc_crc_bias.py
@@ -30,7 +30,9 @@ from aitemplate.backend.cuda.gemm_universal import (
 def _get_problem_info(**kwargs):
     problem_args = {
         "beta_value": 1,
-        "problem_size": "{N, M, K}",
+        "problem_dim_0": "N",
+        "problem_dim_1": "M",
+        "problem_dim_2": "K",
         "bias_ptr": "bias_ptr",
         "a_batch_stride": "0",
         "b_batch_stride": "K * M",

--- a/tests/unittest/compiler/test_move_view_ops.py
+++ b/tests/unittest/compiler/test_move_view_ops.py
@@ -30,6 +30,10 @@ from aitemplate.utils import graph_utils, shape_utils
 class MoveViewOpsTestCase(unittest.TestCase):
     BATCH_SIZE = 1024
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        torch.manual_seed(0)
+
     def __init__(self, *args, **kwargs):
         super(MoveViewOpsTestCase, self).__init__(*args, **kwargs)
         self.test_count = 0
@@ -1835,4 +1839,5 @@ class MoveViewOpsTestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    torch.manual_seed(0)
     unittest.main()

--- a/tests/unittest/ops/test_bmm.py
+++ b/tests/unittest/ops/test_bmm.py
@@ -21,6 +21,7 @@ from aitemplate.compiler import compile_model, ops
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
+    env_variables,
     filter_test_cases_by_test_env,
     get_random_torch_tensor,
     get_torch_empty_tensor,
@@ -407,6 +408,366 @@ class BMMTestCase(unittest.TestCase):
         self._test_ccc(
             [1, 9, 11], M=64, N=32, K=16, test_name=f"dynamic_b_{dtype}", dtype=dtype
         )
+
+    def test_rrr_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_rrr(
+                    bs=[2, 5, 7],
+                    ms=[1, 7, 9],
+                    K=60,
+                    N=28,
+                    test_name="wrong_alignment_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_rrr(
+                bs=[2, 5, 7],
+                ms=[1, 7, 9],
+                K=64,
+                N=32,
+                test_name="dynamic_fp16_force_sm90",
+                dtype="float16",
+            )
+            self._test_rrr(
+                bs=[2, 5, 7],
+                ms=[1, 7, 9],
+                K=60,
+                N=28,
+                test_name="dynamic_fp32_force_sm90",
+                dtype="float32",
+            )
+            self._test_rrr(
+                bs=[2, 5, 7],
+                ms=[1, 7, 9],
+                K=64,
+                N=32,
+                test_name="dynamic_bf16_force_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_rcr_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_rcr(
+                    bs=[2, 5, 7],
+                    ms=[1, 7, 9],
+                    N=60,
+                    K=28,
+                    test_name="wrong_alignment_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_rcr(
+                bs=[2, 5, 7],
+                ms=[1, 7, 9],
+                N=64,
+                K=32,
+                test_name="dynamic_bm_fp16_force_sm90",
+                dtype="float16",
+            )
+            self._test_rcr(
+                bs=[2, 5, 7],
+                ms=[1, 7, 9],
+                N=60,
+                K=28,
+                test_name="dynamic_bm_fp32_force_sm90",
+                dtype="float32",
+            )
+            self._test_rcr(
+                bs=[2, 5, 7],
+                ms=[1, 7, 9],
+                N=64,
+                K=32,
+                test_name="dynamic_bm_bf16_force_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_ccr_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_ccr(
+                    bs=[1, 5, 11],
+                    M=60,
+                    N=7,
+                    K=28,
+                    test_name="wrong_alignment_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_ccr(
+                bs=[1, 5, 11],
+                M=64,
+                N=7,
+                K=32,
+                test_name="dynamic_b_fp16_forse_sm90",
+                dtype="float16",
+            )
+            self._test_ccr(
+                bs=[1, 5, 11],
+                M=60,
+                N=7,
+                K=28,
+                test_name="dynamic_b_fp32_forse_sm90",
+                dtype="float32",
+            )
+            self._test_ccr(
+                bs=[1, 5, 11],
+                M=64,
+                N=7,
+                K=32,
+                test_name="dynamic_b_bf16_forse_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_crr_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_crr(
+                    bs=[1, 2, 5],
+                    ks=[3, 6, 8],
+                    M=28,
+                    N=60,
+                    test_name="dynamic_bk_fp16_forse_sm90",
+                    dtype="float16",
+                )
+
+            self._test_crr(
+                bs=[1, 2, 5],
+                ks=[3, 6, 8],
+                M=32,
+                N=64,
+                test_name="dynamic_bk_fp16_forse_sm90",
+                dtype="float16",
+            )
+            self._test_crr(
+                bs=[1, 2, 5],
+                ks=[3, 6, 8],
+                M=28,
+                N=60,
+                test_name="dynamic_bk_fp32_forse_sm90",
+                dtype="float32",
+            )
+            self._test_crr(
+                bs=[1, 2, 5],
+                ks=[3, 6, 8],
+                M=32,
+                N=64,
+                test_name="dynamic_bk_bf16_forse_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_rrc_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_rrc(
+                    bs=[2, 5, 7],
+                    ms=[1, 7, 9],
+                    K=60,
+                    N=28,
+                    test_name="wrong_alignment_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_rrc(
+                bs=[2, 5, 7],
+                ms=[1, 7, 9],
+                K=64,
+                N=32,
+                test_name="dynamic_fp16_force_sm90",
+                dtype="float16",
+            )
+            self._test_rrc(
+                bs=[2, 5, 7],
+                ms=[1, 7, 9],
+                K=60,
+                N=28,
+                test_name="dynamic_fp32_force_sm90",
+                dtype="float32",
+            )
+            self._test_rrc(
+                bs=[2, 5, 7],
+                ms=[1, 7, 9],
+                K=64,
+                N=32,
+                test_name="dynamic_bf16_force_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_rcc_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_rcc(
+                    bs=[2, 5, 7],
+                    ms=[1, 7, 9],
+                    N=60,
+                    K=28,
+                    test_name="wrong_alignment_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_rcc(
+                bs=[2, 5, 7],
+                ms=[1, 7, 9],
+                N=64,
+                K=32,
+                test_name="dynamic_bm_fp16_force_sm90",
+                dtype="float16",
+            )
+            self._test_rcc(
+                bs=[2, 5, 7],
+                ms=[1, 7, 9],
+                N=60,
+                K=28,
+                test_name="dynamic_bm_fp32_force_sm90",
+                dtype="float32",
+            )
+            self._test_rcc(
+                bs=[2, 5, 7],
+                ms=[1, 7, 9],
+                N=64,
+                K=32,
+                test_name="dynamic_bm_bf16_force_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_ccc_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_ccc(
+                    bs=[1, 5, 11],
+                    M=60,
+                    N=7,
+                    K=28,
+                    test_name="wrong_alignment_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_ccc(
+                bs=[1, 5, 11],
+                M=64,
+                N=7,
+                K=32,
+                test_name="dynamic_b_fp16_forse_sm90",
+                dtype="float16",
+            )
+            self._test_ccc(
+                bs=[1, 5, 11],
+                M=60,
+                N=7,
+                K=28,
+                test_name="dynamic_b_fp32_forse_sm90",
+                dtype="float32",
+            )
+            self._test_ccc(
+                bs=[1, 5, 11],
+                M=64,
+                N=7,
+                K=32,
+                test_name="dynamic_b_bf16_forse_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_crc_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_crc(
+                    bs=[1, 2, 5],
+                    ks=[3, 6, 8],
+                    M=28,
+                    N=60,
+                    test_name="dynamic_bk_fp16_forse_sm90",
+                    dtype="float16",
+                )
+
+            self._test_crc(
+                bs=[1, 2, 5],
+                ks=[3, 6, 8],
+                M=32,
+                N=64,
+                test_name="dynamic_bk_fp16_forse_sm90",
+                dtype="float16",
+            )
+            self._test_crc(
+                bs=[1, 2, 5],
+                ks=[3, 6, 8],
+                M=28,
+                N=60,
+                test_name="dynamic_bk_fp32_forse_sm90",
+                dtype="float32",
+            )
+            self._test_crc(
+                bs=[1, 2, 5],
+                ks=[3, 6, 8],
+                M=32,
+                N=64,
+                test_name="dynamic_bk_bf16_forse_sm90",
+                dtype="bfloat16",
+            )
 
 
 @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")

--- a/tests/unittest/ops/test_bmm_add.py
+++ b/tests/unittest/ops/test_bmm_add.py
@@ -20,6 +20,7 @@ from aitemplate.compiler import compile_model, ops
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
+    env_variables,
     filter_test_cases_by_test_env,
     get_random_torch_tensor,
     get_torch_empty_tensor,
@@ -36,7 +37,7 @@ class BMMAddTestCase(unittest.TestCase):
         super(BMMAddTestCase, self).__init__(*args, **kwargs)
         self.test_count = 0
 
-    def _test_rrr(self, B, M, K, N, dtype="float16"):
+    def _test_rrr(self, B, M, K, N, test_name, dtype="float16"):
         target = detect_target()
         X = Tensor(shape=[B, M, K], dtype=dtype, name="input_0", is_input=True)
         W = Tensor(shape=[B, K, N], dtype=dtype, name="input_1", is_input=True)
@@ -46,9 +47,7 @@ class BMMAddTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
-            Y, target, "./tmp", f"bmm_rrr_add_{dtype}", dll_name=dll_name
-        )
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         X_pt = get_random_torch_tensor([B, M, K], dtype)
         W_pt = get_random_torch_tensor([B, K, N], dtype)
         D_pt = get_random_torch_tensor([B, M, N], dtype)
@@ -120,7 +119,7 @@ class BMMAddTestCase(unittest.TestCase):
             self.assertTrue(torch.allclose(Y_pt, y, atol=1e-2, rtol=1e-2))
         self.test_count += 1
 
-    def _test_crr(self, B, M, K, N, dtype="float16"):
+    def _test_crr(self, B, M, K, N, test_name, dtype="float16"):
         target = detect_target()
         X = Tensor(
             shape=[B, K, M],
@@ -144,7 +143,6 @@ class BMMAddTestCase(unittest.TestCase):
         Y = OP(X, W, D)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        test_name = f"bmm_crr_add_{dtype}"
         dll_name = f"test_{self.test_count}.so"
         module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         X_pt = get_random_torch_tensor([B, K, M], dtype)
@@ -191,7 +189,7 @@ class BMMAddTestCase(unittest.TestCase):
             self.assertTrue(torch.allclose(Y_pt, y, atol=1e-2, rtol=1e-2))
         self.test_count += 1
 
-    def _test_rrc(self, B, M, K, N, dtype="float16"):
+    def _test_rrc(self, B, M, K, N, test_name, dtype="float16"):
         target = detect_target()
         X = Tensor(shape=[B, M, K], dtype=dtype, name="input_0", is_input=True)
         W = Tensor(shape=[B, K, N], dtype=dtype, name="input_1", is_input=True)
@@ -201,9 +199,7 @@ class BMMAddTestCase(unittest.TestCase):
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
         dll_name = f"test_{self.test_count}.so"
-        module = compile_model(
-            Y, target, "./tmp", f"bmm_rrc_add_{dtype}", dll_name=dll_name
-        )
+        module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         X_pt = get_random_torch_tensor([B, M, K], dtype)
         W_pt = get_random_torch_tensor([B, K, N], dtype)
         D_pt = get_random_torch_tensor([B, N, M], dtype)
@@ -218,7 +214,7 @@ class BMMAddTestCase(unittest.TestCase):
         self.assertTrue(torch.allclose(Y_pt, y, atol=1e-1, rtol=1e-1))
         self.test_count += 1
 
-    def _test_crc(self, B, M, K, N, dtype="float16"):
+    def _test_crc(self, B, M, K, N, test_name, dtype="float16"):
         target = detect_target()
         X = Tensor(
             shape=[B, K, M],
@@ -242,7 +238,6 @@ class BMMAddTestCase(unittest.TestCase):
         Y = OP(X, W, D)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        test_name = f"bmm_crc_add_{dtype}"
         dll_name = f"test_{self.test_count}.so"
         module = compile_model(Y, target, "./tmp", test_name, dll_name=dll_name)
         X_pt = get_random_torch_tensor([B, K, M], dtype)
@@ -290,7 +285,7 @@ class BMMAddTestCase(unittest.TestCase):
         self.test_count += 1
 
     def test_rrr(self):
-        self._test_rrr(B=32, M=256, K=256, N=512)
+        self._test_rrr(B=32, M=256, K=256, N=512, test_name="bmm_rrr_add")
 
     def test_ccr(self):
         self._test_ccr(B=32, M=256, N=256, K=512, test_name="bmm_ccr_add")
@@ -305,7 +300,7 @@ class BMMAddTestCase(unittest.TestCase):
         self._test_rcr(B=1, M=256, N=256, K=0, test_name="bmm_rcr_zero_k")
 
     def test_crr(self):
-        self._test_crr(B=32, M=256, K=256, N=512)
+        self._test_crr(B=32, M=256, K=256, N=512, test_name="bmm_crr_add")
 
     def test_ccc(self):
         self._test_ccc(B=32, M=256, N=256, K=512, test_name="bmm_ccc_add")
@@ -320,50 +315,506 @@ class BMMAddTestCase(unittest.TestCase):
         self._test_rcc(B=1, M=256, N=256, K=0, test_name="bmm_rcc_zero_k")
 
     def test_rrc(self):
-        self._test_rrc(B=32, M=256, K=256, N=512)
+        self._test_rrc(B=32, M=256, K=256, N=512, test_name="bmm_rrc_add")
 
     def test_crc(self):
-        self._test_crc(B=32, M=256, K=256, N=512)
+        self._test_crc(B=32, M=256, K=256, N=512, test_name="bmm_crc_add")
 
     def test_bmm_add_0_fp32_sm80(self, dtype="float32"):
-        self._test_rrr(B=8, M=32, K=8, N=64, dtype=dtype)
-        self._test_ccr(
-            B=8, M=32, N=64, K=16, test_name=f"bmm_ccr_add_{dtype}", dtype=dtype
+        self._test_rrr(
+            B=8,
+            M=32,
+            K=8,
+            N=64,
+            test_name=f"bmm_rrr_add_{dtype}",
+            dtype=dtype,
         )
-        self._test_crr(B=8, M=32, K=16, N=64, dtype=dtype)
+        self._test_ccr(
+            B=8,
+            M=32,
+            N=64,
+            K=16,
+            test_name=f"bmm_ccr_add_{dtype}",
+            dtype=dtype,
+        )
+        self._test_crr(
+            B=8,
+            M=32,
+            K=16,
+            N=64,
+            test_name=f"bmm_crr_add_{dtype}",
+            dtype=dtype,
+        )
         self._test_rcr(
-            B=8, M=32, N=64, K=16, test_name=f"bmm_rcr_add_{dtype}", dtype=dtype
+            B=8,
+            M=32,
+            N=64,
+            K=16,
+            test_name=f"bmm_rcr_add_{dtype}",
+            dtype=dtype,
         )
 
     def test_bmm_add_0_bf16(self, dtype="bfloat16"):
-        self._test_rrr(B=8, M=32, K=8, N=64, dtype=dtype)
-        self._test_ccr(
-            B=8, M=32, N=64, K=16, test_name=f"bmm_ccr_add_{dtype}", dtype=dtype
+        self._test_rrr(
+            B=8,
+            M=32,
+            K=8,
+            N=64,
+            test_name=f"bmm_rrr_add_{dtype}",
+            dtype=dtype,
         )
-        self._test_crr(B=8, M=32, K=16, N=64, dtype=dtype)
+        self._test_ccr(
+            B=8,
+            M=32,
+            N=64,
+            K=16,
+            test_name=f"bmm_ccr_add_{dtype}",
+            dtype=dtype,
+        )
+        self._test_crr(
+            B=8,
+            M=32,
+            K=16,
+            N=64,
+            test_name=f"bmm_crr_add_{dtype}",
+            dtype=dtype,
+        )
         self._test_rcr(
-            B=8, M=32, N=64, K=16, test_name=f"bmm_rcr_add_{dtype}", dtype=dtype
+            B=8,
+            M=32,
+            N=64,
+            K=16,
+            test_name=f"bmm_rcr_add_{dtype}",
+            dtype=dtype,
         )
 
     def test_bmm_add_1_fp32_sm80(self, dtype="float32"):
-        self._test_rrc(B=8, M=32, K=8, N=64, dtype=dtype)
-        self._test_ccc(
-            B=8, M=32, N=64, K=16, test_name=f"bmm_ccr_add_{dtype}", dtype=dtype
+        self._test_rrc(
+            B=8,
+            M=32,
+            K=8,
+            N=64,
+            test_name=f"bmm_rrc_add_{dtype}",
+            dtype=dtype,
         )
-        self._test_crc(B=8, M=32, K=16, N=64, dtype=dtype)
+        self._test_ccc(
+            B=8,
+            M=32,
+            N=64,
+            K=16,
+            test_name=f"bmm_ccc_add_{dtype}",
+            dtype=dtype,
+        )
+        self._test_crc(
+            B=8,
+            M=32,
+            K=16,
+            N=64,
+            test_name=f"bmm_crc_add_{dtype}",
+            dtype=dtype,
+        )
         self._test_rcc(
-            B=8, M=32, N=64, K=16, test_name=f"bmm_rcc_add_{dtype}", dtype=dtype
+            B=8,
+            M=32,
+            N=64,
+            K=16,
+            test_name=f"bmm_rcc_add_{dtype}",
+            dtype=dtype,
         )
 
     def test_bmm_add_1_bf16(self, dtype="bfloat16"):
-        self._test_rrc(B=8, M=32, K=8, N=64, dtype=dtype)
+        self._test_rrc(
+            B=8,
+            M=32,
+            K=8,
+            N=64,
+            test_name=f"bmm_rrc_add_{dtype}",
+            dtype=dtype,
+        )
         self._test_ccc(
-            B=8, M=32, N=64, K=16, test_name=f"bmm_ccr_add_{dtype}", dtype=dtype
+            B=8,
+            M=32,
+            N=64,
+            K=16,
+            test_name=f"bmm_ccc_add_{dtype}",
+            dtype=dtype,
         )
-        self._test_crc(B=8, M=32, K=16, N=64, dtype=dtype)
+        self._test_crc(
+            B=8,
+            M=32,
+            K=16,
+            N=64,
+            test_name=f"bmm_crc_add_{dtype}",
+            dtype=dtype,
+        )
         self._test_rcc(
-            B=8, M=32, N=64, K=16, test_name=f"bmm_rcc_add_{dtype}", dtype=dtype
+            B=8,
+            M=32,
+            N=64,
+            K=16,
+            test_name=f"bmm_rcc_add_{dtype}",
+            dtype=dtype,
         )
+
+    def test_rrr_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_rrr(
+                    B=5,
+                    M=7,
+                    K=60,
+                    N=28,
+                    test_name="bmm_rrr_add_wrong_alignment_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_rrr(
+                B=5,
+                M=7,
+                K=64,
+                N=32,
+                test_name="bmm_rrr_add_fp16_force_sm90",
+                dtype="float16",
+            )
+            self._test_rrr(
+                B=5,
+                M=7,
+                K=60,
+                N=28,
+                test_name="bmm_rrr_add_fp32_force_sm90",
+                dtype="float32",
+            )
+            self._test_rrr(
+                B=5,
+                M=7,
+                K=64,
+                N=32,
+                test_name="bmm_rrr_add_bf16_force_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_rcr_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_rcr(
+                    B=5,
+                    M=7,
+                    N=60,
+                    K=28,
+                    test_name="bmm_rcr_add_wrong_alignment_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_rcr(
+                B=5,
+                M=7,
+                N=64,
+                K=32,
+                test_name="bmm_rcr_add_fp16_force_sm90",
+                dtype="float16",
+            )
+            self._test_rcr(
+                B=5,
+                M=7,
+                N=60,
+                K=28,
+                test_name="bmm_rcr_add_fp32_force_sm90",
+                dtype="float32",
+            )
+            self._test_rcr(
+                B=5,
+                M=7,
+                N=64,
+                K=32,
+                test_name="bmm_rcr_add_bf16_force_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_ccr_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_ccr(
+                    B=5,
+                    M=60,
+                    N=7,
+                    K=28,
+                    test_name="bmm_ccr_add_wrong_alignment_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_ccr(
+                B=5,
+                M=64,
+                N=7,
+                K=32,
+                test_name="bmm_ccr_add_fp16_forse_sm90",
+                dtype="float16",
+            )
+            self._test_ccr(
+                B=5,
+                M=60,
+                N=7,
+                K=28,
+                test_name="bmm_ccr_add_fp32_forse_sm90",
+                dtype="float32",
+            )
+            self._test_ccr(
+                B=5,
+                M=64,
+                N=7,
+                K=32,
+                test_name="bmm_ccr_add_bf16_forse_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_crr_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_crr(
+                    B=5,
+                    K=7,
+                    M=28,
+                    N=60,
+                    test_name="bmm_crr_add_wrong_alignment_forse_sm90",
+                    dtype="float16",
+                )
+
+            self._test_crr(
+                B=5,
+                K=7,
+                M=32,
+                N=64,
+                test_name="bmm_crr_add_fp16_forse_sm90",
+                dtype="float16",
+            )
+            self._test_crr(
+                B=5,
+                K=7,
+                M=28,
+                N=60,
+                test_name="bmm_crr_add_fp32_forse_sm90",
+                dtype="float32",
+            )
+            self._test_crr(
+                B=5,
+                K=7,
+                M=32,
+                N=64,
+                test_name="bmm_crr_add_bk_bf16_forse_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_rrc_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_rrc(
+                    B=5,
+                    M=7,
+                    K=60,
+                    N=28,
+                    test_name="bmm_rrc_add_wrong_alignment_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_rrc(
+                B=5,
+                M=7,
+                K=64,
+                N=32,
+                test_name="bmm_rrc_add_fp16_force_sm90",
+                dtype="float16",
+            )
+            self._test_rrc(
+                B=5,
+                M=7,
+                K=60,
+                N=28,
+                test_name="bmm_rrc_add_fp32_force_sm90",
+                dtype="float32",
+            )
+            self._test_rrc(
+                B=5,
+                M=7,
+                K=64,
+                N=32,
+                test_name="bmm_rrc_add_bf16_force_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_rcc_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_rcc(
+                    B=5,
+                    M=7,
+                    N=60,
+                    K=28,
+                    test_name="bmm_rcc_add_wrong_alignment_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_rcc(
+                B=5,
+                M=7,
+                N=64,
+                K=32,
+                test_name="bmm_rcc_add_fp16_force_sm90",
+                dtype="float16",
+            )
+            self._test_rcc(
+                B=5,
+                M=7,
+                N=60,
+                K=28,
+                test_name="bmm_rcc_add_fp32_force_sm90",
+                dtype="float32",
+            )
+            self._test_rcc(
+                B=5,
+                M=7,
+                N=64,
+                K=32,
+                test_name="bmm_rcc_add_bf16_force_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_ccc_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_ccc(
+                    B=5,
+                    M=60,
+                    N=7,
+                    K=28,
+                    test_name="bmm_ccc_add_wrong_alignment_force_sm90",
+                    dtype="float16",
+                )
+
+            self._test_ccc(
+                B=5,
+                M=64,
+                N=7,
+                K=32,
+                test_name="bmm_ccc_add_fp16_forse_sm90",
+                dtype="float16",
+            )
+            self._test_ccc(
+                B=5,
+                M=60,
+                N=7,
+                K=28,
+                test_name="bmm_ccc_add_fp32_forse_sm90",
+                dtype="float32",
+            )
+            self._test_ccc(
+                B=5,
+                M=64,
+                N=7,
+                K=32,
+                test_name="bmm_ccc_add_bf16_forse_sm90",
+                dtype="bfloat16",
+            )
+
+    def test_crc_sm90(self) -> None:
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_crc(
+                    B=5,
+                    K=7,
+                    M=28,
+                    N=60,
+                    test_name="bmm_crc_add_wrong_alignment_forse_sm90",
+                    dtype="float16",
+                )
+
+            self._test_crc(
+                B=5,
+                K=7,
+                M=32,
+                N=64,
+                test_name="bmm_crc_add_fp16_forse_sm90",
+                dtype="float16",
+            )
+            self._test_crc(
+                B=5,
+                K=7,
+                M=28,
+                N=60,
+                test_name="bmm_crc_add_fp32_forse_sm90",
+                dtype="float32",
+            )
+            self._test_crc(
+                B=5,
+                K=7,
+                M=32,
+                N=64,
+                test_name="bmm_crc_add_bk_bf16_forse_sm90",
+                dtype="bfloat16",
+            )
 
 
 @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")


### PR DESCRIPTION
Summary:
SM90 CUTLASS 3.x kernels are added to the following `bmm_xxx` ops:

- `bmm_rrr`
- `bmm_rcr`
- `bmm_crr`
- `bmm_ccr`
- `bmm_rrc`
- `bmm_rcc`
- `bmm_crc`
- `bmm_ccc`

and the following `bmm_xxx_add` ops:

- `bmm_rrr_add`
- `bmm_rcr_add`
- `bmm_crr_add`
- `bmm_ccr_add`
- `bmm_rrc_add`
- `bmm_rcc_add`
- `bmm_crc_add`
- `bmm_ccc_add`

The bmm + permute ops, `bmm_rcr_permute` and `bmm_rrr_permute` are not extended in this diff, as they require special treatment of the output layout / strides.

Differential Revision: D45400720

