### PR TITLE
Fix get_positive_dim for IntVar

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -660,7 +660,8 @@ def acc_ops_slice(
             num_none_indices += 1
             continue
         if isinstance(i, int):
-            i = get_positive_dim(i, input_val.shape()[index].value())
+            if isinstance(input_val.shape()[index], IntImm):
+                i = get_positive_dim(i, input_val.shape()[index].value())
             # If we pass an int, we need to squeeze this dim.
             # Note that because we skip None-indices before, so we adjust
             # the index by subtracting the number of None-indices.


### PR DESCRIPTION
Summary:
This is an issue encountered during ig model lowering: https://fb.workplace.com/groups/757073672259175/permalink/903432870956587/
`get_positive_dim` is the function to deduce positive dim for slice_op.
e.g. `a[-2]` where `len(a)=3` denotes we should access `a[2]`
But this only meaningful when the input is not IntVar, but IntImm.
Also, we don't have IntVar with negative values so there is no need to deduce positive dim for it.

Reviewed By: amateurcoffee

Differential Revision: D45722873

