### PR TITLE
Add SM90 CUTLASS 3.x kernels to perm102_bmm ops

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rcr.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rcr.py
@@ -34,6 +34,9 @@ def _get_default_problem_info(**kwargs):
         "ldb": "K",
         "ldbias": "N * B",
         "ldc": "N * B",
+        "a_row_major": True,
+        "b_row_major": False,
+        "c_row_major": True,
     }
     for k, v in kwargs.items():
         problem_args[k] = v
@@ -63,6 +66,9 @@ def _get_strided_problem_info(func_attrs):
         ldb="K",
         ldbias="output_stride",
         ldc="output_stride",
+        a_row_major=True,
+        b_row_major=False,
+        c_row_major=True,
     )
 
 
@@ -112,7 +118,10 @@ def gemm_rcr_config(func_attrs, dtype="float16"):
             epilogue_name=func_attrs["epilogue"],
         )
 
-    func_attrs["op_instance"] = common.extract_config(fproc)
+    func_attrs["op_instance"] = common.extract_config(
+        f_proc_op=fproc,
+        include_cutlass_3x_ops=True,
+    )
 
 
 @registry.reg("cuda.perm102_bmm_rcr.gen_profiler")
@@ -127,15 +136,22 @@ def gen_profiler(func_attrs, workdir, profiler_filename, dim_info_dict):
     problem_args = bmm_common.PROBLEM_ARGS_TEMPLATE.render(
         mm_info=mm_info,
     )
+    problem_args_cutlass_3x = bmm_common.PROBLEM_ARGS_TEMPLATE_CUTLASS_3X.render(
+        mm_info=bmm_common.add_elem_types_to_mm_info(
+            mm_info=mm_info,
+            func_attrs=func_attrs,
+        ),
+    )
 
     return bmm_common.gen_profiler(
-        func_attrs,
-        workdir,
-        profiler_filename,
-        dim_info_dict,
-        common.SRC_TEMPLATE,
-        problem_args,
-        args_parser,
+        func_attrs=func_attrs,
+        workdir=workdir,
+        profiler_filename=profiler_filename,
+        dim_info_dict=dim_info_dict,
+        src_template=common.SRC_TEMPLATE,
+        problem_args=problem_args,
+        problem_args_cutlass_3x=problem_args_cutlass_3x,
+        args_parser=args_parser,
     )
 
 
@@ -151,14 +167,21 @@ def gen_function(
     problem_args = bmm_common.PROBLEM_ARGS_TEMPLATE.render(
         mm_info=bmm_problem_info,
     )
+    problem_args_cutlass_3x = bmm_common.PROBLEM_ARGS_TEMPLATE_CUTLASS_3X.render(
+        mm_info=bmm_common.add_elem_types_to_mm_info(
+            mm_info=bmm_problem_info,
+            func_attrs=func_attrs,
+        ),
+    )
 
     return bmm_common.gen_function(
-        func_attrs,
-        exec_cond_template,
-        problem_args,
-        dim_info_dict,
-        "",  # input_addr_calculator
-        get_output_addr_calculator(func_attrs),
+        func_attrs=func_attrs,
+        exec_cond_template=exec_cond_template,
+        problem_args=problem_args,
+        problem_args_cutlass_3x=problem_args_cutlass_3x,
+        dim_info_dict=dim_info_dict,
+        input_addr_calculator="",
+        output_addr_calculator=get_output_addr_calculator(func_attrs),
     )
 
 

--- a/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rcr_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rcr_bias.py
@@ -43,6 +43,9 @@ def _get_default_problem_info(**kwargs):
         "ldb": "K",
         "ldbias": "0",
         "ldc": "N * B",
+        "a_row_major": True,
+        "b_row_major": False,
+        "c_row_major": True,
     }
     for k, v in kwargs.items():
         problem_args[k] = v
@@ -73,6 +76,9 @@ def _get_strided_problem_info(func_attrs):
         ldb="K",
         ldbias="0",
         ldc="output_stride",
+        a_row_major=True,
+        b_row_major=False,
+        c_row_major=True,
     )
 
 
@@ -93,15 +99,22 @@ def gen_profiler(func_attrs, workdir, profiler_filename, dim_info_dict):
     problem_args = bmm_common.PROBLEM_ARGS_TEMPLATE.render(
         mm_info=mm_info,
     )
+    problem_args_cutlass_3x = bmm_common.PROBLEM_ARGS_TEMPLATE_CUTLASS_3X.render(
+        mm_info=bmm_common.add_elem_types_to_mm_info(
+            mm_info=mm_info,
+            func_attrs=func_attrs,
+        ),
+    )
 
     return bmm_common.gen_profiler(
-        func_attrs,
-        workdir,
-        profiler_filename,
-        dim_info_dict,
-        common_bias.SRC_TEMPLATE,
-        problem_args,
-        args_parser,
+        func_attrs=func_attrs,
+        workdir=workdir,
+        profiler_filename=profiler_filename,
+        dim_info_dict=dim_info_dict,
+        src_template=common_bias.SRC_TEMPLATE,
+        problem_args=problem_args,
+        problem_args_cutlass_3x=problem_args_cutlass_3x,
+        args_parser=args_parser,
         bias_ptr_arg="memory_pool->RequestTensorByIdx(3)",
     )
 
@@ -118,16 +131,23 @@ def gen_function(
     problem_args = bmm_common.PROBLEM_ARGS_TEMPLATE.render(
         mm_info=bmm_problem_info,
     )
+    problem_args_cutlass_3x = bmm_common.PROBLEM_ARGS_TEMPLATE_CUTLASS_3X.render(
+        mm_info=bmm_common.add_elem_types_to_mm_info(
+            mm_info=bmm_problem_info,
+            func_attrs=func_attrs,
+        ),
+    )
 
     input_ndims = len(func_attrs["input_accessors"][0].original_shapes)
     weight_ndims = len(func_attrs["input_accessors"][1].original_shapes)
     output_ndims = len(func_attrs["output_accessors"][0].original_shapes)
 
     return common.gen_function(
-        func_attrs,
-        common_bias.SRC_TEMPLATE,
-        exec_cond_template,
-        problem_args,
+        func_attrs=func_attrs,
+        src_template=common_bias.SRC_TEMPLATE,
+        exec_cond_template=exec_cond_template,
+        problem_args=problem_args,
+        problem_args_cutlass_3x=problem_args_cutlass_3x,
         input_ndims=input_ndims,
         weight_ndims=weight_ndims,
         output_ndims=output_ndims,

--- a/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rrr_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rrr_bias.py
@@ -43,6 +43,9 @@ def _get_default_problem_info(**kwargs):
         "ldb": "N",
         "ldbias": "0",
         "ldc": "N * B",
+        "a_row_major": True,
+        "b_row_major": True,
+        "c_row_major": True,
     }
     for k, v in kwargs.items():
         problem_args[k] = v
@@ -72,6 +75,9 @@ def _get_strided_problem_info(func_attrs):
         ldb="N",
         ldbias="0",
         ldc="output_stride",
+        a_row_major=True,
+        b_row_major=True,
+        c_row_major=True,
     )
 
 
@@ -92,15 +98,22 @@ def gen_profiler(func_attrs, workdir, profiler_filename, dim_info_dict):
     problem_args = bmm_common.PROBLEM_ARGS_TEMPLATE.render(
         mm_info=mm_info,
     )
+    problem_args_cutlass_3x = bmm_common.PROBLEM_ARGS_TEMPLATE_CUTLASS_3X.render(
+        mm_info=bmm_common.add_elem_types_to_mm_info(
+            mm_info=mm_info,
+            func_attrs=func_attrs,
+        ),
+    )
 
     return bmm_common.gen_profiler(
-        func_attrs,
-        workdir,
-        profiler_filename,
-        dim_info_dict,
-        common_bias.SRC_TEMPLATE,
-        problem_args,
-        args_parser,
+        func_attrs=func_attrs,
+        workdir=workdir,
+        profiler_filename=profiler_filename,
+        dim_info_dict=dim_info_dict,
+        src_template=common_bias.SRC_TEMPLATE,
+        problem_args=problem_args,
+        problem_args_cutlass_3x=problem_args_cutlass_3x,
+        args_parser=args_parser,
         bias_ptr_arg="memory_pool->RequestTensorByIdx(3)",
     )
 
@@ -117,16 +130,23 @@ def gen_function(
     problem_args = bmm_common.PROBLEM_ARGS_TEMPLATE.render(
         mm_info=bmm_problem_info,
     )
+    problem_args_cutlass_3x = bmm_common.PROBLEM_ARGS_TEMPLATE_CUTLASS_3X.render(
+        mm_info=bmm_common.add_elem_types_to_mm_info(
+            mm_info=bmm_problem_info,
+            func_attrs=func_attrs,
+        ),
+    )
 
     input_ndims = len(func_attrs["input_accessors"][0].original_shapes)
     weight_ndims = len(func_attrs["input_accessors"][1].original_shapes)
     output_ndims = len(func_attrs["output_accessors"][0].original_shapes)
 
     return common.gen_function(
-        func_attrs,
-        common_bias.SRC_TEMPLATE,
-        exec_cond_template,
-        problem_args,
+        func_attrs=func_attrs,
+        src_template=common_bias.SRC_TEMPLATE,
+        exec_cond_template=exec_cond_template,
+        problem_args=problem_args,
+        problem_args_cutlass_3x=problem_args_cutlass_3x,
         input_ndims=input_ndims,
         weight_ndims=weight_ndims,
         output_ndims=output_ndims,

--- a/tests/unittest/ops/test_perm102_bmm_rrr.py
+++ b/tests/unittest/ops/test_perm102_bmm_rrr.py
@@ -29,28 +29,23 @@ from aitemplate.compiler import compile_model, ops
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 from aitemplate.testing.test_utils import (
-    filter_test_cases_by_params,
+    env_variables,
+    filter_test_cases_by_test_env,
     get_random_torch_tensor,
-    TestEnv,
 )
-from parameterized import parameterized
 
 
 @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
-class Perm102BMMTestCase(unittest.TestCase):
-    @parameterized.expand(
-        **filter_test_cases_by_params(
-            {
-                TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
-                TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],
-            }
-        )
-    )
-    def test_perm102_bmm_rrr(self, dtype="float16"):
-        B = 25
-        M = 128
-        K = 256
-        N = 100
+class Perm102BMMRRRTestCase(unittest.TestCase):
+    def _test_perm102_bmm_rrr(
+        self,
+        B=25,
+        M=128,
+        N=100,
+        K=256,
+        dtype="float16",
+        test_name="perm102_bmm_rrr",
+    ):
         target = detect_target()
         X = Tensor(shape=[M, B, K], dtype=dtype, name="input_0", is_input=True)
         W = Tensor(shape=[B, K, N], dtype=dtype, name="input_1", is_input=True)
@@ -58,7 +53,7 @@ class Perm102BMMTestCase(unittest.TestCase):
         Y = OP(X, W)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "perm102_bmm_rrr")
+        module = compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor(shape=(M, B, K), dtype=dtype)
         W_pt = get_random_torch_tensor(shape=(B, K, N), dtype=dtype)
@@ -71,22 +66,60 @@ class Perm102BMMTestCase(unittest.TestCase):
 
         torch.testing.assert_close(Y_pt, y, atol=1e-1, rtol=1e-1)
 
+    def test_perm102_bmm_rrr_fp16(self):
+        self._test_perm102_bmm_rrr(
+            dtype="float16",
+            test_name="perm102_bmm_rrr_fp16",
+        )
+
+    def test_perm102_bmm_rrr_fp32_sm80(self):
+        self._test_perm102_bmm_rrr(
+            dtype="float32",
+            test_name="perm102_bmm_rrr_fp32",
+        )
+
+    def test_perm102_bmm_rrr_bf16(self):
+        self._test_perm102_bmm_rrr(
+            dtype="bfloat16",
+            test_name="perm102_bmm_rrr_bf16",
+        )
+
+    def test_perm102_bmm_rrr_sm90(self):
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            self._test_perm102_bmm_rrr(
+                N=64,
+                K=256,
+                dtype="float16",
+                test_name="perm102_bmm_rrr_fp16_force_sm90",
+            )
+            self._test_perm102_bmm_rrr(
+                N=64,
+                K=256,
+                dtype="float32",
+                test_name="perm102_bmm_rrr_fp32_force_sm90",
+            )
+            self._test_perm102_bmm_rrr(
+                N=64,
+                K=256,
+                dtype="bfloat16",
+                test_name="perm102_bmm_rrr_bf16_force_sm90",
+            )
+
 
 @unittest.skipIf(detect_target().name() == "rocm", "Not supported by ROCM.")
-class Perm102BMMBiasTestCase(unittest.TestCase):
-    @parameterized.expand(
-        **filter_test_cases_by_params(
-            {
-                TestEnv.CUDA_LESS_THAN_SM80: [("float16")],
-                TestEnv.CUDA_SM80: [("float32"), ("bfloat16")],
-            }
-        )
-    )
-    def test_perm102_bmm_rrr_bias(self, dtype="float16"):
-        B = 25
-        M = 128
-        K = 256
-        N = 100
+class Perm102BMMRRRBiasTestCase(unittest.TestCase):
+    def _test_perm102_bmm_rrr_bias(
+        self,
+        B=25,
+        M=128,
+        K=256,
+        N=100,
+        dtype="float16",
+        test_name="perm102_bmm_rrr_bias",
+    ):
         target = detect_target()
         X = Tensor(shape=[M, B, K], dtype=dtype, name="input_0", is_input=True)
         W = Tensor(shape=[B, K, N], dtype=dtype, name="input_1", is_input=True)
@@ -95,7 +128,7 @@ class Perm102BMMBiasTestCase(unittest.TestCase):
         Y = OP(X, W, BIAS)
         Y._attrs["name"] = "output_0"
         Y._attrs["is_output"] = True
-        module = compile_model(Y, target, "./tmp", "perm102_bmm_rrr_bias")
+        module = compile_model(Y, target, "./tmp", test_name)
 
         X_pt = get_random_torch_tensor(shape=(M, B, K), dtype=dtype)
         W_pt = get_random_torch_tensor(shape=(B, K, N), dtype=dtype)
@@ -112,6 +145,52 @@ class Perm102BMMBiasTestCase(unittest.TestCase):
         )
 
         torch.testing.assert_close(Y_pt, y, atol=1e-1, rtol=1e-1)
+
+    def test_perm102_bmm_rrr_bias_fp16(self):
+        self._test_perm102_bmm_rrr_bias(
+            dtype="float16",
+            test_name="perm102_bmm_rrr_bias_fp16",
+        )
+
+    def test_perm102_bmm_rrr_bias_fp32_sm80(self):
+        self._test_perm102_bmm_rrr_bias(
+            dtype="float32",
+            test_name="perm102_bmm_rrr_bias_fp32",
+        )
+
+    def test_perm102_bmm_rrr_bias_bf16(self):
+        self._test_perm102_bmm_rrr_bias(
+            dtype="bfloat16",
+            test_name="perm102_bmm_rrr_bias_bf16",
+        )
+
+    def test_perm102_bmm_rrr_bias_sm90(self):
+        with env_variables(
+            AIT_FORCE_CUTLASS_SM90_KERNELS="1",
+            INSIDE_RE_WORKER="1",
+        ):
+            self._test_perm102_bmm_rrr_bias(
+                N=64,
+                K=256,
+                dtype="float16",
+                test_name="perm102_bmm_rrr_bias_fp16_force_sm90",
+            )
+            self._test_perm102_bmm_rrr_bias(
+                N=64,
+                K=256,
+                dtype="float32",
+                test_name="perm102_bmm_rrr_bias_fp32_force_sm90",
+            )
+            self._test_perm102_bmm_rrr_bias(
+                N=64,
+                K=256,
+                dtype="bfloat16",
+                test_name="perm102_bmm_rrr_bias_bf16_force_sm90",
+            )
+
+
+filter_test_cases_by_test_env(Perm102BMMRRRTestCase)
+filter_test_cases_by_test_env(Perm102BMMRRRBiasTestCase)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
ATT. SM90 kernels are added to the following ops:

- `perm102_bmm_rcr`
- `perm102_bmm_rcr_bias`
- `perm102_bmm_rrr`
- `perm102_bmm_rrr_bias`

Differential Revision: D45817288

