### PR TITLE
Fix gap in ads model BF16

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -18,6 +18,7 @@ import operator
 from typing import Dict, List, Sequence, Tuple, Union
 
 import numpy as np
+import torch
 
 from aitemplate.compiler.public import (
     avg_pool2d,
@@ -887,16 +888,22 @@ def acc_ops_nan_to_num(
 
     def _get_dtype(dtype: str):
         if dtype in ("float", "float32"):
-            return np.float32
+            return torch.float32
         elif dtype == "float16":
-            return np.float16
+            return torch.float16
+        elif dtype == "bfloat16":
+            return torch.bfloat16
         else:
             raise NotImplementedError(f"Unsupported dtype {dtype} for nan_to_num")
 
     input_dtype = input_val.dtype()
-    np_dtype = _get_dtype(input_dtype)
-    posinf = np.finfo(np_dtype).max if kwargs["posinf"] is None else kwargs["posinf"]
-    neginf = np.finfo(np_dtype).min if kwargs["neginf"] is None else kwargs["neginf"]
+    torch_dtype = _get_dtype(input_dtype)
+    posinf = (
+        torch.finfo(torch_dtype).max if kwargs["posinf"] is None else kwargs["posinf"]
+    )
+    neginf = (
+        torch.finfo(torch_dtype).min if kwargs["neginf"] is None else kwargs["neginf"]
+    )
     return elementwise(FuncEnum.NAN_TO_NUM)(
         input_val,
         AITTensor(value=nan, shape=[], name="nan", dtype=input_dtype),


### PR DESCRIPTION
Summary:
Now we can set LowerPrecision=BF16 during ads publish pipeline. However, this setting won't change the packaged sample_input's dtype, thus AIT lower pipeline would hit this error during lowering:
```
RuntimeError: AITModel run failed with input spec: [10, 3968]:c10::BFloat16, [10, 96]:c10::BFloat16, [10, 64]:c10::BFloat16, [10, 96]:c10::BFloat16, [10, 64]:c10::BFloat16, [10, 96]:c10::BFloat16, [10, 128]:c10::BFloat16, [10, 72]:c10::BFloat16, [10, 96]:c10::BFloat16, [10, 96]:c10::BFloat16, [10, 96]:c10::BFloat16, [10, 64]:c10::BFloat16, [10, 96]:c10::BFloat16, [10, 72]:c10::BFloat16, [10, 96]:c10::BFloat16, [10, 72]:c10::BFloat16, [10, 72]:c10::BFloat16, [10, 72]:c10::BFloat16, [10, 96]:c10::BFloat16, [10, 72]:c10::BFloat16, [10, 96]:c10::BFloat16, [10, 64]:c10::BFloat16, [10, 72]:c10::BFloat16, [10, 120]:c10::BFloat16, [10, 72]:c10::BFloat16, [10, 72]:c10::BFloat16, [10, 2069]:c10::BFloat16, [10, 5252]:c10::BFloat16,
```
Because the sample input used by AIT is still fp16. Adding input and submod dtype conversion in pipeline to resolve this issue.
*We cannot add the dtype conversion earlier in pipeline, because this would affect run_on_gpu part of model, which may contain op that doesn't suport BF16.

**TO use BF16 input, AIT lowering setting need to be set as:
(input) precision: LowerPrecision.BF16
output_precision: LowerPrecision.FP16
This setting makes sure the connections between any run_on_acc and run_on_gpu graph is smooth. Otherwise a run_on_gpu graph follow after run_on_acc may throw error due to unable to process BF16 tensors.

Differential Revision: D45298122

