### PR TITLE
Fix circleci test errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ setup_env: &setup_env
           echo 'export PYTHONPATH=$PWD/python:$PYTHONPATH' >> $BASH_ENV &&
           echo 'export CI_FLAG=CIRCLECI' >> $BASH_ENV &&
           echo 'export CACHE_DIR=$PWD/tests/ci_profile_cache' >> $BASH_ENV &&
+          echo 'export LOGLEVEL=DEBUG' >> $BASH_ENV &&
           break || sleep 5;
         done
 

--- a/tests/unittest/compiler/test_split_bmm_fusion.py
+++ b/tests/unittest/compiler/test_split_bmm_fusion.py
@@ -153,7 +153,7 @@ class SplitBmmFusionTestCase(unittest.TestCase):
         )
         # bmm_rcr, split_dim = 1
         self._test_split_bmm_rcr_fusion(
-            ops.bmm_rcr, 1024, 512, 512, 256 * 2, 256, 1, "test_split_bmm_rcr"
+            ops.bmm_rcr, 10, 512, 512, 256 * 2, 256, 1, "test_split_bmm_rcr"
         )
 
     def _test_split_bmm_rcr_fusion_dynamic_M(
@@ -238,7 +238,7 @@ class SplitBmmFusionTestCase(unittest.TestCase):
         # bmm_rcr
         self._test_split_bmm_rcr_fusion_dynamic_M(
             ops.bmm_rcr,
-            1024,
+            10,
             [128, 256],
             512,
             256 * 2,


### PR DESCRIPTION
Summary:
ATT, from
https://app.circleci.com/pipelines/github/facebookincubator/AITemplate/2068/workflows/e8948454-1658-4245-92d1-d185c1c4fb69/jobs/3959,
there are OOM errors. I cannot reproduce this error by locally sshing to circleci
instance, and this error only happens on main branch, instead of a forked branch.
But I do see that these tests use more memory than others.

So in this diff, reduce input tensor size and enable DEBUG logging in circleCI.

Differential Revision: D45436389

