### PR TITLE
Add SM90 CUTLASS 3.x kernels to gemm_rcr_bias_broadcast ops

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_elementwise.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_elementwise.py
@@ -59,15 +59,15 @@ def gemm_rcr_config(func_attrs, dtype="float16"):
 def gen_profiler_template(unary_op1, binary_op1, binary_op2, unary_op2):
     def gen_profiler(func_attrs, workdir, profiler_filename, dim_info_dict):
         return common_bias_broadcast.gen_profiler(
-            func_attrs,
-            workdir,
-            profiler_filename,
-            dim_info_dict,
-            RCR,
-            unary_op1,
-            binary_op1,
-            binary_op2,
-            unary_op2,
+            func_attrs=func_attrs,
+            workdir=workdir,
+            profiler_filename=profiler_filename,
+            dim_info_dict=dim_info_dict,
+            layout=RCR,
+            unary_op1=unary_op1,
+            binary_op1=binary_op1,
+            binary_op2=binary_op2,
+            unary_op2=unary_op2,
         )
 
     return gen_profiler
@@ -80,14 +80,14 @@ def gen_function_template(unary_op1, binary_op1, binary_op2, unary_op2):
         dim_info_dict,
     ):
         return common_bias_broadcast.gen_function(
-            func_attrs,
-            exec_cond_template,
-            dim_info_dict,
-            RCR,
-            unary_op1,
-            binary_op1,
-            binary_op2,
-            unary_op2,
+            func_attrs=func_attrs,
+            exec_cond_template=exec_cond_template,
+            dim_info_dict=dim_info_dict,
+            layout=RCR,
+            unary_op1=unary_op1,
+            binary_op1=binary_op1,
+            binary_op2=binary_op2,
+            unary_op2=unary_op2,
         )
 
     return gen_function

--- a/python/aitemplate/utils/mk_cutlass_lib/extra_enum.py
+++ b/python/aitemplate/utils/mk_cutlass_lib/extra_enum.py
@@ -220,6 +220,7 @@ EpilogueScheduleMapping = {
     EpilogueFunctor.LinearCombinationHardSwish: EpilogueScheduleType.TmaWarpSpecializedElementwiseHardSwish,
     EpilogueFunctor.LinearCombinationGELU: EpilogueScheduleType.TmaWarpSpecializedElementwiseGELU,
     EpilogueFunctor.LinearCombinationFastGELU: EpilogueScheduleType.TmaWarpSpecializedElementwiseFastGELU,
+    EpilogueFunctor.LinearCombinationResidualBlock: EpilogueScheduleType.TmaWarpSpecialized,
   },
   EpilogueScheduleType.TmaWarpSpecializedCooperative: {
     EpilogueFunctor.LinearCombinationRelu: EpilogueScheduleType.TmaWarpSpecializedCooperativeElementwiseRelu,
@@ -229,6 +230,7 @@ EpilogueScheduleMapping = {
     EpilogueFunctor.LinearCombinationHardSwish: EpilogueScheduleType.TmaWarpSpecializedCooperativeElementwiseHardSwish,
     EpilogueFunctor.LinearCombinationGELU: EpilogueScheduleType.TmaWarpSpecializedCooperativeElementwiseGELU,
     EpilogueFunctor.LinearCombinationFastGELU: EpilogueScheduleType.TmaWarpSpecializedCooperativeElementwiseFastGELU,
+    EpilogueFunctor.LinearCombinationResidualBlock: EpilogueScheduleType.TmaWarpSpecializedCooperative,
   },
 }
 


### PR DESCRIPTION
Summary:
ATT. SM90 kernels are added to the following ops:

- `gemm_rcr_bias_add`
- `gemm_rcr_bias_add_relu`
- `gemm_rcr_bias_add_add`
- `gemm_rcr_bias_add_add_relu`
- `gemm_rcr_bias_mul`
- `gemm_rcr_bias_mul_add`
- `gemm_rcr_bias_mul_tanh`
- `gemm_rcr_bias_sigmoid_mul`
- `gemm_rcr_bias_sigmoid_mul_tanh`

Differential Revision: D45814653

