### PR TITLE
Add SM90 CUTLASS 3.x kernels to gemm_rcr_bias_relu

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_relu.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_relu.py
@@ -51,19 +51,48 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
 )
 
 
+PROBLEM_ARGS_TEMPLATE_CUTLASS_3X = jinja2.Template(
+    """
+    cutlass::gemm::GemmUniversalMode::kGemm,                     // GemmUniversalMode mode
+    {
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(K),
+        static_cast<coord_t>(1)
+    },                                                           // ProblemShape problem_shape
+    ({{elem_input_type}}*)(a_ptr),              // ElementA const* ptr_A
+    {K, cute::Int<1>{}, cute::Int<0>{}},            // StrideA dA
+    ({{elem_input_type}}*)(b_ptr),              // ElementB const* ptr_B
+    {K, cute::Int<1>{}, cute::Int<0>{}},            // StrideB dB
+    {
+        {ElementComputeEpilogue(1), ElementComputeEpilogue(1)},  // typename ThreadEpilogueOp::Params thread
+        ({{elem_input_type}}*)(bias_ptr),                        // ElementC const* ptr_C
+        {cute::Int<0>{}, cute::Int<1>{}, cute::Int<0>{}},        // StrideC dC
+        ({{elem_output_type}}*)(c_ptr) + output_offset,          // ElementD const* ptr_D
+        {output_stride, cute::Int<1>{}, cute::Int<0>{}},         // StrideD dD
+    },                                                           // EpilogueArguments epilogue
+"""
+)
+
+
 @registry.reg("cuda.gemm_rcr_bias_relu.config")
 def gemm_rcr_config(func_attrs, dtype="float16"):
-    return common_bias_activation.gemm_rcr_config(func_attrs, dtype)
+    return common_bias_activation.gemm_rcr_config(
+        func_attrs=func_attrs,
+        dtype=dtype,
+        include_cutlass_3x_ops=True,
+    )
 
 
 @registry.reg("cuda.gemm_rcr_bias_relu.gen_profiler")
 def gen_profiler(func_attrs, workdir, profiler_filename, dim_info_dict):
     return common_bias_activation.gen_profiler(
-        func_attrs,
-        workdir,
-        profiler_filename,
-        dim_info_dict,
-        PROBLEM_ARGS_TEMPLATE,
+        func_attrs=func_attrs,
+        workdir=workdir,
+        profiler_filename=profiler_filename,
+        dim_info_dict=dim_info_dict,
+        problem_args_template=PROBLEM_ARGS_TEMPLATE,
+        problem_args_template_cutlass_3x=PROBLEM_ARGS_TEMPLATE_CUTLASS_3X,
     )
 
 
@@ -74,10 +103,11 @@ def gen_function(
     dim_info_dict,
 ):
     return common_bias_activation.gen_function(
-        func_attrs,
-        PROBLEM_ARGS_TEMPLATE,
-        exec_cond_template,
-        dim_info_dict,
+        func_attrs=func_attrs,
+        problem_args_template=PROBLEM_ARGS_TEMPLATE,
+        problem_args_template_cutlass_3x=PROBLEM_ARGS_TEMPLATE_CUTLASS_3X,
+        exec_cond_template=exec_cond_template,
+        dim_info_dict=dim_info_dict,
     )
 
 

--- a/python/aitemplate/backend/cuda/utils.py
+++ b/python/aitemplate/backend/cuda/utils.py
@@ -51,17 +51,19 @@ registry.reg("cuda.make_cutlass_lib")(mk_cutlass_lib)
 
 
 @registry.reg("cuda.gen_cutlass_ops")
-def gen_ops(arch):
+def gen_ops(arch, cuda_version):
     import cutlass_lib
 
     args = Args(arch)
+    if cuda_version is not None:
+        args.cuda_version = cuda_version
     manifest = cutlass_lib.manifest.Manifest(args)
 
     if arch == "90":
         if force_cutlass_sm90_kernels():
-            cutlass_lib.generator.GenerateSM90(manifest, cuda_version="12.0.0")
+            cutlass_lib.generator.GenerateSM90(manifest, args.cuda_version)
         elif allow_cutlass_sm90_kernels():
-            cutlass_lib.generator.GenerateSM90(manifest, cuda_version="12.0.0")
+            cutlass_lib.generator.GenerateSM90(manifest, args.cuda_version)
             cutlass_lib.generator.GenerateSM80(manifest, args.cuda_version)
             cutlass_lib.extra_operation.GenerateSM80(manifest, args)
         else:

--- a/python/aitemplate/utils/mk_cutlass_lib/extra_enum.py
+++ b/python/aitemplate/utils/mk_cutlass_lib/extra_enum.py
@@ -146,6 +146,44 @@ EpiloguePermuteLayoutName = {
   # "Permute3DBMM_021": EpiloguePermuteLayout.Permute3DBMM_021,
 }
 
+class EpilogueScheduleType(enum.Enum):
+  ScheduleAuto = enum_auto()
+  EpilogueTransposed = enum_auto()
+  NoSmemWarpSpecialized = enum_auto()
+  TmaWarpSpecialized = enum_auto()
+  TmaWarpSpecializedCooperative = enum_auto()
+  TmaWarpSpecializedElementwiseRelu = enum_auto()
+  TmaWarpSpecializedCooperativeElementwiseRelu = enum_auto()
+
+EpilogueScheduleTag = {
+  EpilogueScheduleType.ScheduleAuto: 'cutlass::epilogue::collective::EpilogueScheduleAuto',
+  EpilogueScheduleType.EpilogueTransposed: 'cutlass::gemm::EpilogueTransposed',
+  EpilogueScheduleType.NoSmemWarpSpecialized: 'cutlass::epilogue::NoSmemWarpSpecialized',
+  EpilogueScheduleType.TmaWarpSpecialized: 'cutlass::epilogue::TmaWarpSpecialized',
+  EpilogueScheduleType.TmaWarpSpecializedCooperative: 'cutlass::epilogue::TmaWarpSpecializedCooperative',
+  EpilogueScheduleType.TmaWarpSpecializedElementwiseRelu: 'cutlass::epilogue::TmaWarpSpecializedElementwise<cutlass::epilogue::thread::ReLu>',
+  EpilogueScheduleType.TmaWarpSpecializedCooperativeElementwiseRelu: 'cutlass::epilogue::TmaWarpSpecializedCooperativeElementwise<cutlass::epilogue::thread::ReLu>',
+}
+
+EpilogueScheduleSuffixes = {
+  EpilogueScheduleType.ScheduleAuto: '',
+  EpilogueScheduleType.EpilogueTransposed: '',
+  EpilogueScheduleType.NoSmemWarpSpecialized: '_epi_nosmem',
+  EpilogueScheduleType.TmaWarpSpecialized: '_epi_tma',
+  EpilogueScheduleType.TmaWarpSpecializedCooperative: '_epi_tma',
+  EpilogueScheduleType.TmaWarpSpecializedElementwiseRelu: '_epi_tma_relu',
+  EpilogueScheduleType.TmaWarpSpecializedCooperativeElementwiseRelu: '_epi_tma_relu',
+}
+
+EpilogueScheduleMapping = {
+  EpilogueScheduleType.TmaWarpSpecialized: {
+    EpilogueFunctor.LinearCombinationRelu: EpilogueScheduleType.TmaWarpSpecializedElementwiseRelu,
+  },
+  EpilogueScheduleType.TmaWarpSpecializedCooperative: {
+    EpilogueFunctor.LinearCombinationRelu: EpilogueScheduleType.TmaWarpSpecializedCooperativeElementwiseRelu,
+  },
+}
+
 """
 )
 

--- a/tests/unittest/ops/test_gemm_bias_relu.py
+++ b/tests/unittest/ops/test_gemm_bias_relu.py
@@ -19,12 +19,11 @@ from aitemplate.compiler import compile_model, ops
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
-    filter_test_cases_by_params,
+    env_variables,
+    filter_test_cases_by_test_env,
     get_random_torch_tensor,
     get_torch_empty_tensor,
-    TestEnv,
 )
-from parameterized import parameterized
 
 
 _TOLERANCE_LIMITS = {
@@ -39,10 +38,14 @@ class GEMMBiasReluTestCase(unittest.TestCase):
         super(GEMMBiasReluTestCase, self).__init__(*args, **kwargs)
         self._test_id = 0
 
-    def _test_gemm_rcr_bias_relu(self, dtype="float16", target=None):
-        M = 128
-        K = 1024
-        N = 64
+    def _test_gemm_rcr_bias_relu(
+        self,
+        M=128,
+        K=1024,
+        N=64,
+        dtype="float16",
+        test_suffix=None,
+    ):
         tolerance_limits = _TOLERANCE_LIMITS[dtype]
         X = Tensor(shape=[M, K], dtype=dtype, name="input_0", is_input=True)
         W = Tensor(shape=[N, K], dtype=dtype, name="input_1", is_input=True)
@@ -51,9 +54,11 @@ class GEMMBiasReluTestCase(unittest.TestCase):
         Y = OP(X, W, B)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        test_name = f"gemm_rcr_bias_relu_{dtype}_{self._test_id}"
+        if test_suffix is None:
+            test_suffix = dtype
+        test_name = f"gemm_rcr_bias_relu_{test_suffix}_{self._test_id}"
         self._test_id += 1
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = compile_model(Y, detect_target(), "./tmp", test_name)
         X_pt = get_random_torch_tensor([M, K], dtype)
         W_pt = get_random_torch_tensor([N, K], dtype)
         B_pt = get_random_torch_tensor([N], dtype)
@@ -65,20 +70,56 @@ class GEMMBiasReluTestCase(unittest.TestCase):
         module.run_with_tensors(inputs, [y])
         torch.testing.assert_close(Y_pt, y, **tolerance_limits)
 
-    @parameterized.expand(
-        **filter_test_cases_by_params(
-            {
-                TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
-                TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],
-                TestEnv.ROCM: [("float16")],
-            }
-        )
-    )
-    def test_gemm_rcr_bias_relu(self, ait_dtype):
-        target = detect_target()
-        self._test_gemm_rcr_bias_relu(ait_dtype, target)
+    def test_gemm_rcr_bias_relu_fp16(self):
+        self._test_gemm_rcr_bias_relu(dtype="float16")
 
-    def _test_gemm_rcr_bias_add_relu(self, dtype="float16", target=None):
+    def test_gemm_rcr_bias_relu_fp16_rocm(self):
+        self._test_gemm_rcr_bias_relu(dtype="float16")
+
+    def test_gemm_rcr_bias_relu_fp32_sm80(self):
+        self._test_gemm_rcr_bias_relu(dtype="float32")
+
+    def test_gemm_rcr_bias_relu_bf16(self):
+        self._test_gemm_rcr_bias_relu(dtype="bfloat16")
+
+    def test_gemm_rcr_bias_relu_sm90(self):
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # input alignment < 8 not supported by SM90 kernels
+                # use alignment 4 to avoid auto-padding to 8
+                self._test_gemm_rcr_bias_relu(
+                    K=1020,
+                    dtype="float16",
+                    test_suffix="wrong_input_alignment_sm90",
+                )
+
+            with self.assertRaisesRegex(
+                expected_exception=RuntimeError,
+                expected_regex="No GEMM op instances are left after filtering",
+            ):
+                # output alignment < 8 not supported by SM90 TMA epilogues
+                self._test_gemm_rcr_bias_relu(
+                    N=63,
+                    dtype="float16",
+                    test_suffix="wrong_output_alignment_sm90",
+                )
+
+            self._test_gemm_rcr_bias_relu(
+                dtype="float16",
+                test_suffix="float16_force_sm90",
+            )
+            self._test_gemm_rcr_bias_relu(
+                dtype="bfloat16",
+                test_suffix="bfloat16_force_sm90",
+            )
+
+    def _test_gemm_rcr_bias_add_relu(self, dtype="float16"):
         M = 128
         K = 1024
         N = 64
@@ -93,7 +134,7 @@ class GEMMBiasReluTestCase(unittest.TestCase):
         Y._attrs["is_output"] = True
         test_name = f"gemm_rcr_bias_add_relu_{dtype}_{self._test_id}"
         self._test_id += 1
-        module = compile_model(Y, target, "./tmp", test_name)
+        module = compile_model(Y, detect_target(), "./tmp", test_name)
         X_pt = get_random_torch_tensor([M, K], dtype)
         W_pt = get_random_torch_tensor([N, K], dtype)
         B_pt = get_random_torch_tensor([N], dtype)
@@ -106,18 +147,20 @@ class GEMMBiasReluTestCase(unittest.TestCase):
         module.run_with_tensors(inputs, [y])
         torch.testing.assert_close(Y_pt, y, **tolerance_limits)
 
-    @parameterized.expand(
-        **filter_test_cases_by_params(
-            {
-                TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
-                TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],
-                TestEnv.ROCM: [("float16")],
-            }
-        )
-    )
-    def test_gemm_rcr_bias_add_relu(self, ait_dtype):
-        target = detect_target()
-        self._test_gemm_rcr_bias_add_relu(ait_dtype, target)
+    def test_gemm_rcr_bias_add_relu_fp16(self):
+        self._test_gemm_rcr_bias_add_relu(dtype="float16")
+
+    def test_gemm_rcr_bias_add_relu_fp16_rocm(self):
+        self._test_gemm_rcr_bias_add_relu(dtype="float16")
+
+    def test_gemm_rcr_bias_add_relu_fp32_sm80(self):
+        self._test_gemm_rcr_bias_add_relu(dtype="float32")
+
+    def test_gemm_rcr_bias_add_relu_bf16(self):
+        self._test_gemm_rcr_bias_add_relu(dtype="bfloat16")
+
+
+filter_test_cases_by_test_env(GEMMBiasReluTestCase)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
ATT.

Also, the foundations are added for extending the remaining `gemm_rcr_bias_<epilogue>` ops (except the `gemm_rcr_bias_broadcst` family) with the SM90 kernels.

Differential Revision: D45608620

