### PR TITLE
Use device 0 for profiling if devices list is empty

### DIFF
--- a/python/aitemplate/backend/profiler_runner.py
+++ b/python/aitemplate/backend/profiler_runner.py
@@ -267,7 +267,8 @@ class ProfilerRunner:
         timeout : int
             timeout to wait for all profilers completion in seconds
         """
-        if devices is None:
+        if not devices:
+            # devices is either None or empty list: use device 0
             devices = [0]
         # This queue is used to ensure only one task is executed on a device at a time
         self._device_queue = Queue()


### PR DESCRIPTION
Summary: If the `devices` list passed to the `ProfilerRunner` is empty, currently an exception is raised on the `ThreadPoolExecutor` instantiation: `ValueError("max_workers must be greater than 0")`. We replace the `devices` list with `[0]` in such case to use the device 0 for profiling and avoid the exception.

Reviewed By: amateurcoffee

Differential Revision: D45637622

