### PR TITLE
Make GEMM ProfilerMemoryPool size computation generic

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/common_dual_gemm.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/common_dual_gemm.py
@@ -75,7 +75,7 @@ TENSOR_DECL_TEMPLATE = jinja2.Template(
 {% if has_bias %}
   one_copy_sz += b1_ptr_sz;
 {%endif%}
-  int64_t mem_pool_sz = memory_pool->ComputeMemPoolSize(one_copy_sz, ptr_max_sz);
+  int64_t mem_pool_sz = memory_pool->ComputeMemPoolSize(one_copy_sz, ptr_max_sz, device_properties.l2CacheSize);
 
   memory_pool->AllocateTensor(a_ptr_sz, mem_pool_sz);  // a_ptr: index 0
   memory_pool->AllocateTensor(b0_ptr_sz, mem_pool_sz);  // b_ptr: index 1

--- a/python/aitemplate/backend/cuda/gemm_universal/bmm_common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/bmm_common.py
@@ -142,7 +142,7 @@ TENSOR_DECL_TEMPLATE = jinja2.Template(
 {% if has_d %}
   one_copy_sz += c_ptr_sz;
 {%endif%}
-  int64_t mem_pool_sz = memory_pool->ComputeMemPoolSize(one_copy_sz, ptr_max_sz);
+  int64_t mem_pool_sz = memory_pool->ComputeMemPoolSize(one_copy_sz, ptr_max_sz, device_properties.l2CacheSize);
 
   memory_pool->AllocateTensor(a_ptr_sz, mem_pool_sz);  // a_ptr: index 0
   memory_pool->AllocateTensor(b_ptr_sz, mem_pool_sz);  // b_ptr: index 1

--- a/python/aitemplate/backend/cuda/gemm_universal/common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/common.py
@@ -368,7 +368,7 @@ TENSOR_DECL_TEMPLATE = jinja2.Template(
 {% if has_bias %}
   one_copy_sz += c_dim1;
 {%endif%}
-  int64_t mem_pool_sz = memory_pool->ComputeMemPoolSize(one_copy_sz, ptr_max_sz);
+  int64_t mem_pool_sz = memory_pool->ComputeMemPoolSize(one_copy_sz, ptr_max_sz, device_properties.l2CacheSize);
 
   memory_pool->AllocateTensor(a_ptr_sz, mem_pool_sz);  // a_ptr: index 0
   memory_pool->AllocateTensor(b_ptr_sz, mem_pool_sz);  // b_ptr: index 1
@@ -484,10 +484,9 @@ struct ProfilerMemoryPool {
   }
   ~ProfilerMemoryPool() {}
 
-  int64_t ComputeMemPoolSize(size_t one_copy_sz, size_t ptr_max_sz) {
-    // TODO: special pool size for A100 L2 cache 40M
-    // need to tune it for other devices
-    int64_t mem_pool_sz = std::max(2,  std::min(64, int((1 << 25) / ptr_max_sz)));
+  int64_t ComputeMemPoolSize(size_t one_copy_sz, size_t ptr_max_sz, size_t l2_cache_bytes) {
+    int times_covers_l2_cache = (int)std::ceil(l2_cache_bytes / sizeof(DType) / ptr_max_sz);
+    int64_t mem_pool_sz = std::max(2, std::min(512, times_covers_l2_cache));
     size_t free_global_mem = 0;
     size_t total_global_mem = 0;
     cudaError_t cuda_error = cudaMemGetInfo(&free_global_mem, &total_global_mem);

--- a/python/aitemplate/backend/cuda/gemm_universal/common_bias_broadcast.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/common_bias_broadcast.py
@@ -322,7 +322,7 @@ TENSOR_DECL_TEMPLATE = jinja2.Template(
 {% if has_d1 %}
   one_copy_sz += c_ptr_sz;
 {%endif%}
-  int64_t mem_pool_sz = memory_pool->ComputeMemPoolSize(one_copy_sz, ptr_max_sz);
+  int64_t mem_pool_sz = memory_pool->ComputeMemPoolSize(one_copy_sz, ptr_max_sz, device_properties.l2CacheSize);
 
   memory_pool->AllocateTensor(a_ptr_sz, mem_pool_sz);  // a_ptr: index 0
   memory_pool->AllocateTensor(b_ptr_sz, mem_pool_sz);  // b_ptr: index 1


### PR DESCRIPTION
Summary:
Currently there are some hard-coded magic numbers like `(1 << 25)` in computing the `ProfilerMemoryPool`'s size (in terms of the number of fitting largest input sizes). In this diff, the magic number is replaced by the size of the actual L2 cache retrieved from the `device_properties.l2CacheSize`.

Also, the upper bound of the `mem_pool_sz` is increased from 64 to 512. The latter should be safe, given that the upper bound of the allocated total tensor memory per input / output is the size of the L2 cache.

Differential Revision: D45530460

