### PR TITLE
Fix naming error caused by dump_program().

### DIFF
--- a/python/aitemplate/compiler/base.py
+++ b/python/aitemplate/compiler/base.py
@@ -17,6 +17,8 @@ Basic data types of AITemplate.
 """
 from __future__ import annotations
 
+import copy
+
 import math
 
 from abc import ABC, abstractmethod
@@ -940,6 +942,12 @@ class Tensor(Node):
             )
         self._attrs["data"] = data
 
+    def __deepcopy__(self, memo):
+        result = Tensor(self.shape())
+        memo[id(self)] = result
+        result._attrs = copy.deepcopy(self._attrs, memo)
+        return result
+
     def __add__(self, other: Any) -> Tensor:
         return OP_REGISTRY.get("ADD")(self, other)
 
@@ -1032,6 +1040,12 @@ class IntVarTensor(Tensor):
     def pseudo_code(self, with_shape=True) -> str:
         return f"IntVarTensor({self._attrs['int_var'].pseudo_code()})"
 
+    def __deepcopy__(self, memo):
+        result = IntVarTensor(self._attrs["int_var"])
+        memo[id(self)] = result
+        result._attrs = copy.deepcopy(self._attrs, memo)
+        return result
+
     def __add__(self, other: Any) -> Tensor:
         return OP_REGISTRY.get("INT_ADD")(self, other)
 
@@ -1107,6 +1121,12 @@ class Operator(Node):
         NotImplementedError
         """
         raise NotImplementedError
+
+    def __deepcopy__(self, memo):
+        result = type(self)(**self._get_op_attributes())
+        memo[id(self)] = result
+        result._attrs = copy.deepcopy(self._attrs, memo)
+        return result
 
     def _set_depth(self) -> None:
         """

--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -215,9 +215,6 @@ def compile_model(
     if profile_dir is None:
         profile_dir = workdir
 
-    if debug_settings.dump_ait_to_py:
-        dump_program(tensor, debug_settings.dump_ait_to_py)
-
     if int(recompile) == 1:
         os.makedirs(test_dir, exist_ok=True)
         with target:
@@ -241,6 +238,9 @@ def compile_model(
 
             compiler.transform.name_graph(graph)
             graph_utils.dump_graph_debug_str_to_file(graph, test_dir, "name_graph")
+
+            if debug_settings.dump_ait_to_py:
+                dump_program(tensor, debug_settings.dump_ait_to_py)
 
             compiler.transform.dedup_symbolic_name(graph)
             graph_utils.dump_graph_debug_str_to_file(

--- a/python/aitemplate/compiler/transform/name_graph.py
+++ b/python/aitemplate/compiler/transform/name_graph.py
@@ -15,11 +15,14 @@
 """
 Graph pass to assign names to a sorted graph.
 """
+import logging
 import re
 from typing import List
 
 from aitemplate.compiler.base import IntImm, IntVar, IntVarTensor, JaggedIntVar, Tensor
 from aitemplate.utils import graph_utils
+
+_LOGGER = logging.getLogger(__name__)
 
 # pylint: disable=C0103
 
@@ -71,6 +74,10 @@ def name_graph(sorted_graph: List[Tensor]) -> None:
     global tensor_cnt
     global func_name_to_tensor_cnt
     global user_provided_dim
+
+    _LOGGER.debug(
+        f"before name_graph: {func_cnt=}, {tensor_cnt=}, {len(func_name_to_tensor_cnt)=}, {len(user_provided_dim)=}"
+    )
     for node in sorted_graph:
         funcs = node.src_ops()
         if len(funcs) == 0:
@@ -136,6 +143,10 @@ def name_graph(sorted_graph: List[Tensor]) -> None:
                 # the batch_dim wasn't named above, so we name it here
                 jagged_int_var_name = jagged_int_var._attrs["name"]
                 batch_dim._attrs["name"] = f"{jagged_int_var_name}_jagged_batch_dim"
+
+    _LOGGER.debug(
+        f"after name_graph: {func_cnt=}, {tensor_cnt=}, {len(func_name_to_tensor_cnt)=}, {len(user_provided_dim)=}"
+    )
 
 
 def dedup_symbolic_name(sorted_graph: List[Tensor]) -> None:

--- a/python/aitemplate/utils/serialization/serdes_code.py
+++ b/python/aitemplate/utils/serialization/serdes_code.py
@@ -15,6 +15,7 @@
 """
 Dump/Read sorted_graph to/from python code.
 """
+import copy
 import os
 
 from typing import Dict, List, Optional, Tuple, Union
@@ -306,6 +307,7 @@ def dump_program(
     """
     if isinstance(sorted_graph, Tensor):
         sorted_graph = [sorted_graph]
+    sorted_graph = copy.deepcopy(sorted_graph)
 
     # Make sure the graph is in correct order and has names and param set correctly.
     sorted_graph = toposort(sorted_graph)


### PR DESCRIPTION
Summary:
fx2ait tries to dump an AIT program before AIT compilation by default
(https://fburl.com/code/z9lmvihn).

dump_program() internally calls name_graph(https://fburl.com/code/p94s8xkf),
which updates global naming counters (https://fburl.com/code/clkfj2g9).

However, at the beginning of AIT compile_model(), reset_name_counters() is
called to reset these global naming counters.

As a result, new tensors / operators generated by the AIT compiler may have
duplicate names which already exist in the AIT graph, and cause errors.

Reviewed By: muchulee8, wushirong

Differential Revision: D45467803

