### PR TITLE
Fix test logging errors

### DIFF
--- a/fx2ait/fx2ait/tools/common_fx2ait.py
+++ b/fx2ait/fx2ait/tools/common_fx2ait.py
@@ -125,7 +125,7 @@ class AITTestCase(TestCase):
         for p in passes:
             mod = p(mod, inputs)
 
-        logger.info(mod.graph)
+        logger.info(f"{mod.graph=}")
 
         original_inputs = copy.deepcopy(inputs)
         if permute_inputs:
@@ -163,7 +163,7 @@ class AITTestCase(TestCase):
             start = time.perf_counter()
             interp_result = interp.run()
             sec = time.perf_counter() - start
-            logger.info("Interpreter run time(s):", sec)
+            logger.info(f"Interpreter run time(s):{sec}")
             if OSS_AITModel:
                 ait_mod = AITModule(
                     torch.classes.ait.AITModel(
@@ -197,7 +197,7 @@ class AITTestCase(TestCase):
             end_event.record()
             torch.cuda.synchronize()
             logger.info(
-                "AIT run time(s)=", (start_event.elapsed_time(end_event) * 1.0e-3)
+                f"AIT run time(s)={start_event.elapsed_time(end_event) * 1.0e-3}"
             )
             # PyTorch Transformer model would yield 2 output tensors, of which the second one is
             # not useful. AIT model only output 1 output tensor, alter ref_output to match this.
@@ -264,7 +264,7 @@ class AITTestCase(TestCase):
         )
         for p in passes:
             mod = p(mod, inputs_min)
-        logger.info(mod.graph)
+        logger.info(f"{mod.graph=}")
 
         original_inputs = inputs_min
         # Trace and test with inputs_min
@@ -287,7 +287,7 @@ class AITTestCase(TestCase):
             start = time.perf_counter()
             interp_result = interp.run()
             sec = time.perf_counter() - start
-            logger.info("Interpreter run time(s):", sec)
+            logger.info(f"Interpreter run time(s):{sec}")
             if OSS_AITModel:
                 ait_mod = AITModule(
                     torch.classes.ait.AITModel(
@@ -323,7 +323,7 @@ class AITTestCase(TestCase):
             end_event.record()
             torch.cuda.synchronize()
             logger.info(
-                "AIT run time(s)=", (start_event.elapsed_time(end_event) * 1.0e-3)
+                f"AIT run time(s)={start_event.elapsed_time(end_event) * 1.0e-3}"
             )
 
             if isinstance(outputs, torch.Tensor):


### PR DESCRIPTION
Summary:
1. Use logger f-strings so we stop running into `TypeError: not all arguments converted during string formatting` and makes test output easier to read

Differential Revision: D45616742

