### PR TITLE
optionally print python callstack stats for model compilation

### DIFF
--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -21,7 +21,6 @@ from datetime import datetime
 from typing import Dict, List, Optional, Union
 
 from aitemplate import backend, compiler
-
 from aitemplate.compiler.base import (
     DynamicProfileStrategy,
     IntImm,
@@ -39,6 +38,7 @@ from aitemplate.compiler.transform.name_graph import reset_name_counters
 from aitemplate.compiler.transform.profile import elapsed_dt_sec
 from aitemplate.utils import graph_utils
 from aitemplate.utils.debug_settings import AITDebugSettings
+from aitemplate.utils.misc import callstack_stats
 from aitemplate.utils.serialization.serdes_code import dump_program
 
 # pylint: disable=W0102
@@ -145,6 +145,7 @@ def _mark_isolated_int_vars(sorted_graph: List[Tensor]):
 _DEBUG_SETTINGS = AITDebugSettings()
 
 
+@callstack_stats()
 def compile_model(
     tensor: Union[Tensor, List[Tensor]],
     target: backend.target.Target,

--- a/python/aitemplate/utils/misc.py
+++ b/python/aitemplate/utils/misc.py
@@ -59,3 +59,39 @@ def short_str(s, length=8) -> str:
     """
     hash_str = hashlib.sha256(s.encode()).hexdigest()
     return hash_str[0:length]
+
+
+def callstack_stats(enable=False):
+    if enable:
+
+        def decorator(f):
+            import cProfile
+            import io
+            import pstats
+
+            logger = logging.getLogger(__name__)
+
+            def inner_function(*args, **kwargs):
+                pr = cProfile.Profile()
+                pr.enable()
+                result = f(*args, **kwargs)
+                pr.disable()
+                s = io.StringIO()
+                pstats.Stats(pr, stream=s).sort_stats(
+                    pstats.SortKey.CUMULATIVE
+                ).print_stats(30)
+                logger.debug(s.getvalue())
+                return result
+
+            return inner_function
+
+        return decorator
+    else:
+
+        def decorator(f):
+            def inner_function(*args, **kwargs):
+                return f(*args, **kwargs)
+
+            return inner_function
+
+        return decorator


### PR DESCRIPTION
e.g.

```
2023-04-30 23:41:00,967 DEBUG <aitemplate.compiler.compiler>          1960165 function calls (1638331 primitive calls) in 14.739 seconds

   Ordered by: cumulative time
   List reduced from 1012 to 30 due to restriction <30>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   14.740   14.740 /home/max/AITemplate-OSS/python/aitemplate/compiler/compiler.py:170(compile_model)
        1    0.000    0.000   13.826   13.826 /home/max/AITemplate-OSS/python/aitemplate/backend/builder.py:862(make)
        1    0.000    0.000   13.748   13.748 /home/max/AITemplate-OSS/python/aitemplate/backend/builder.py:146(_run_make_cmds)
        3    0.000    0.000   13.717    4.572 /home/max/miniconda3/envs/ait/lib/python3.9/subprocess.py:1090(communicate)
        1    0.000    0.000   13.715   13.715 /home/max/miniconda3/envs/ait/lib/python3.9/subprocess.py:1926(_communicate)
       12    0.000    0.000   13.715    1.143 /home/max/miniconda3/envs/ait/lib/python3.9/selectors.py:403(select)
       12   13.715    1.143   13.715    1.143 {method 'poll' of 'select.poll' objects}
        1    0.000    0.000    0.480    0.480 /home/max/AITemplate-OSS/python/aitemplate/backend/cuda/target_def.py:149(__enter__)
        1    0.000    0.000    0.479    0.479 /home/max/AITemplate-OSS/python/aitemplate/backend/cuda/utils.py:53(gen_ops)
        1    0.000    0.000    0.478    0.478 /tmp/tmp1d682fp8/cutlass_lib/generator.py:1854(GenerateSM75)
     2989    0.014    0.000    0.420    0.000 /tmp/tmp1d682fp8/cutlass_lib/manifest.py:333(append)
       37    0.001    0.000    0.419    0.011 /home/max/AITemplate-OSS/python/aitemplate/utils/graph_utils.py:94(dump_graph_debug_str_to_file)
        1    0.000    0.000    0.290    0.290 /home/max/AITemplate-OSS/python/aitemplate/compiler/transform/optimize_graph.py:59(optimize_graph)
       37    0.000    0.000    0.240    0.006 /home/max/AITemplate-OSS/python/aitemplate/utils/graph_utils.py:49(sorted_graph_debug_str)
 1877/113    0.004    0.000    0.238    0.002 /home/max/miniconda3/envs/ait/lib/python3.9/pprint.py:55(pformat)
 1877/113    0.003    0.000    0.238    0.002 /home/max/miniconda3/envs/ait/lib/python3.9/pprint.py:151(pformat)
14944/113    0.021    0.000    0.237    0.002 /home/max/miniconda3/envs/ait/lib/python3.9/pprint.py:163(_format)
     6124    0.015    0.000    0.232    0.000 /tmp/tmp1d682fp8/cutlass_lib/conv2d_operation.py:95(configuration_name)
        1    0.000    0.000    0.230    0.230 /tmp/tmp1d682fp8/cutlass_lib/generator.py:1272(GenerateSM75_TensorOp_1688)
    18056    0.069    0.000    0.227    0.000 /tmp/tmp1d682fp8/cutlass_lib/library.py:548(SubstituteTemplate)
27423/4179    0.017    0.000    0.224    0.000 /home/max/miniconda3/envs/ait/lib/python3.9/pprint.py:430(_repr)
27423/4179    0.010    0.000    0.220    0.000 /home/max/miniconda3/envs/ait/lib/python3.9/pprint.py:439(format)
59967/4179    0.060    0.000    0.219    0.000 /home/max/miniconda3/envs/ait/lib/python3.9/pprint.py:529(_safe_repr)
 1865/457    0.005    0.000    0.204    0.000 /home/max/miniconda3/envs/ait/lib/python3.9/pprint.py:189(_pprint_dict)
51603/7923    0.010    0.000    0.203    0.000 {built-in method builtins.repr}
       16    0.003    0.000    0.198    0.012 /tmp/tmp1d682fp8/cutlass_lib/generator.py:392(CreateConv2dOperator)
 1865/457    0.020    0.000    0.194    0.000 /home/max/miniconda3/envs/ait/lib/python3.9/pprint.py:372(_format_dict_items)
     4595    0.002    0.000    0.177    0.000 /tmp/tmp1d682fp8/cutlass_lib/conv2d_operation.py:126(procedural_name)
       37    0.000    0.000    0.171    0.005 /home/max/AITemplate-OSS/python/aitemplate/utils/graph_utils.py:55(<listcomp>)
    97/37    0.001    0.000    0.171    0.005 /home/max/AITemplate-OSS/python/aitemplate/compiler/base.py:1124(__str__)

```