### PR TITLE
add nix-shell config

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,48 @@
+{ pkgs ? import <nixpkgs> {
+  config = {
+    allowUnfree = true;
+    cudaSupport = true;
+  };
+}}:
+
+let 
+  ait-deps = ps: with ps; [
+    pytorch-bin
+    pip
+    wheel
+    unidecode
+    inflect
+    librosa
+    jinja2
+    sympy
+    einops
+    parameterized
+    # (
+    #   buildPythonPackage rec {
+    #     pname = "cuda_python";
+    #     version = "12.1.0";
+    #     format = "wheel";
+    #     src = fetchPypi {
+    #       inherit pname version format;
+    #       sha256 = "94506d730baade1744767e2c05d5ddd84d7fbe4c9b6f694a54a3f376f7ffa525";
+    #       abi = "cp39";
+    #       python = "cp39";
+    #       platform = "manylinux_2_17_x86_64.manylinux2014_x86_64";
+    #     };
+    #     doCheck = false;
+    #   }
+    # )
+  ];  
+in
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.cmake
+    pkgs.cudatoolkit
+    (pkgs.python39.withPackages ait-deps)
+  ];
+
+  shellHook = ''
+    export CUDA_PATH=${pkgs.cudatoolkit}
+    echo "You are now using a NIX environment"
+  '';
+}


### PR DESCRIPTION
```
$> nix-shell
```
downloads and caches the dependencies on the first run, launches a shell with set up environment on any run. Within the shell, I could run a unit test for aitemplate
```
PYTHONPATH=python:$PYTHONPATH python tests/unittest/ops/test_activation.py -k softplus
```
some deps might still be missing to use all the components though