### PR TITLE
Replace hasattr with getattr in aitemplate/AITemplate/python/aitemplate/frontend/nn/multiscale_attention.py

### DIFF
--- a/python/aitemplate/frontend/nn/multiscale_attention.py
+++ b/python/aitemplate/frontend/nn/multiscale_attention.py
@@ -428,17 +428,17 @@ class MultiScaleAttention(Module):
         self._attention_pool_q = _AttentionPool(
             self.pool_q,
             has_cls_embed=self.has_cls_embed,
-            norm=self.norm_q if hasattr(self, "norm_q") else None,
+            norm=getattr(self, "norm_q", None),
         )
         self._attention_pool_k = _AttentionPool(
             self.pool_k,
             has_cls_embed=self.has_cls_embed,
-            norm=self.norm_k if hasattr(self, "norm_k") else None,
+            norm=getattr(self, "norm_k", None),
         )
         self._attention_pool_v = _AttentionPool(
             self.pool_v,
             has_cls_embed=self.has_cls_embed,
-            norm=self.norm_v if hasattr(self, "norm_v") else None,
+            norm=getattr(self, "norm_v", None),
         )
 
     def _qkv_proj(


### PR DESCRIPTION
Summary:
The pattern
```
X.Y if hasattr(X, "Y") else Z
```
can be replaced with
```
getattr(X, "Y", Z)
```

The [getattr](https://www.w3schools.com/python/ref_func_getattr.asp) function gives more succinct code than the [hasattr](https://www.w3schools.com/python/ref_func_hasattr.asp) function. Please use it when appropriate.

**This diff is very low risk. Green tests indicate that you can safely Accept & Ship.**

Differential Revision: D44886430

