### PR TITLE
Add attribute to allow tensor not to participate in constant folding

### DIFF
--- a/python/aitemplate/compiler/base.py
+++ b/python/aitemplate/compiler/base.py
@@ -744,6 +744,7 @@ class Tensor(Node):
         value: Any = None,
         is_view_of: Any = None,
         is_internal_constant: bool = False,
+        skip_constant_folding: bool = False,
         check_nan_and_inf: bool = False,
         check_outputs: bool = False,
     ) -> None:
@@ -776,6 +777,8 @@ class Tensor(Node):
             Whether this Tensor is a view of another Tensor.
         is_internal_constant: bool, optional
             Whether this constant tensor could be modified.
+        skip_constant_folding: bool, optional
+            Whether this tensor participates in constant folding.
         check_nan_and_inf : bool, optional
             Whether or not to check this tensor is nan or inf during runtime.
         check_outputs : bool, optional
@@ -791,6 +794,7 @@ class Tensor(Node):
         self._attrs["is_input"] = is_input
         self._attrs["is_param"] = False
         self._attrs["is_internal_constant"] = is_internal_constant
+        self._attrs["skip_constant_folding"] = skip_constant_folding
 
         # True if this is an internal tensor that aliases an output through
         # a view. Set up in mark_param_tensor

--- a/python/aitemplate/compiler/ops/tensor/full.py
+++ b/python/aitemplate/compiler/ops/tensor/full.py
@@ -17,7 +17,7 @@ from typing import List
 
 from aitemplate import backend
 from aitemplate.backend import registry
-from aitemplate.compiler.base import IntVar, Operator, Tensor
+from aitemplate.compiler.base import IntImm, IntVar, Operator, Tensor
 from aitemplate.compiler.dtype import get_dtype_size
 
 
@@ -52,6 +52,7 @@ class full(Operator):
         if not isinstance(shape, (list, tuple)):
             raise TypeError(f"shape must be List[IntVar], but got {shape}.")
         shape = list(shape)
+        static_shape = all([isinstance(s, (int, IntImm)) for s in shape])
 
         if not isinstance(fill_value, (int, float)):
             raise TypeError(f"fill_value must be a scalar, but got {fill_value}.")
@@ -64,7 +65,9 @@ class full(Operator):
         self._attrs["fill_value"] = fill_value
 
         self._set_depth()
-        output = Tensor(shape, src_ops={self}, dtype=dtype)
+        output = Tensor(
+            shape, src_ops={self}, dtype=dtype, skip_constant_folding=not static_shape
+        )
         self._attrs["outputs"] = [output]
         return output
 

--- a/python/aitemplate/compiler/transform/constant_folding.py
+++ b/python/aitemplate/compiler/transform/constant_folding.py
@@ -143,7 +143,7 @@ def _extract_foldable_subgraph(
     subgraph = []
 
     for tensor in sorted_graph:
-        if tensor._attrs["is_input"]:
+        if tensor._attrs["is_input"] or tensor._attrs["skip_constant_folding"]:
             continue
 
         name = tensor._attrs["name"]


### PR DESCRIPTION
Summary:
Add attribute to allow tensor to skip constant folding.
We need this attribute to overwrite logics within constant folding, since not
all tensors that have no input are necessary constants, the constant-ness could
be embedded in the operation that generates the constant.

Differential Revision: D45790578

