### PR TITLE
Add a flag for elementwise computation in float32

### DIFF
--- a/python/aitemplate/backend/backend_spec.py
+++ b/python/aitemplate/backend/backend_spec.py
@@ -91,7 +91,11 @@ class GPUBackendSpec(BackendSpec):
     backend_datatype_convertors: Dict[str, Dict[str, str]] = field(
         default_factory=lambda: {
             "half": {"float": "__half2float"},
-            "float": {"half": "__float2half_rn"},
+            "bfloat16": {"float": "__bfloat162float"},
+            "float": {
+                "half": "__float2half_rn",
+                "bfloat16": "__float2bfloat16_rn",
+            },
         }
     )
 


### PR DESCRIPTION
Summary:
Currently, the intermediate computations in `fused_elementwise` are made in the input / output type. This may lead to a poor end-to-end model accuracy, especially if the subgraph covered by the `fused_elementwise` is relatively large. Alternatively, all computations could be made in a more precise type, like `float32`.

In this diff, a new flag, `elementwise_use_fp32_acc`, is added for the `Target` to perform all intermediate computations in `float32` type in the `fused_elementwise` backend.

## Example of the generated code

This fused elementwise subgraph:

```
    X4 = ops.elementwise(FuncEnum.SIGN)(X1)
    X5 = ops.elementwise(FuncEnum.ABS)(X1)
    X6 = ops.elementwise(FuncEnum.ADD)(X5, X2)
    X7 = ops.elementwise(FuncEnum.LOGE)(X6)
    X8 = ops.elementwise(FuncEnum.MUL)(X4, X7)
    X9 = ops.elementwise(FuncEnum.MUL)(X8, X3)

```

With `elementwise_use_fp32_acc=False` in the `Target` (or not set at all == default):

```
    p_tmp_o0[i] = __hmul2(
        __hmul2(
            h2sign_custom(
                p_tmp_i1[i]
            ),
            h2log(
                __hadd2(
                    __habs2(
                        p_tmp_i1[i]
                    ),
                    half2(2.0,2.0)
                )
            )
        ),
        p_tmp_i0[i]
    );
```

With `elementwise_use_fp32_acc=True` in the `Target`:

```
    p_tmp_o0[i] = __float2half_rn(
        __fmul_rn(
            __fmul_rn(
                sign_custom<float>(
                    __half2float(
                        p_tmp_i0[i]
                    )
                ),
                logf(
                    __fadd_rn(
                        fabsf(
                            __half2float(
                                p_tmp_i0[i]
                            )
                        ),
                        float(2.0)))),
            __half2float(
                p_tmp_i1[i]
            )
        )
    );
```

Differential Revision: D45959405

