### PR TITLE
refactor op level benchmark

### DIFF
--- a/python/aitemplate/testing/profile.py
+++ b/python/aitemplate/testing/profile.py
@@ -59,6 +59,9 @@ def profile_callable(
     """
     if n_iter <= 0:
         return [], []
+    # warmup
+    for _ in range(5):
+        func()
     with torch.profiler.profile(
         activities=[torch.profiler.ProfilerActivity.CUDA],
         record_shapes=True,
@@ -69,7 +72,7 @@ def profile_callable(
     # log the invoked kernels
     results = prof.key_averages().table(
         sort_by="self_cuda_time_total",
-        max_name_column_width=None,
+        max_name_column_width=120,
         row_limit=-1,
     )
     logger.info(results)
@@ -90,7 +93,7 @@ def profile_callable(
     n_groups = len(sorted_events) // n_iter
     # in each group (corresponding to a profiling iteration),
     # skip measuring the first kernel, which is the l2 cache flush
-    event_groups = [g[1:] for g in zip(*([iter(sorted_events)] * n_groups))]
+    event_groups = [g[0:] for g in zip(*([iter(sorted_events)] * n_groups))]
     logger.info(
         f"First kernel sequence: {list(map(itemgetter('name'), event_groups[0]))}"
     )


### PR DESCRIPTION
Summary:
1. refactor the op registration by extracting the ait,trt,pt2 lowering part. Reduce the new code workload for adding new op
2. In profile.py L96, we enabled g[0:] to capture the 1st kernel. It is used to fill in cache for the following computation. But in some op, it seems to be the only countable kernel. For ex.

split
{F975474668}

dynamic slice
{F975475144}

while for gemm_rcr, it is the case that this kernel used to fill value
{F975475533}
3. Report is here https://docs.google.com/document/d/1ngMa0BlETHv6d9CnpYQXsEjXwklyY6G0mbuKgXaVj24/edit#bookmark=id.5rt46dr52l04

Next step:
1. We already tried IG in this diff. Next step, we need to test CMF30x and ICVR22x. Even stable diffusion.
2. Consider the model with fusion. We need to capture the do_optimization=True in shape capture

Differential Revision: D45345181

