### PR TITLE
Add Windows support for owned constants

### DIFF
--- a/python/aitemplate/backend/builder.py
+++ b/python/aitemplate/backend/builder.py
@@ -430,14 +430,17 @@ clean_constants:
         build_so_cmd = "$(CC) -shared $(fPIC_flag) $(CFLAGS) -o $@ $(obj_files)"
         standalone_src = "standalone.cu"
         standalone_obj = "standalone.obj"
+        windll_obj = "windll.obj"
         obj_files = []
-        # standalone.cu is an AITemplate internal file that is used for generating
-        # standalone executables. We only want to compile it when the relevant
-        # debug option is enabled.
+        # * standalone.cu is an AITemplate internal file that is used for generating
+        #   standalone executables. We only want to compile it when the relevant
+        #   debug option is enabled.
+        # * windll.cu and windll.obj are used in builder_cmake.py for MSVC compiler
+        #   and are not needed to be used in builder_make.py compiler engine.
         obj_files = [
             pair[1].split("/")[-1]
             for pair in file_pairs
-            if not pair[1].endswith(standalone_obj)
+            if not pair[1].endswith(standalone_obj) and not pair[1].endswith(windll_obj)
         ]
         obj_files = " ".join(obj_files)
 

--- a/python/aitemplate/backend/codegen.py
+++ b/python/aitemplate/backend/codegen.py
@@ -941,6 +941,8 @@ class ModelContainerGenerator:
             set_up_constant_folding_inputs="\n".join(
                 self.set_up_constant_folding_inputs
             ),
+            # # todo: enable once this feature is fully available
+            # is_windows=is_windows(),
         )
         result[model_container_src_fname] = model_container_base_src
         return result

--- a/python/aitemplate/backend/main_templates.py
+++ b/python/aitemplate/backend/main_templates.py
@@ -197,6 +197,11 @@ MODEL_CONTAINER_TEMPLATE = jinja2.Template(
 
 namespace ait {
 namespace {
+
+{% if is_windows %}
+#include "windll.h"
+{% endif %}
+
 // Contains the metadata for each constant.
 constexpr std::array<ConstantInfo, {{ num_constants }}> owned_constants = {
   {{ owned_constants_init }}
@@ -241,14 +246,22 @@ ModelContainerBase::ModelContainerBase(
 {{ set_up_constant_offsets }}
 {{ set_up_constant_folding_inputs }}
 
-  auto* constants_ptr = static_cast<uint8_t*>(constants_primary_.get());
+{% if is_windows %}
+  size_t binary_constants_bin_size = 0;
+  uint8_t* binary_constants_bin_start = nullptr;
+  GetConstantsBin((void**)&binary_constants_bin_start, &binary_constants_bin_size);
+{% else %}
   const auto binary_constants_bin_size = static_cast<size_t>(_binary_constants_bin_end - _binary_constants_bin_start);
+  const uint8_t* const binary_constants_bin_start = _binary_constants_bin_start;
+{% endif %}
+
+  auto* constants_ptr = static_cast<uint8_t*>(constants_primary_.get());
   for (auto& constant_info : owned_constants) {
     auto* dst = constants_ptr + constant_info.internal_offset;
     if (constant_info.data_offset + constant_info.num_bytes > binary_constants_bin_size) {
       throw std::runtime_error(std::string("Copying constant ") + constant_info.name + " would overflow constant buffer");
     }
-    DEVICE_CHECK(CopyToDevice(dst, _binary_constants_bin_start + constant_info.data_offset, constant_info.num_bytes));
+    DEVICE_CHECK(CopyToDevice(dst, binary_constants_bin_start + constant_info.data_offset, constant_info.num_bytes));
   }
 }
 

--- a/static/csrc/windll.cpp
+++ b/static/csrc/windll.cpp
@@ -1,0 +1,70 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#include <stdexcept>
+#include <string>
+
+#include <windows.h>
+
+HMODULE SavedDllHandle;
+
+BOOL WINAPI DllMain(
+    HINSTANCE hinstDLL, // handle to DLL module
+    DWORD fdwReason, // reason for calling function
+    LPVOID lpvReserved) // reserved
+{
+  switch (fdwReason) {
+    case DLL_PROCESS_ATTACH:
+      SavedDllHandle = hinstDLL;
+      break;
+  }
+  return TRUE;
+}
+
+namespace ait {
+
+#define TRIGGER_ERROR(message)                        \
+  throw std::runtime_error(                           \
+      (message) + " at file " + __FILE__ + ", line" + \
+      std::to_string(__LINE__));
+
+void GetConstantsBin(void** address, size_t* size) {
+  HRSRC hResource = FindResource(SavedDllHandle, "constant_bin", "CUSTOMDATA");
+  if (!hResource) {
+    // Could not find a resource. Return zero values, because
+    // linker won't include empty constant.bin file. So, this is an
+    // expected behavior.
+    *size = 0;
+    *address = nullptr;
+    return;
+  }
+
+  HGLOBAL hResourceData = LoadResource(SavedDllHandle, hResource);
+  if (!hResourceData) {
+    // could not load a resource
+    auto errorCode = GetLastError();
+    TRIGGER_ERROR(std::string(
+        "LoadResource() call in GetConstantsBin() has failed with error " +
+        std::to_string(errorCode)));
+  }
+
+  DWORD resourceSize = SizeofResource(SavedDllHandle, hResource);
+  void* resourceData = LockResource(hResourceData);
+
+  *size = resourceSize;
+  *address = resourceData;
+}
+
+} // namespace ait

--- a/static/include/owned_constants.h
+++ b/static/include/owned_constants.h
@@ -42,5 +42,6 @@ struct ConstantInfo {
 // For information on the binary format, see `man objcopy`, under
 // the "binary-architecture" flag:
 // https://man7.org/linux/man-pages/man1/objcopy.1.html
+// todo: use #embed in C++ 23 once available
 extern const uint8_t _binary_constants_bin_start[];
 extern const uint8_t _binary_constants_bin_end[];

--- a/static/include/windll.h
+++ b/static/include/windll.h
@@ -1,0 +1,25 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#pragma once
+
+#include <cstdint>
+
+namespace ait {
+
+// throws std::runtime_error in case of problems
+void GetConstantsBin(void** address, size_t* size);
+
+} // namespace ait


### PR DESCRIPTION
Summary: Add the needed facilities for handling owned constants, which currently is a hack around linux linker.

Differential Revision: D45579379

