### PR TITLE
Remove manually set Parameter names

### DIFF
--- a/python/aitemplate/frontend/nn/batch_norm.py
+++ b/python/aitemplate/frontend/nn/batch_norm.py
@@ -35,10 +35,12 @@ class _BatchNorm(Module):
         self.dtype = dtype
         self.num_features = num_features
         self.eps = eps
-        self.weight = Parameter(shape=self.dim, name="weight", dtype=dtype)
-        self.bias = Parameter(shape=self.dim, name="bias", dtype=dtype)
-        self.running_mean = Parameter(shape=self.dim, name="running_mean", dtype=dtype)
-        self.running_var = Parameter(shape=self.dim, name="running_var", dtype=dtype)
+        self.weight = Parameter(shape=self.dim, dtype=dtype)
+        self.bias = Parameter(shape=self.dim, dtype=dtype)
+        self.running_mean = Parameter(shape=self.dim, dtype=dtype)
+        self.running_var = Parameter(shape=self.dim, dtype=dtype)
+        # Placeholder for setting constants, won't be used
+        self.num_batches_tracked = Parameter(shape=[], value=0, dtype=dtype)
 
     def forward(self, *args):
         assert len(args) == 1

--- a/python/aitemplate/frontend/nn/conv3d.py
+++ b/python/aitemplate/frontend/nn/conv3d.py
@@ -104,7 +104,7 @@ class Conv3d(Module):
             dtype=dtype,
         )
         if self.has_bias:
-            self.bias = Parameter(shape=[out_channels], dtype=dtype, name="bias")
+            self.bias = Parameter(shape=[out_channels], dtype=dtype)
 
         if groups == 1:
             if self.has_bias:


### PR DESCRIPTION
Summary: Remove manually set `Parameter` names and rely on `.name_parameter_tensor()` to set parameter names instead

Differential Revision: D45435099

