### PR TITLE
Integrate CUDA 12.1

### DIFF
--- a/python/aitemplate/backend/cuda/utils.py
+++ b/python/aitemplate/backend/cuda/utils.py
@@ -51,17 +51,19 @@ registry.reg("cuda.make_cutlass_lib")(mk_cutlass_lib)
 
 
 @registry.reg("cuda.gen_cutlass_ops")
-def gen_ops(arch):
+def gen_ops(arch, cuda_version):
     import cutlass_lib
 
     args = Args(arch)
+    if cuda_version is not None:
+        args.cuda_version = cuda_version
     manifest = cutlass_lib.manifest.Manifest(args)
 
     if arch == "90":
         if force_cutlass_sm90_kernels():
-            cutlass_lib.generator.GenerateSM90(manifest, cuda_version="12.0.0")
+            cutlass_lib.generator.GenerateSM90(manifest, args.cuda_version)
         elif allow_cutlass_sm90_kernels():
-            cutlass_lib.generator.GenerateSM90(manifest, cuda_version="12.0.0")
+            cutlass_lib.generator.GenerateSM90(manifest, args.cuda_version)
             cutlass_lib.generator.GenerateSM80(manifest, args.cuda_version)
             cutlass_lib.extra_operation.GenerateSM80(manifest, args)
         else:


### PR DESCRIPTION
Summary: CUTLASS SM90 kernel generation depends not only on the arch, but also on the CUDA version. In this diff, the CUDA version is propagated to the `cuda/utils.py` to be passed to the CUTLASS generator functions.

Differential Revision: D45602855

