### PR TITLE
Add layernorm CUDA kernel based on Welford's algorithm

### DIFF
--- a/python/aitemplate/backend/cuda/layernorm_sigmoid_mul/layer_norm.cuh
+++ b/python/aitemplate/backend/cuda/layernorm_sigmoid_mul/layer_norm.cuh
@@ -1,0 +1,1246 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+// Original OneFlow copyright notice:
+
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+namespace layer_norm {
+
+constexpr int kWarpSize = 32;
+
+template <typename T>
+struct SumOp {
+  __device__ __forceinline__ T operator()(const T& a, const T& b) const {
+    return a + b;
+  }
+};
+
+template <typename T>
+struct MaxOp {
+  __device__ __forceinline__ T operator()(const T& a, const T& b) const {
+    return max(a, b);
+  }
+};
+
+template <
+    template <typename>
+    class ReductionOp,
+    typename T,
+    int thread_group_width = kWarpSize>
+__inline__ __device__ T WarpAllReduce(T val) {
+  for (int mask = thread_group_width / 2; mask > 0; mask /= 2) {
+    val = ReductionOp<T>()(
+        val, __shfl_xor_sync(0xffffffff, val, mask, thread_group_width));
+  }
+  return val;
+}
+
+template <template <typename> class ReductionOp, typename T, int block_size>
+__inline__ __device__ T BlockAllReduce(T val) {
+  typedef cub::BlockReduce<T, block_size> BlockReduce;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  __shared__ T result_broadcast;
+  T result = BlockReduce(temp_storage).Reduce(val, ReductionOp<T>());
+  if (threadIdx.x == 0) {
+    result_broadcast = result;
+  }
+  __syncthreads();
+  return result_broadcast;
+}
+
+template <typename T>
+__inline__ __device__ T Div(T a, T b);
+
+template <>
+__inline__ __device__ float Div<float>(float a, float b) {
+#ifdef OF_LAYER_NORM_USE_FAST_MATH
+  return __fdividef(a, b);
+#else
+  return a / b;
+#endif
+}
+
+template <>
+__inline__ __device__ double Div<double>(double a, double b) {
+  return a / b;
+}
+
+template <typename T>
+__inline__ __device__ T Rsqrt(T x);
+
+template <>
+__inline__ __device__ float Rsqrt<float>(float x) {
+#ifdef OF_LAYER_NORM_USE_FAST_MATH
+  return __frsqrt_rn(x);
+#else
+  return rsqrt(x);
+#endif
+}
+
+template <>
+__inline__ __device__ double Rsqrt<double>(double x) {
+  return rsqrt(x);
+}
+
+template <class Func>
+inline cudaError_t GetNumBlocks(
+    Func func,
+    int64_t block_size,
+    size_t dynamic_smem_size,
+    int64_t max_blocks,
+    int64_t waves,
+    int* num_blocks) {
+  int dev;
+  {
+    cudaError_t err = cudaGetDevice(&dev);
+    if (err != cudaSuccess) {
+      return err;
+    }
+  }
+  int sm_count;
+  {
+    cudaError_t err =
+        cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, dev);
+    if (err != cudaSuccess) {
+      return err;
+    }
+  }
+  int max_active_blocks;
+  {
+    cudaError_t err = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks, func, block_size, dynamic_smem_size);
+  }
+  *num_blocks = std::max<int>(
+      1, std::min<int64_t>(max_blocks, sm_count * max_active_blocks * waves));
+  return cudaSuccess;
+}
+
+template <typename T>
+class HasCanPackAs {
+  typedef char one;
+  struct two {
+    char x[2];
+  };
+
+  template <typename C>
+  static one test(decltype(&C::CanPackAs));
+  template <typename C>
+  static two test(...);
+
+ public:
+  enum { value = sizeof(test<T>(0)) == sizeof(char) };
+};
+
+template <typename T>
+typename std::enable_if<HasCanPackAs<T>::value == true, bool>::type CanPackAs(
+    T t,
+    size_t pack_size) {
+  return t.CanPackAs(pack_size);
+}
+
+template <typename T>
+typename std::enable_if<HasCanPackAs<T>::value == false, bool>::type CanPackAs(
+    T t,
+    size_t pack_size) {
+  return true;
+}
+
+template <typename T, int N>
+struct GetPackType {
+  using type =
+      typename std::aligned_storage<N * sizeof(T), N * sizeof(T)>::type;
+};
+
+template <typename T, int N>
+using PackType = typename GetPackType<T, N>::type;
+
+template <typename T, int N>
+union Pack {
+  static_assert(sizeof(PackType<T, N>) == sizeof(T) * N, "");
+  __device__ Pack() {
+    // do nothing
+  }
+  PackType<T, N> storage;
+  T elem[N];
+};
+
+template <typename SRC, typename DST>
+struct DirectLoad {
+  DirectLoad(const SRC* src, int64_t row_size) : src(src), row_size(row_size) {}
+  template <int N>
+  __device__ void load(DST* dst, int64_t row, int64_t col) const {
+    Pack<SRC, N> pack;
+    const int64_t offset = (row * row_size + col) / N;
+    pack.storage = *(reinterpret_cast<const PackType<SRC, N>*>(src) + offset);
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      dst[i] = static_cast<DST>(pack.elem[i]);
+    }
+  }
+  const SRC* src;
+  int64_t row_size;
+};
+
+template <typename SRC, typename DST>
+struct DirectStore {
+  DirectStore(DST* dst, int64_t row_size) : dst(dst), row_size(row_size) {}
+  template <int N>
+  __device__ void store(const SRC* src, int64_t row, int64_t col) {
+    Pack<DST, N> pack;
+    const int64_t offset = (row * row_size + col) / N;
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      pack.elem[i] = static_cast<DST>(src[i]);
+    }
+    *(reinterpret_cast<PackType<DST, N>*>(dst) + offset) = pack.storage;
+  }
+  DST* dst;
+  int64_t row_size;
+};
+
+template <typename T>
+inline __device__ void WelfordCombine(T val, T* mean, T* m2, T* count) {
+  // Use Welford Online algorithm to compute mean and variance
+  // For more details you can refer to:
+  // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
+  *count += 1;
+  T delta1 = val - *mean;
+  *mean += Div(delta1, *count);
+  T delta2 = val - *mean;
+  *m2 += delta1 * delta2;
+}
+
+template <typename T>
+inline __device__ void WelfordCombine(
+    T b_mean,
+    T b_m2,
+    T b_count,
+    T* mean,
+    T* m2,
+    T* count) {
+  if (b_count == 0) {
+    return;
+  }
+  T new_count = *count + b_count;
+  T nb_over_n = Div(b_count, new_count);
+  T delta = b_mean - *mean;
+  *mean += delta * nb_over_n;
+  *m2 += b_m2 + delta * delta * (*count) * nb_over_n;
+  *count = new_count;
+}
+
+template <typename T, int thread_group_width = kWarpSize>
+__inline__ __device__ void WelfordWarpReduce(
+    T thread_mean,
+    T thread_m2,
+    T thread_count,
+    T* mean,
+    T* m2,
+    T* count) {
+  *mean = thread_mean;
+  *m2 = thread_m2;
+  *count = thread_count;
+  for (int mask = thread_group_width / 2; mask > 0; mask /= 2) {
+    T b_mean = __shfl_down_sync(0xffffffff, *mean, mask, thread_group_width);
+    T b_m2 = __shfl_down_sync(0xffffffff, *m2, mask, thread_group_width);
+    T b_count = __shfl_down_sync(0xffffffff, *count, mask, thread_group_width);
+    WelfordCombine(b_mean, b_m2, b_count, mean, m2, count);
+  }
+}
+
+template <typename T, int thread_group_width = kWarpSize>
+__inline__ __device__ void WelfordWarpAllReduce(
+    T thread_mean,
+    T thread_m2,
+    T thread_count,
+    T* mean,
+    T* m2,
+    T* count) {
+  WelfordWarpReduce<T, thread_group_width>(
+      thread_mean, thread_m2, thread_count, mean, m2, count);
+  *mean = __shfl_sync(0xffffffff, *mean, 0, thread_group_width);
+  *m2 = __shfl_sync(0xffffffff, *m2, 0, thread_group_width);
+  *count = __shfl_sync(0xffffffff, *count, 0, thread_group_width);
+}
+
+template <typename T>
+__inline__ __device__ void WelfordBlockAllReduce(
+    T thread_mean,
+    T thread_m2,
+    T thread_count,
+    T* result_mean,
+    T* result_m2,
+    T* result_count) {
+  __shared__ T mean_shared[kWarpSize];
+  __shared__ T m2_shared[kWarpSize];
+  __shared__ T count_shared[kWarpSize];
+  __shared__ T mean_result_broadcast;
+  __shared__ T m2_result_broadcast;
+  __shared__ T count_result_broadcast;
+  const int lid = threadIdx.x % kWarpSize;
+  const int wid = threadIdx.x / kWarpSize;
+  T warp_mean = 0;
+  T warp_m2 = 0;
+  T warp_count = 0;
+  WelfordWarpReduce(
+      thread_mean, thread_m2, thread_count, &warp_mean, &warp_m2, &warp_count);
+  __syncthreads();
+  if (lid == 0) {
+    mean_shared[wid] = warp_mean;
+    m2_shared[wid] = warp_m2;
+    count_shared[wid] = warp_count;
+  }
+  __syncthreads();
+  if (wid == 0) {
+    if (threadIdx.x < blockDim.x / kWarpSize) {
+      warp_mean = mean_shared[lid];
+      warp_m2 = m2_shared[lid];
+      warp_count = count_shared[lid];
+    } else {
+      warp_mean = static_cast<T>(0);
+      warp_m2 = static_cast<T>(0);
+      warp_count = static_cast<T>(0);
+    }
+    __syncwarp();
+    T block_mean = 0;
+    T block_m2 = 0;
+    T block_count = 0;
+    WelfordWarpReduce(
+        warp_mean, warp_m2, warp_count, &block_mean, &block_m2, &block_count);
+    if (lid == 0) {
+      mean_result_broadcast = block_mean;
+      m2_result_broadcast = block_m2;
+      count_result_broadcast = block_count;
+    }
+  }
+  __syncthreads();
+  *result_mean = mean_result_broadcast;
+  *result_m2 = m2_result_broadcast;
+  *result_count = count_result_broadcast;
+}
+
+template <
+    typename LOAD,
+    typename STORE,
+    typename ComputeType,
+    int pack_size,
+    int max_cols_per_thread,
+    int min_cols_per_thread,
+    int thread_group_width,
+    int rows_per_access,
+    bool padding>
+__global__ void LayerNormWarpImpl(
+    LOAD load,
+    STORE store,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance) {
+  static_assert(max_cols_per_thread % pack_size == 0, "");
+  static_assert(min_cols_per_thread % pack_size == 0, "");
+  static_assert(thread_group_width <= kWarpSize, "");
+  static_assert(kWarpSize % thread_group_width == 0, "");
+  constexpr int max_num_packs = max_cols_per_thread / pack_size;
+  constexpr int min_num_packs = min_cols_per_thread / pack_size;
+  assert(cols <= max_cols_per_thread * thread_group_width);
+  ComputeType buf[rows_per_access][max_cols_per_thread];
+  const int64_t global_thread_group_id = blockIdx.x * blockDim.y + threadIdx.y;
+  const int64_t num_global_thread_group = gridDim.x * blockDim.y;
+  const int64_t lane_id = threadIdx.x;
+  const int64_t step = num_global_thread_group * rows_per_access;
+  for (int64_t row = global_thread_group_id * rows_per_access; row < rows;
+       row += step) {
+    ComputeType thread_mean[rows_per_access];
+    ComputeType thread_m2[rows_per_access];
+    ComputeType thread_count[rows_per_access];
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      thread_mean[row_id] = 0;
+      thread_m2[row_id] = 0;
+      thread_count[row_id] = 0;
+      ComputeType* row_buf = buf[row_id];
+#pragma unroll
+      for (int pack_id = 0; pack_id < min_num_packs; ++pack_id) {
+        const int col = (pack_id * thread_group_width + lane_id) * pack_size;
+        const int pack_offset = pack_id * pack_size;
+        load.template load<pack_size>(row_buf + pack_offset, row + row_id, col);
+#pragma unroll
+        for (int i = 0; i < pack_size; ++i) {
+          WelfordCombine(
+              row_buf[pack_offset + i],
+              thread_mean + row_id,
+              thread_m2 + row_id,
+              thread_count + row_id);
+        }
+      }
+      for (int pack_id = min_num_packs; pack_id < max_num_packs; ++pack_id) {
+        const int col = (pack_id * thread_group_width + lane_id) * pack_size;
+        const int pack_offset = pack_id * pack_size;
+        if (!padding || col < cols) {
+          load.template load<pack_size>(
+              row_buf + pack_offset, row + row_id, col);
+#pragma unroll
+          for (int i = 0; i < pack_size; ++i) {
+            WelfordCombine(
+                row_buf[pack_offset + i],
+                thread_mean + row_id,
+                thread_m2 + row_id,
+                thread_count + row_id);
+          }
+        } else {
+#pragma unroll
+          for (int i = 0; i < pack_size; ++i) {
+            row_buf[pack_offset + i] = 0;
+          }
+        }
+      }
+    }
+    ComputeType warp_mean[rows_per_access];
+    ComputeType warp_m2[rows_per_access];
+    ComputeType warp_count[rows_per_access];
+#pragma unroll
+    for (int row_id = 0; row_id < rows_per_access; ++row_id) {
+      int global_row_id = row + row_id;
+      ComputeType* row_buf = buf[row_id];
+      WelfordWarpAllReduce<ComputeType, thread_group_width>(
+          thread_mean[row_id],
+          thread_m2[row_id],
+          thread_count[row_id],
+          warp_mean + row_id,
+          warp_m2 + row_id,
+          warp_count + row_id);
+      ComputeType row_mean = warp_mean[row_id];
+      ComputeType row_variance =
+          max(Div(warp_m2[row_id], warp_count[row_id]),
+              static_cast<ComputeType>(0.0));
+      ComputeType row_inv_var =
+          Rsqrt(row_variance + static_cast<ComputeType>(epsilon));
+      if (mean && inv_variance && lane_id == 0) {
+        mean[global_row_id] = row_mean;
+        inv_variance[global_row_id] = row_inv_var;
+      }
+#pragma unroll
+      for (int i = 0; i < max_cols_per_thread; ++i) {
+        row_buf[i] = (row_buf[i] - row_mean) * row_inv_var;
+      }
+#pragma unroll
+      for (int i = 0; i < min_num_packs; ++i) {
+        const int col = (i * thread_group_width + lane_id) * pack_size;
+        store.template store<pack_size>(
+            row_buf + i * pack_size, global_row_id, col);
+      }
+#pragma unroll
+      for (int i = min_num_packs; i < max_num_packs; ++i) {
+        const int col = (i * thread_group_width + lane_id) * pack_size;
+        if (!padding || col < cols) {
+          store.template store<pack_size>(
+              row_buf + i * pack_size, global_row_id, col);
+        }
+      }
+    }
+  }
+}
+
+template <
+    typename LOAD,
+    typename STORE,
+    typename ComputeType,
+    int pack_size,
+    int max_cols_per_thread,
+    int min_cols_per_thread,
+    int thread_group_width,
+    int rows_per_access,
+    bool padding>
+inline cudaError_t LaunchLayerNormWarpImpl(
+    cudaStream_t stream,
+    LOAD load,
+    STORE store,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance) {
+  constexpr int block_size = 128;
+  constexpr int waves = 32;
+  static_assert(block_size % thread_group_width == 0, "");
+  constexpr int thread_groups_per_block = block_size / thread_group_width;
+  dim3 block_dim(thread_group_width, thread_groups_per_block);
+  const int64_t num_blocks =
+      (rows / rows_per_access + thread_groups_per_block - 1) /
+      thread_groups_per_block;
+  int grid_dim_x;
+  {
+    cudaError_t err = GetNumBlocks(
+        LayerNormWarpImpl<
+            LOAD,
+            STORE,
+            ComputeType,
+            pack_size,
+            max_cols_per_thread,
+            min_cols_per_thread,
+            thread_group_width,
+            rows_per_access,
+            padding>,
+        block_size,
+        0,
+        num_blocks,
+        waves,
+        &grid_dim_x);
+    if (err != cudaSuccess) {
+      return err;
+    }
+  }
+  LayerNormWarpImpl<
+      LOAD,
+      STORE,
+      ComputeType,
+      pack_size,
+      max_cols_per_thread,
+      min_cols_per_thread,
+      thread_group_width,
+      rows_per_access,
+      padding><<<grid_dim_x, block_dim, 0, stream>>>(
+      load, store, rows, cols, epsilon, mean, inv_variance);
+  return cudaPeekAtLastError();
+}
+
+template <
+    typename LOAD,
+    typename STORE,
+    typename ComputeType,
+    int pack_size,
+    int max_cols_per_thread,
+    int min_cols_per_thread,
+    int thread_group_width,
+    int rows_per_access>
+inline cudaError_t DispatchLayerNormWarpImplPadding(
+    cudaStream_t stream,
+    LOAD load,
+    STORE store,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance) {
+  if (cols == max_cols_per_thread * thread_group_width) {
+    // when not padding, min_cols_per_thread must equals to max_cols_per_thread,
+    // pass max_cols_per_thread as min_cols_per_thread and max_cols_per_thread
+    // param.
+    return LaunchLayerNormWarpImpl<
+        LOAD,
+        STORE,
+        ComputeType,
+        pack_size,
+        max_cols_per_thread,
+        max_cols_per_thread,
+        thread_group_width,
+        rows_per_access,
+        false>(stream, load, store, rows, cols, epsilon, mean, inv_variance);
+  } else {
+    return LaunchLayerNormWarpImpl<
+        LOAD,
+        STORE,
+        ComputeType,
+        pack_size,
+        max_cols_per_thread,
+        min_cols_per_thread,
+        thread_group_width,
+        rows_per_access,
+        true>(stream, load, store, rows, cols, epsilon, mean, inv_variance);
+  }
+}
+
+template <typename LOAD, typename STORE, typename ComputeType, int pack_size>
+typename std::enable_if<pack_size == 1, cudaError_t>::type
+DispatchLayerNormWarpImplCols(
+    cudaStream_t stream,
+    LOAD load,
+    STORE store,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance) {
+  if (cols <= 0) {
+    return cudaErrorInvalidValue;
+  }
+#define DEFINE_ONE_ELIF(thread_group_width)                                 \
+  else if (cols <= (thread_group_width)*pack_size) {                        \
+    if (rows % 2 == 0) {                                                    \
+      return DispatchLayerNormWarpImplPadding<                              \
+          LOAD,                                                             \
+          STORE,                                                            \
+          ComputeType,                                                      \
+          pack_size,                                                        \
+          pack_size,                                                        \
+          0,                                                                \
+          thread_group_width,                                               \
+          2>(stream, load, store, rows, cols, epsilon, mean, inv_variance); \
+    } else {                                                                \
+      return DispatchLayerNormWarpImplPadding<                              \
+          LOAD,                                                             \
+          STORE,                                                            \
+          ComputeType,                                                      \
+          pack_size,                                                        \
+          pack_size,                                                        \
+          0,                                                                \
+          thread_group_width,                                               \
+          1>(stream, load, store, rows, cols, epsilon, mean, inv_variance); \
+    }                                                                       \
+  }
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+#define DEFINE_ONE_ELIF(max_col, min_col)                                 \
+  else if (cols <= (max_col)*kWarpSize) {                                 \
+    return DispatchLayerNormWarpImplPadding<                              \
+        LOAD,                                                             \
+        STORE,                                                            \
+        ComputeType,                                                      \
+        pack_size,                                                        \
+        max_col,                                                          \
+        min_col,                                                          \
+        kWarpSize,                                                        \
+        1>(stream, load, store, rows, cols, epsilon, mean, inv_variance); \
+  }
+  DEFINE_ONE_ELIF(2, 1)
+  DEFINE_ONE_ELIF(4, 2)
+  DEFINE_ONE_ELIF(8, 4)
+  DEFINE_ONE_ELIF(12, 8)
+  DEFINE_ONE_ELIF(16, 12)
+  DEFINE_ONE_ELIF(20, 16)
+  DEFINE_ONE_ELIF(24, 20)
+  DEFINE_ONE_ELIF(28, 24)
+  DEFINE_ONE_ELIF(32, 28)
+#undef DEFINE_ONE_ELIF
+  else {
+    return cudaErrorInvalidValue;
+  }
+}
+
+template <typename LOAD, typename STORE, typename ComputeType, int pack_size>
+typename std::enable_if<pack_size == 2, cudaError_t>::type
+DispatchLayerNormWarpImplCols(
+    cudaStream_t stream,
+    LOAD load,
+    STORE store,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance) {
+  if (cols <= 0) {
+    return cudaErrorInvalidValue;
+  }
+#define DEFINE_ONE_ELIF(thread_group_width)                                 \
+  else if (cols <= (thread_group_width)*pack_size) {                        \
+    if (rows % 2 == 0) {                                                    \
+      return DispatchLayerNormWarpImplPadding<                              \
+          LOAD,                                                             \
+          STORE,                                                            \
+          ComputeType,                                                      \
+          pack_size,                                                        \
+          pack_size,                                                        \
+          0,                                                                \
+          thread_group_width,                                               \
+          2>(stream, load, store, rows, cols, epsilon, mean, inv_variance); \
+    } else {                                                                \
+      return DispatchLayerNormWarpImplPadding<                              \
+          LOAD,                                                             \
+          STORE,                                                            \
+          ComputeType,                                                      \
+          pack_size,                                                        \
+          pack_size,                                                        \
+          0,                                                                \
+          thread_group_width,                                               \
+          1>(stream, load, store, rows, cols, epsilon, mean, inv_variance); \
+    }                                                                       \
+  }
+  DEFINE_ONE_ELIF(4)
+  DEFINE_ONE_ELIF(8)
+  DEFINE_ONE_ELIF(16)
+  DEFINE_ONE_ELIF(32)
+#undef DEFINE_ONE_ELIF
+#define DEFINE_ONE_ELIF(max_col, min_col)                                   \
+  else if ((cols <= (max_col)*kWarpSize) && (cols > (min_col)*kWarpSize)) { \
+    return DispatchLayerNormWarpImplPadding<                                \
+        LOAD,                                                               \
+        STORE,                                                              \
+        ComputeType,                                                        \
+        pack_size,                                                          \
+        max_col,                                                            \
+        min_col,                                                            \
+        kWarpSize,                                                          \
+        1>(stream, load, store, rows, cols, epsilon, mean, inv_variance);   \
+  }
+  DEFINE_ONE_ELIF(4, 2)
+  DEFINE_ONE_ELIF(8, 4)
+  DEFINE_ONE_ELIF(12, 8)
+  DEFINE_ONE_ELIF(16, 12)
+  DEFINE_ONE_ELIF(20, 16)
+  DEFINE_ONE_ELIF(24, 20)
+  DEFINE_ONE_ELIF(28, 24)
+  DEFINE_ONE_ELIF(32, 28)
+#undef DEFINE_ONE_ELIF
+  else {
+    return cudaErrorInvalidValue;
+  }
+}
+
+template <typename LOAD, typename STORE, typename ComputeType>
+struct DispatchLayerNormWarpImplPackSize {
+  cudaError_t operator()(
+      cudaStream_t stream,
+      LOAD load,
+      STORE store,
+      const int64_t rows,
+      const int64_t cols,
+      const double epsilon,
+      ComputeType* mean,
+      ComputeType* inv_variance) {
+    if (cols % 2 == 0 && CanPackAs<LOAD>(load, 2) &&
+        CanPackAs<STORE>(store, 2)) {
+      return DispatchLayerNormWarpImplCols<LOAD, STORE, ComputeType, 2>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    } else {
+      return DispatchLayerNormWarpImplCols<LOAD, STORE, ComputeType, 1>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    }
+  }
+};
+
+template <typename LOAD, typename STORE, typename ComputeType>
+inline cudaError_t DispatchLayerNormWarpImpl(
+    cudaStream_t stream,
+    LOAD load,
+    STORE store,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance) {
+  return DispatchLayerNormWarpImplPackSize<LOAD, STORE, ComputeType>()(
+      stream, load, store, rows, cols, epsilon, mean, inv_variance);
+}
+
+template <
+    typename LOAD,
+    typename STORE,
+    typename ComputeType,
+    int pack_size,
+    int block_size>
+__global__ void LayerNormBlockSMemImpl(
+    LOAD load,
+    STORE store,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance) {
+  extern __shared__ __align__(sizeof(double)) unsigned char shared_buf[];
+  auto* buf = reinterpret_cast<ComputeType*>(shared_buf);
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = static_cast<int>(cols) / pack_size;
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    ComputeType thread_mean = 0;
+    ComputeType thread_m2 = 0;
+    ComputeType thread_count = 0;
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      load.template load<pack_size>(pack, row, pack_id * pack_size);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        buf[i * num_packs + pack_id] = pack[i];
+        WelfordCombine(pack[i], &thread_mean, &thread_m2, &thread_count);
+      }
+    }
+    ComputeType row_mean = 0;
+    ComputeType row_m2 = 0;
+    ComputeType row_count = 0;
+    WelfordBlockAllReduce<ComputeType>(
+        thread_mean, thread_m2, thread_count, &row_mean, &row_m2, &row_count);
+    ComputeType row_variance =
+        max(Div(row_m2, row_count), static_cast<ComputeType>(0.0));
+    ComputeType row_inv_var =
+        Rsqrt(row_variance + static_cast<ComputeType>(epsilon));
+    if (mean && inv_variance && threadIdx.x == 0) {
+      mean[row] = row_mean;
+      inv_variance[row] = row_inv_var;
+    }
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        pack[i] = (buf[i * num_packs + pack_id] - row_mean) * row_inv_var;
+      }
+      store.template store<pack_size>(pack, row, pack_id * pack_size);
+    }
+  }
+}
+
+template <
+    typename LOAD,
+    typename STORE,
+    typename ComputeType,
+    int pack_size,
+    int block_size>
+inline cudaError_t LaunchLayerNormBlockSMemImpl(
+    cudaStream_t stream,
+    LOAD load,
+    STORE store,
+    int smem,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance) {
+  constexpr int waves = 32;
+  int grid_dim_x;
+  {
+    cudaError_t err = GetNumBlocks(
+        LayerNormBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size>,
+        block_size,
+        smem,
+        rows,
+        waves,
+        &grid_dim_x);
+    if (err != cudaSuccess) {
+      return err;
+    }
+  }
+  LayerNormBlockSMemImpl<LOAD, STORE, ComputeType, pack_size, block_size>
+      <<<grid_dim_x, block_size, smem, stream>>>(
+          load, store, rows, cols, epsilon, mean, inv_variance);
+  return cudaPeekAtLastError();
+}
+
+template <typename LOAD, typename STORE, typename ComputeType, int pack_size>
+inline cudaError_t TryDispatchLayerNormBlockSMemImplBlockSize(
+    cudaStream_t stream,
+    LOAD load,
+    STORE store,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance,
+    bool* success) {
+  constexpr int block_size_conf_1 = 128;
+  constexpr int block_size_conf_2 = 256;
+  constexpr int block_size_conf_3 = 512;
+  constexpr int block_size_conf_4 = 1024;
+  const size_t smem = cols * sizeof(ComputeType);
+  int max_active_blocks_conf_1;
+
+  {
+    cudaError_t err = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_1,
+        LayerNormBlockSMemImpl<
+            LOAD,
+            STORE,
+            ComputeType,
+            pack_size,
+            block_size_conf_1>,
+        block_size_conf_1,
+        smem);
+    if (err != cudaSuccess) {
+      return err;
+    }
+  }
+  if (max_active_blocks_conf_1 <= 0) {
+    *success = false;
+    return cudaSuccess;
+  }
+  int max_active_blocks_conf_4;
+  {
+    cudaError_t err = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_4,
+        LayerNormBlockSMemImpl<
+            LOAD,
+            STORE,
+            ComputeType,
+            pack_size,
+            block_size_conf_4>,
+        block_size_conf_4,
+        smem);
+    if (err != cudaSuccess) {
+      return err;
+    }
+  }
+
+  if (max_active_blocks_conf_4 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchLayerNormBlockSMemImpl<
+        LOAD,
+        STORE,
+        ComputeType,
+        pack_size,
+        block_size_conf_4>(
+        stream, load, store, smem, rows, cols, epsilon, mean, inv_variance);
+  }
+  int max_active_blocks_conf_3;
+  {
+    cudaError_t err = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_3,
+        LayerNormBlockSMemImpl<
+            LOAD,
+            STORE,
+            ComputeType,
+            pack_size,
+            block_size_conf_3>,
+        block_size_conf_3,
+        smem);
+    if (err != cudaSuccess) {
+      return err;
+    }
+  }
+
+  if (max_active_blocks_conf_3 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchLayerNormBlockSMemImpl<
+        LOAD,
+        STORE,
+        ComputeType,
+        pack_size,
+        block_size_conf_3>(
+        stream, load, store, smem, rows, cols, epsilon, mean, inv_variance);
+  }
+  int max_active_blocks_conf_2;
+  {
+    cudaError_t err = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks_conf_2,
+        LayerNormBlockSMemImpl<
+            LOAD,
+            STORE,
+            ComputeType,
+            pack_size,
+            block_size_conf_2>,
+        block_size_conf_2,
+        smem);
+    if (err != cudaSuccess) {
+      return err;
+    }
+  }
+
+  if (max_active_blocks_conf_2 == max_active_blocks_conf_1) {
+    *success = true;
+    return LaunchLayerNormBlockSMemImpl<
+        LOAD,
+        STORE,
+        ComputeType,
+        pack_size,
+        block_size_conf_2>(
+        stream, load, store, smem, rows, cols, epsilon, mean, inv_variance);
+  }
+  *success = true;
+  return LaunchLayerNormBlockSMemImpl<
+      LOAD,
+      STORE,
+      ComputeType,
+      pack_size,
+      block_size_conf_1>(
+      stream, load, store, smem, rows, cols, epsilon, mean, inv_variance);
+}
+
+template <typename LOAD, typename STORE, typename ComputeType>
+struct TryDispatchLayerNormBlockSMemImplPackSize {
+  cudaError_t operator()(
+      cudaStream_t stream,
+      LOAD load,
+      STORE store,
+      const int64_t rows,
+      const int64_t cols,
+      const double epsilon,
+      ComputeType* mean,
+      ComputeType* inv_variance,
+      bool* success) {
+    if (cols % 4 == 0 && CanPackAs<LOAD>(load, 4) &&
+        CanPackAs<STORE>(store, 4)) {
+      return TryDispatchLayerNormBlockSMemImplBlockSize<
+          LOAD,
+          STORE,
+          ComputeType,
+          4>(
+          stream,
+          load,
+          store,
+          rows,
+          cols,
+          epsilon,
+          mean,
+          inv_variance,
+          success);
+    } else if (
+        cols % 2 == 0 && CanPackAs<LOAD>(load, 2) &&
+        CanPackAs<STORE>(store, 2)) {
+      return TryDispatchLayerNormBlockSMemImplBlockSize<
+          LOAD,
+          STORE,
+          ComputeType,
+          2>(
+          stream,
+          load,
+          store,
+          rows,
+          cols,
+          epsilon,
+          mean,
+          inv_variance,
+          success);
+    } else {
+      return TryDispatchLayerNormBlockSMemImplBlockSize<
+          LOAD,
+          STORE,
+          ComputeType,
+          1>(
+          stream,
+          load,
+          store,
+          rows,
+          cols,
+          epsilon,
+          mean,
+          inv_variance,
+          success);
+    }
+  }
+};
+
+template <typename LOAD, typename STORE, typename ComputeType>
+inline cudaError_t TryDispatchLayerNormBlockSMemImpl(
+    cudaStream_t stream,
+    LOAD load,
+    STORE store,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance,
+    bool* success) {
+  return TryDispatchLayerNormBlockSMemImplPackSize<LOAD, STORE, ComputeType>()(
+      stream, load, store, rows, cols, epsilon, mean, inv_variance, success);
+}
+
+template <
+    typename LOAD,
+    typename STORE,
+    typename ComputeType,
+    int pack_size,
+    int block_size>
+__global__ void __launch_bounds__(1024) LayerNormBlockUncachedImpl(
+    LOAD load,
+    STORE store,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance) {
+  const int tid = threadIdx.x;
+  assert(cols % pack_size == 0);
+  const int num_packs = static_cast<int>(cols) / pack_size;
+  for (int64_t row = blockIdx.x; row < rows; row += gridDim.x) {
+    ComputeType thread_mean = 0;
+    ComputeType thread_m2 = 0;
+    ComputeType thread_count = 0;
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      load.template load<pack_size>(pack, row, pack_id * pack_size);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        WelfordCombine(pack[i], &thread_mean, &thread_m2, &thread_count);
+      }
+    }
+    ComputeType row_mean = 0;
+    ComputeType row_m2 = 0;
+    ComputeType row_count = 0;
+    WelfordBlockAllReduce<ComputeType>(
+        thread_mean, thread_m2, thread_count, &row_mean, &row_m2, &row_count);
+    ComputeType row_variance =
+        max(Div(row_m2, row_count), static_cast<ComputeType>(0.0));
+    ComputeType row_inv_var =
+        Rsqrt(row_variance + static_cast<ComputeType>(epsilon));
+    if (mean && inv_variance && threadIdx.x == 0) {
+      mean[row] = row_mean;
+      inv_variance[row] = row_inv_var;
+    }
+    for (int pack_id = tid; pack_id < num_packs; pack_id += block_size) {
+      ComputeType pack[pack_size];
+      const int pack_offset = pack_id * pack_size;
+      load.template load<pack_size>(pack, row, pack_offset);
+#pragma unroll
+      for (int i = 0; i < pack_size; ++i) {
+        pack[i] = (pack[i] - row_mean) * row_inv_var;
+      }
+      store.template store<pack_size>(pack, row, pack_offset);
+    }
+  }
+}
+
+template <typename LOAD, typename STORE, typename ComputeType, int pack_size>
+inline cudaError_t LaunchLayerNormBlockUncachedImpl(
+    cudaStream_t stream,
+    LOAD load,
+    STORE store,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance) {
+  constexpr int block_size = 1024;
+  constexpr int waves = 32;
+  int grid_dim_x;
+  {
+    cudaError_t err = GetNumBlocks(
+        LayerNormBlockUncachedImpl<
+            LOAD,
+            STORE,
+            ComputeType,
+            pack_size,
+            block_size>,
+        block_size,
+        0,
+        rows,
+        waves,
+        &grid_dim_x);
+    if (err != cudaSuccess) {
+      return err;
+    }
+  }
+  LayerNormBlockUncachedImpl<LOAD, STORE, ComputeType, pack_size, block_size>
+      <<<grid_dim_x, block_size, 0, stream>>>(
+          load, store, rows, cols, epsilon, mean, inv_variance);
+  return cudaPeekAtLastError();
+}
+
+template <typename LOAD, typename STORE, typename ComputeType>
+struct DispatchLayerNormBlockUncachedImplPackSize {
+  cudaError_t operator()(
+      cudaStream_t stream,
+      LOAD load,
+      STORE store,
+      const int64_t rows,
+      const int64_t cols,
+      const double epsilon,
+      ComputeType* mean,
+      ComputeType* inv_variance) {
+    if (cols % 4 == 0 && CanPackAs<LOAD>(load, 4) &&
+        CanPackAs<STORE>(store, 4)) {
+      return LaunchLayerNormBlockUncachedImpl<LOAD, STORE, ComputeType, 4>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    } else if (
+        cols % 2 == 0 && CanPackAs<LOAD>(load, 2) &&
+        CanPackAs<STORE>(store, 2)) {
+      return LaunchLayerNormBlockUncachedImpl<LOAD, STORE, ComputeType, 2>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    } else {
+      return LaunchLayerNormBlockUncachedImpl<LOAD, STORE, ComputeType, 1>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    }
+  }
+};
+
+template <typename LOAD, typename STORE, typename ComputeType>
+inline cudaError_t DispatchLayerNormBlockUncachedImpl(
+    cudaStream_t stream,
+    LOAD load,
+    STORE store,
+    const int64_t rows,
+    const int64_t cols,
+    const double epsilon,
+    ComputeType* mean,
+    ComputeType* inv_variance) {
+  return DispatchLayerNormBlockUncachedImplPackSize<LOAD, STORE, ComputeType>()(
+      stream, load, store, rows, cols, epsilon, mean, inv_variance);
+}
+
+template <typename LOAD, typename STORE, typename ComputeType>
+inline typename std::
+    enable_if<!std::is_same<ComputeType, double>::value, cudaError_t>::type
+    DispatchLayerNorm(
+        cudaStream_t stream,
+        LOAD load,
+        STORE store,
+        const int64_t rows,
+        const int64_t cols,
+        const double epsilon,
+        ComputeType* mean,
+        ComputeType* inv_variance) {
+  if (cols <= 1024) {
+    return DispatchLayerNormWarpImpl<LOAD, STORE, ComputeType>(
+        stream, load, store, rows, cols, epsilon, mean, inv_variance);
+  } else {
+    bool dispatch_smem_impl_success;
+    {
+      cudaError_t err =
+          TryDispatchLayerNormBlockSMemImpl<LOAD, STORE, ComputeType>(
+              stream,
+              load,
+              store,
+              rows,
+              cols,
+              epsilon,
+              mean,
+              inv_variance,
+              &dispatch_smem_impl_success);
+      if (err != cudaSuccess) {
+        return err;
+      }
+    }
+    if (!dispatch_smem_impl_success) {
+      return DispatchLayerNormBlockUncachedImpl<LOAD, STORE, ComputeType>(
+          stream, load, store, rows, cols, epsilon, mean, inv_variance);
+    }
+    return cudaSuccess;
+  }
+}
+
+template <typename LOAD, typename STORE, typename ComputeType>
+inline typename std::
+    enable_if<std::is_same<ComputeType, double>::value, cudaError_t>::type
+    DispatchLayerNorm(
+        cudaStream_t stream,
+        LOAD load,
+        STORE store,
+        const int64_t rows,
+        const int64_t cols,
+        const double epsilon,
+        ComputeType* mean,
+        ComputeType* inv_variance) {
+  return DispatchLayerNormBlockUncachedImpl<LOAD, STORE, ComputeType>(
+      stream, load, store, rows, cols, epsilon, mean, inv_variance);
+}
+
+// gradient kernels are omitted
+
+} // namespace layer_norm

--- a/python/aitemplate/backend/cuda/layernorm_sigmoid_mul/layernorm_welford.cuh
+++ b/python/aitemplate/backend/cuda/layernorm_sigmoid_mul/layernorm_welford.cuh
@@ -1,0 +1,284 @@
+//  Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+#ifndef LAYERNORM_KERNEL_CUH
+#define LAYERNORM_KERNEL_CUH
+
+constexpr uint32_t kFinalMask = 0xffffffff;
+
+#ifndef __HALF_TO_US
+#define __HALF_TO_US(var) *(reinterpret_cast<unsigned short*>(&(var)))
+#endif
+
+#define NOT_IMPLEMENTED() assert(0 && __PRETTY_FUNCTION__)
+
+__device__ half fast_tanh(half x) {
+#if defined(AIT_USE_FAST_MATH)
+#if defined(__CUDA_ARCH__) && (__CUDACC_VER_MAJOR__ >= 11) && \
+    (__CUDA_ARCH__ >= 750)
+
+  asm volatile("tanh.approx.f16 %0, %1;"
+               : "=h"(__HALF_TO_US(x))
+               : "h"(__HALF_TO_US(x)));
+  return x;
+
+#else
+  return half(cutlass::fast_tanh(float(x)));
+#endif
+#else
+  return half(tanhf(float(x)));
+#endif
+}
+
+__device__ bfloat16 fast_tanh(bfloat16 x) {
+#if defined(__CUDA_ARCH__) && (__CUDACC_VER_MAJOR__ >= 11) && \
+    (__CUDA_ARCH__ >= 900) && defined(AIT_USE_FAST_MATH)
+  asm volatile("tanh.approx.bf16 %0, %1;"
+               : "=h"(__HALF_TO_US(x))
+               : "h"(__HALF_TO_US(x)));
+  return x;
+
+#elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+#if defined(AIT_USE_FAST_MATH)
+  return cutlass::fast_tanh(float(x));
+#else
+  return bfloat16(tanhf(float(x)));
+#endif
+#else
+  NOT_IMPLEMENTED();
+#endif
+}
+
+#define CUDA_FP16_ONE_HALF \
+  __half_raw {             \
+    0x3800u                \
+  }
+#define CUDA_FP16_ONE \
+  __half_raw {        \
+    0x3c00u           \
+  }
+#define CUDA_BF16_ONE_HALF \
+  __nv_bfloat16_raw {      \
+    0x3f00u                \
+  }
+#define CUDA_BF16_ONE \
+  __nv_bfloat16_raw { \
+    0x3f80u           \
+  }
+
+__device__ float sigmoid(const float a) {
+  return (cutlass::fast_tanh(a * 0.5f) + 1.0f) * 0.5f;
+}
+
+__device__ half hsigmoid(const half a) {
+  return __hmul(
+      (__hadd(fast_tanh(__hmul(a, CUDA_FP16_ONE_HALF)), CUDA_FP16_ONE)),
+      CUDA_FP16_ONE_HALF);
+}
+
+#if defined(__CUDA_ARCH__) && (__CUDACC_VER_MAJOR__ >= 11) && \
+    (__CUDA_ARCH__ >= 800)
+__device__ bfloat16 bf16sigmoid(const bfloat16 a) {
+  return __hmul(
+      (__hadd(fast_tanh(__hmul(a, CUDA_BF16_ONE_HALF)), CUDA_BF16_ONE)),
+      CUDA_BF16_ONE_HALF);
+}
+#endif
+
+template <typename T>
+struct FSigmoid {
+  __inline__ __device__ T operator()(const T input) const;
+};
+
+template <>
+struct FSigmoid<half> {
+  __inline__ __device__ half operator()(const half a) const {
+    return hsigmoid(a);
+  }
+};
+
+#if defined(__CUDA_ARCH__) && (__CUDACC_VER_MAJOR__ >= 11) && \
+    (__CUDA_ARCH__ >= 800)
+template <>
+struct FSigmoid<bfloat16> {
+  __inline__ __device__ bfloat16 operator()(const bfloat16 a) const {
+    return bf16sigmoid(a);
+  }
+};
+#endif
+
+template <>
+struct FSigmoid<float> {
+  __inline__ __device__ float operator()(const float a) const {
+    return sigmoid(a);
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// The Layernorm implementation below is based on OneFlow's Layernorm
+// implementation at:
+// https://github.com/Oneflow-Inc/oneflow/blob/master/oneflow/core/cuda/layer_norm.cuh
+
+/*
+Copyright 2020 The OneFlow Authors. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+template <typename SRC, typename DST>
+struct TensorAccessorLoad {
+  TensorAccessorLoad(
+      const SRC* src,
+      int64_t row_size,
+      const TensorAccessor input_accessor)
+      : src(src), row_size(row_size), input_accessor(input_accessor) {}
+
+  template <int N>
+  __device__ void load(DST* dst, int64_t row, int64_t col) const {
+    layer_norm::Pack<SRC, N> pack;
+    pack.storage =
+        *input_accessor.get<const SRC, const layer_norm::PackType<SRC, N>>(
+            reinterpret_cast<const layer_norm::PackType<SRC, N>*>(src),
+            (row * row_size + col) / N);
+
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      dst[i] = static_cast<DST>(pack.elem[i]);
+    }
+  }
+
+  bool CanPackAs(size_t pack_size) {
+    return row_size % pack_size == 0 &&
+        input_accessor.max_alignment() % pack_size == 0;
+  }
+
+  const SRC* src;
+  int64_t row_size;
+  const TensorAccessor input_accessor;
+};
+
+template <typename SRC, typename DST, bool FuseSigmoidMul>
+struct TensorAccessorStore {
+  TensorAccessorStore(
+      DST* y,
+      const DST* x,
+      const DST* gamma,
+      const DST* beta,
+      int64_t row_size,
+      const TensorAccessor input_accessor,
+      const TensorAccessor output_accessor)
+      : y(y),
+        x(x),
+        gamma(gamma),
+        beta(beta),
+        row_size(row_size),
+        input_accessor(input_accessor),
+        output_accessor(output_accessor) {}
+
+  template <int N>
+  __device__ void store(const SRC* src, int64_t row, int64_t col) {
+    layer_norm::Pack<DST, N> x_pack;
+    layer_norm::Pack<DST, N> y_pack;
+
+    if constexpr (FuseSigmoidMul) {
+      x_pack.storage =
+          *input_accessor.get<const DST, const layer_norm::PackType<DST, N>>(
+              reinterpret_cast<const layer_norm::PackType<DST, N>*>(x),
+              (row * row_size + col) / N);
+    }
+
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      SRC normalized_i = src[i];
+
+#ifdef AIT_LAYERNORM_CONST_GAMMA
+      const SRC gamma_val = AIT_LAYERNORM_CONST_GAMMA;
+#else
+      const SRC gamma_val = static_cast<SRC>(gamma[col + i]);
+#endif // AIT_LAYERNORM_CONST_GAMMA
+
+#ifdef AIT_LAYERNORM_CONST_BETA
+      const SRC beta_val = AIT_LAYERNORM_CONST_BETA;
+#else
+      const SRC beta_val = static_cast<SRC>(beta[col + i]);
+#endif // AIT_LAYERNORM_CONST_BETA
+
+      normalized_i = normalized_i * gamma_val + beta_val;
+
+      if constexpr (FuseSigmoidMul) {
+        FSigmoid<SRC> fsigmoid;
+        normalized_i =
+            static_cast<SRC>(x_pack.elem[i]) * fsigmoid(normalized_i);
+      }
+
+      y_pack.elem[i] = DST(normalized_i);
+    }
+
+    *output_accessor.get<DST, layer_norm::PackType<DST, N>>(
+        reinterpret_cast<layer_norm::PackType<DST, N>*>(y),
+        (row * row_size + col) / N) = y_pack.storage;
+  }
+
+  bool CanPackAs(size_t pack_size) {
+    return row_size % pack_size == 0 &&
+        output_accessor.max_alignment() % pack_size == 0;
+  }
+
+  DST* y;
+  const DST* x;
+  const DST* gamma;
+  const DST* beta;
+  int64_t row_size;
+  const TensorAccessor input_accessor;
+  const TensorAccessor output_accessor;
+};
+
+template <typename TInput, typename TCompute, bool FuseSigmoidMul>
+cudaError_t invokeLayernormSigmoidMul(
+    TInput* output,
+    const TInput* input,
+    const TInput* gamma,
+    const TInput* beta,
+    int m,
+    int n,
+    const float eps,
+    cudaStream_t stream,
+    const TensorAccessor& input_accessor,
+    const TensorAccessor& output_accessor) {
+  TensorAccessorLoad<TInput, TCompute> load(input, n, input_accessor);
+  TensorAccessorStore<TCompute, TInput, FuseSigmoidMul> store(
+      output, input, gamma, beta, n, input_accessor, output_accessor);
+
+  // mean and inv_variance are not required for forward pass, hence omitted
+  layer_norm::DispatchLayerNorm<decltype(load), decltype(store), TCompute>(
+      stream,
+      load,
+      store,
+      m /* rows */,
+      n /* cols */,
+      eps /* epsilon */,
+      nullptr /* mean */,
+      nullptr /* inv_variance */);
+
+  return cudaGetLastError();
+}
+
+#endif /* LAYERNORM_KERNEL_CUH */

--- a/tests/unittest/compiler/test_strided_layernorm.py
+++ b/tests/unittest/compiler/test_strided_layernorm.py
@@ -39,8 +39,11 @@ def build_ait_module(
     ait_dtype="float16",
     workdir="./tmp",
     test_name="strided_layernorm",
+    use_welford_algorithm=False,
 ):
-    target = detect_target()
+    target = detect_target(
+        layernorm_use_welford_algorithm=use_welford_algorithm,
+    )
     X0 = Tensor(
         shape=[
             shape_utils.gen_int_var_min_max(values=batch_sizes, name="input_batch"),
@@ -88,7 +91,7 @@ def build_ait_module(
         output,
         target,
         workdir,
-        test_name,
+        f"{test_name}_{test_id}",
         dll_name=dll_name,
     )
 
@@ -151,6 +154,8 @@ class SliceLayerNormTestCase(unittest.TestCase):
         start_indices: List[int] = (0,),
         end_indices: List[int] = (None,),
         dtype: str = "float16",
+        test_name="test_slice_layer_norm",
+        use_welford_algorithm=False,
     ):
 
         input_rank = 1 + len(input_nonbatch_shape)
@@ -175,6 +180,8 @@ class SliceLayerNormTestCase(unittest.TestCase):
             **_layernorm_common_params,
             test_id=self._test_id,
             ait_dtype=dtype,
+            test_name=f"{test_name}_{dtype}",
+            use_welford_algorithm=use_welford_algorithm,
         )
         self._test_id += 1
         pt_dtype = torch_utils.string_to_torch_dtype(dtype)
@@ -187,29 +194,30 @@ class SliceLayerNormTestCase(unittest.TestCase):
             }
             ait_outputs = {"output": torch.empty_like(pt_tensors["output"])}
             ait_module.run_with_tensors(ait_inputs, ait_outputs)
-
-            self.assertTrue(
-                torch.allclose(
-                    ait_outputs["output"], pt_tensors["output"], atol=1e-3, rtol=1e-3
-                )
+            torch.testing.assert_close(
+                ait_outputs["output"],
+                pt_tensors["output"],
+                atol=1e-3,
+                rtol=1e-3,
             )
 
     def _test_slice_layer_norm_kernels(
         self,
         **kwargs,
     ):
-        for start_indices, end_indices, input_nonbatch_shape in (
+        for start_indices, end_indices, input_nonbatch_shape, use_welford_algorithm in (
             # (cuda-half4) kernel
-            ((0, 0, 0, 4), (None, None, None, 36), (4, 1, 40)),
+            ((0, 0, 0, 4), (None, None, None, 36), (4, 1, 40), False),
             # (generic n < 1024) kernel
-            ((0, 0, 0, 11), (None, None, None, 13), (4, 1, 15)),
+            ((0, 0, 0, 11), (None, None, None, 13), (4, 1, 15), False),
             # (cuda-half; block size = 512) kernel
-            ((0, 0, 0, 1), (None, None, None, 1026), (4, 1, 1027)),
+            ((0, 0, 0, 1), (None, None, None, 1026), (4, 1, 1027), True),
         ):
             self._test_slice_layer_norm(
                 start_indices=start_indices,
                 end_indices=end_indices,
                 input_nonbatch_shape=input_nonbatch_shape,
+                use_welford_algorithm=use_welford_algorithm,
                 **kwargs,
             )
 
@@ -217,18 +225,19 @@ class SliceLayerNormTestCase(unittest.TestCase):
         self,
         **kwargs,
     ):
-        for start_indices, end_indices, input_nonbatch_shape in (
+        for start_indices, end_indices, input_nonbatch_shape, use_welford_algorithm in (
             # (cuda-half4) kernel
-            ((0, 0, 4, 0), (None, None, 36, None), (2, 40, 4)),
+            ((0, 0, 4, 0), (None, None, 36, None), (2, 40, 4), False),
             # (generic n < 1024) kernel
-            ((0, 0, 11, 0), (None, None, 13, None), (2, 15, 2)),
+            ((0, 0, 11, 0), (None, None, 13, None), (2, 15, 2), True),
             # (cuda-half; block size = 512) kernel
-            ((0, 0, 1, 0), (None, None, 1026, None), (2, 1027, 2)),
+            ((0, 0, 1, 0), (None, None, 1026, None), (2, 1027, 2), False),
         ):
             self._test_slice_layer_norm(
                 start_indices=start_indices,
                 end_indices=end_indices,
                 input_nonbatch_shape=input_nonbatch_shape,
+                use_welford_algorithm=use_welford_algorithm,
                 **kwargs,
             )
 
@@ -247,6 +256,7 @@ class SliceLayerNormTestCase(unittest.TestCase):
                 gamma_is_none=gamma_is_none,
                 beta_is_none=beta_is_none,
                 fuse_sigmoid_mul=False,
+                test_name="test_slice_layer_norm_float16",
             )
 
     def test_middle_slice_layer_norm_float16(self):
@@ -264,6 +274,7 @@ class SliceLayerNormTestCase(unittest.TestCase):
                 gamma_is_none=gamma_is_none,
                 beta_is_none=beta_is_none,
                 fuse_sigmoid_mul=False,
+                test_name="test_middle_slice_layer_norm_float16",
             )
 
     def test_slice_layer_norm_fuse_sigmoid_mul_float16(self):
@@ -281,6 +292,7 @@ class SliceLayerNormTestCase(unittest.TestCase):
                 gamma_is_none=gamma_is_none,
                 beta_is_none=beta_is_none,
                 fuse_sigmoid_mul=True,
+                test_name="test_slice_layer_norm_fuse_sigmoid_mul_float16",
             )
 
     def test_middle_slice_layer_norm_fuse_sigmoid_mul_float16(self):
@@ -298,6 +310,7 @@ class SliceLayerNormTestCase(unittest.TestCase):
                 gamma_is_none=gamma_is_none,
                 beta_is_none=beta_is_none,
                 fuse_sigmoid_mul=True,
+                test_name="test_middle_slice_layer_norm_fuse_sigmoid_mul_float16",
             )
 
     @unittest.skipIf(
@@ -310,6 +323,7 @@ class SliceLayerNormTestCase(unittest.TestCase):
             beta_is_none=True,
             fuse_sigmoid_mul=False,
             dtype="float32",
+            test_name="test_slice_layer_norm_float32_1",
         )
         self._test_middle_slice_layer_norm_kernels(
             n_normalize_over_last_dims=2,
@@ -317,6 +331,7 @@ class SliceLayerNormTestCase(unittest.TestCase):
             beta_is_none=False,
             fuse_sigmoid_mul=False,
             dtype="float32",
+            test_name="test_slice_layer_norm_float32_2",
         )
         self._test_slice_layer_norm_kernels(
             n_normalize_over_last_dims=3,
@@ -324,6 +339,7 @@ class SliceLayerNormTestCase(unittest.TestCase):
             beta_is_none=True,
             fuse_sigmoid_mul=True,
             dtype="float32",
+            test_name="test_slice_layer_norm_float32_3",
         )
         self._test_middle_slice_layer_norm_kernels(
             n_normalize_over_last_dims=2,
@@ -331,6 +347,7 @@ class SliceLayerNormTestCase(unittest.TestCase):
             beta_is_none=False,
             fuse_sigmoid_mul=True,
             dtype="float32",
+            test_name="test_slice_layer_norm_float32_4",
         )
 
 

--- a/tests/unittest/ops/test_layernorm_sigmoid_mul.py
+++ b/tests/unittest/ops/test_layernorm_sigmoid_mul.py
@@ -46,6 +46,7 @@ class FusedLayernormSigmoidMulTestCase(unittest.TestCase):
         rtol=1e-2,
         eps=1e-5,
         dtype="float16",
+        use_welford_algorithm=False,
     ):
         logging.info(
             f"_test_fused_layernorm_sigmoid_mul: M={MS}, N={NS}, "
@@ -95,12 +96,14 @@ class FusedLayernormSigmoidMulTestCase(unittest.TestCase):
         X6._attrs["is_output"] = True
         X6._attrs["name"] = "output"
 
-        target = detect_target()
+        target = detect_target(
+            layernorm_use_welford_algorithm=use_welford_algorithm,
+        )
         with compile_model(
             X6,
             target,
             "./tmp",
-            f"fused_layernorm_sigmoid_mul_test_{self._test_id}",
+            f"fused_layernorm_sigmoid_mul_test_{dtype}_{self._test_id}",
         ) as module:
             self._test_id += 1
             for batch_size in [50, 900, 1024]:
@@ -184,20 +187,24 @@ class FusedLayernormSigmoidMulTestCase(unittest.TestCase):
             eps=eps,
             dtype="float16",
         )
-        # block_size = 512 kernel
-        self._test_fused_layernorm_sigmoid_mul(
-            MS=(2, 4),
-            NS=(1055, 5),
-            eps=eps,
-            dtype="float16",
-        )
 
-        self._test_fused_layernorm_sigmoid_mul(
-            NS=(1496,),
-            gamma_is_none=True,
-            beta_is_none=True,
-            dtype="float16",
-        )
+        for use_welford_algorithm in (True, False):
+            # block_size = 512 kernel
+            self._test_fused_layernorm_sigmoid_mul(
+                MS=(2, 4),
+                NS=(1055, 5),
+                eps=eps,
+                dtype="float16",
+                use_welford_algorithm=use_welford_algorithm,
+            )
+            self._test_fused_layernorm_sigmoid_mul(
+                NS=(1496,),
+                gamma_is_none=True,
+                beta_is_none=True,
+                dtype="float16",
+                use_welford_algorithm=use_welford_algorithm,
+            )
+
         self._test_fused_layernorm_sigmoid_mul(
             NS=(515,),
             gamma_is_none=True,
@@ -271,20 +278,24 @@ class FusedLayernormSigmoidMulTestCase(unittest.TestCase):
             eps=eps,
             dtype="float32",
         )
-        # block_size = 512 kernel
-        self._test_fused_layernorm_sigmoid_mul(
-            MS=(2, 4),
-            NS=(1055, 5),
-            eps=eps,
-            dtype="float32",
-        )
 
-        self._test_fused_layernorm_sigmoid_mul(
-            NS=(1496,),
-            gamma_is_none=True,
-            beta_is_none=True,
-            dtype="float32",
-        )
+        for use_welford_algorithm in (True, False):
+            # block_size = 512 kernel
+            self._test_fused_layernorm_sigmoid_mul(
+                MS=(2, 4),
+                NS=(1055, 5),
+                eps=eps,
+                dtype="float32",
+                use_welford_algorithm=use_welford_algorithm,
+            )
+            self._test_fused_layernorm_sigmoid_mul(
+                NS=(1496,),
+                gamma_is_none=True,
+                beta_is_none=True,
+                dtype="float32",
+                use_welford_algorithm=use_welford_algorithm,
+            )
+
         self._test_fused_layernorm_sigmoid_mul(
             NS=(515,),
             gamma_is_none=True,
@@ -345,24 +356,28 @@ class FusedLayernormSigmoidMulTestCase(unittest.TestCase):
             atol=1e-2,
             rtol=1e-2,
         )
-        # block_size = 512 kernel
-        self._test_fused_layernorm_sigmoid_mul(
-            MS=(2, 4),
-            NS=(1055, 5),
-            eps=eps,
-            dtype="bfloat16",
-            atol=1e-2,
-            rtol=1e-2,
-        )
 
-        self._test_fused_layernorm_sigmoid_mul(
-            NS=(1496,),
-            gamma_is_none=True,
-            beta_is_none=True,
-            dtype="bfloat16",
-            atol=1e-2,
-            rtol=1e-2,
-        )
+        for use_welford_algorithm in (True, False):
+            # block_size = 512 kernel
+            self._test_fused_layernorm_sigmoid_mul(
+                MS=(2, 4),
+                NS=(1055, 5),
+                eps=eps,
+                dtype="bfloat16",
+                atol=1e-2,
+                rtol=1e-2,
+                use_welford_algorithm=use_welford_algorithm,
+            )
+            self._test_fused_layernorm_sigmoid_mul(
+                NS=(1496,),
+                gamma_is_none=True,
+                beta_is_none=True,
+                dtype="bfloat16",
+                atol=1e-2,
+                rtol=1e-2,
+                use_welford_algorithm=use_welford_algorithm,
+            )
+
         self._test_fused_layernorm_sigmoid_mul(
             NS=(515,),
             gamma_is_none=True,


### PR DESCRIPTION
Summary: Welford's online [algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) for computing the variance is single-pass and sufficiently numerically stable. This diff adds an alternative CUDA back-end kernel based on Welford's algorithm for the `layernorm` op (together with its `layernorm_sigmoid_mul` fusion and `TensorAccessor` support). The kernel is based on the OneFlow's `layer_norm` kernel implementation (more details [here](https://oneflow2020.medium.com/how-to-implement-an-efficient-layernorm-cuda-kernel-oneflow-performance-optimization-731e91a285b8)).

Differential Revision: D45867506

