### PR TITLE
Fix the profiler bug in bmm_xxx_add SM90 kernels

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_universal/bmm_xxx_add.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/bmm_xxx_add.py
@@ -25,6 +25,7 @@ func_call, and filter for each layout combination under names like
 
 
 from aitemplate.backend import registry
+from aitemplate.backend.backend_spec import CUDASpec
 from aitemplate.backend.common import gemm_common
 from aitemplate.backend.cuda.gemm_universal import bmm_common, common
 from aitemplate.backend.cuda.gemm_universal.bmm_xxx import _get_problem_args, get_config
@@ -108,14 +109,33 @@ def get_gen_profiler(a_layout, b_layout, c_layout):
             mm_info=default_mm_info,
         )
 
+        backend_spec = CUDASpec()
+        elem_input_type = backend_spec.dtype_to_lib_type(
+            func_attrs["inputs"][0]._attrs["dtype"]
+        )
+        elem_output_type = backend_spec.dtype_to_lib_type(
+            func_attrs["outputs"][0]._attrs["dtype"]
+        )
+
+        # CUTLASS 3.x problem args require explicit I/O pointer types (not void*)
+        default_mm_info.a_ptr = f"({elem_input_type}*)({default_mm_info.a_ptr})"
+        default_mm_info.b_ptr = f"({elem_input_type}*)({default_mm_info.b_ptr})"
+        default_mm_info.bias_ptr = f"({elem_output_type}*)({default_mm_info.bias_ptr})"
+        default_mm_info.c_ptr = f"({elem_output_type}*)({default_mm_info.c_ptr})"
+
+        problem_args_cutlass_3x = bmm_common.PROBLEM_ARGS_TEMPLATE_CUTLASS_3X.render(
+            mm_info=default_mm_info,
+        )
+
         return bmm_common.gen_profiler(
-            func_attrs,
-            workdir,
-            profiler_filename,
-            dim_info_dict,
-            common.SRC_TEMPLATE,
-            problem_args,
-            args_parser,
+            func_attrs=func_attrs,
+            workdir=workdir,
+            profiler_filename=profiler_filename,
+            dim_info_dict=dim_info_dict,
+            src_template=common.SRC_TEMPLATE,
+            problem_args=problem_args,
+            problem_args_cutlass_3x=problem_args_cutlass_3x,
+            args_parser=args_parser,
         )
 
     return gen_profiler


### PR DESCRIPTION
Summary: As `bmm_xxx_add` ops are forming the problem arguments for profiling on their own (in contrast to the `bmm_xxx` ops relying on `bmm_common.default_gen_profiler`), I've missed generation and passing of the CUTLASS 3.x problem arguments for their profiler generation. This has resulted in a really clandestine bug in the profiler that hasn't manifested itself in the CI (because profilers are compiled, which worked, but aren't run, which didn't).

Differential Revision: D45751431

