### PR TITLE
speed up MultiScaleBlock

### DIFF
--- a/python/aitemplate/frontend/nn/batch_norm.py
+++ b/python/aitemplate/frontend/nn/batch_norm.py
@@ -28,12 +28,14 @@ class _BatchNorm(Module):
         num_features,
         eps=1e-5,
         dtype="float16",
+        permute_input_output=False,
         **kwargs,
     ):
         super().__init__()
         self.dim = (num_features,)
         self.dtype = dtype
         self.num_features = num_features
+        self.permute_input_output = permute_input_output
         self.eps = eps
         self.weight = Parameter(shape=self.dim, dtype=dtype)
         self.bias = Parameter(shape=self.dim, dtype=dtype)
@@ -46,7 +48,7 @@ class _BatchNorm(Module):
         assert len(args) == 1
         x = args[0]
         self._check_input_dim(x)
-        x = self._convert_input(x)
+        x = self._convert_input(x) if self.permute_input_output else x
 
         x_normalized = elementwise(FuncEnum.DIV)(
             elementwise(FuncEnum.SUB)(x, self.running_mean.tensor()),
@@ -60,7 +62,7 @@ class _BatchNorm(Module):
             self.bias.tensor(),
         )
 
-        y = self._convert_output(y)
+        y = self._convert_output(y) if self.permute_input_output else y
         return y
 
     def _check_input_dim(self):
@@ -79,9 +81,10 @@ class BatchNorm1d(_BatchNorm):
         num_features,
         eps=1e-5,
         dtype="float16",
+        permute_input_output=False,
         **kwargs,
     ):
-        super().__init__(num_features, eps, dtype, **kwargs)
+        super().__init__(num_features, eps, dtype, permute_input_output, **kwargs)
 
     def _check_input_dim(self, x):
         if len(x.shape()) != 2 and len(x.shape()) != 3:
@@ -108,9 +111,10 @@ class BatchNorm2d(_BatchNorm):
         num_features,
         eps=1e-5,
         dtype="float16",
+        permute_input_output=False,
         **kwargs,
     ):
-        super().__init__(num_features, eps, dtype, **kwargs)
+        super().__init__(num_features, eps, dtype, permute_input_output, **kwargs)
 
     def _check_input_dim(self, x):
         if len(x.shape()) != 4:
@@ -129,9 +133,10 @@ class BatchNorm3d(_BatchNorm):
         num_features,
         eps=1e-5,
         dtype="float16",
+        permute_input_output=False,
         **kwargs,
     ):
-        super().__init__(num_features, eps, dtype, **kwargs)
+        super().__init__(num_features, eps, dtype, permute_input_output, **kwargs)
 
     def _check_input_dim(self, x):
         if len(x.shape()) != 5:

--- a/python/aitemplate/frontend/nn/multiscale_attention.py
+++ b/python/aitemplate/frontend/nn/multiscale_attention.py
@@ -220,9 +220,7 @@ class _AttentionPool(Module):
         # input shape: B, num_heads, seqlen, head_dim
         B, N, L, C = get_shape(tensor)
         T, H, W = thw_shape
-        tensor = ops.permute()(
-            ops.reshape()(tensor, [B * N, -1, H, W, C]), [0, 4, 1, 2, 3]
-        )
+        tensor = ops.reshape()(tensor, [B * N, -1, H, W, C])
 
         if self.norm_before_pool:
             # If use BN, we apply norm before pooling instead of after pooling.
@@ -230,7 +228,7 @@ class _AttentionPool(Module):
             # We also empirically find that adding a GELU here is beneficial.
             tensor = ops.elementwise(FuncEnum.GELU)(tensor)
 
-        tensor = self.pool(ops.permute()(tensor, [0, 2, 3, 4, 1]))
+        tensor = self.pool(tensor)
 
         shape = get_shape(tensor)
         thw_shape = [shape[1], shape[2], shape[3]]
@@ -673,7 +671,7 @@ class MultiScaleBlock(Module):
         super().__init__()
         self.dim = dim
         self.dim_out = dim_out
-        self.norm1 = norm_layer(dim)
+        self.norm1 = norm_layer(dim, permute_input_output=True)
         self.norm1_is_batchnorm_1d = isinstance(self.norm1, BatchNorm1d)
         kernel_skip = [s + 1 if s > 1 else s for s in stride_q]
         stride_skip = stride_q
@@ -698,7 +696,7 @@ class MultiScaleBlock(Module):
             max_seq_len=seq_len,
         )
         self.drop_path = DropPath(droppath_rate) if droppath_rate > 0.0 else Identity()
-        self.norm2 = norm_layer(dim)
+        self.norm2 = norm_layer(dim, permute_input_output=True)
         self.norm2_is_batchnorm_1d = isinstance(self.norm2, BatchNorm1d)
         mlp_hidden_dim = int(dim * mlp_ratio)
         self.has_cls_embed = has_cls_embed

--- a/tests/unittest/ops/test_batch_norm.py
+++ b/tests/unittest/ops/test_batch_norm.py
@@ -43,7 +43,9 @@ class BatchnormTestCase(unittest.TestCase):
         input_type="float16",
     ):
         pt_op = getattr(torch.nn, bn_op)(num_features).cuda().half().eval()
-        ait_op = getattr(batch_norm, bn_op)(num_features, eps=pt_op.eps)
+        ait_op = getattr(batch_norm, bn_op)(
+            num_features, eps=pt_op.eps, permute_input_output=True
+        )
         ait_op.name_parameter_tensor()
 
         pt_params = dict(pt_op.named_parameters())


### PR DESCRIPTION
Summary:
Speed up multiscaleblock by removing unnecessary permutes that increase latency. No loss in correctness (still using 1e-4 numeric tolerance).

Also added option to enable/disable input/output shape conversion in batchnorm classes.

Differential Revision: D45740293

