### PR TITLE
Fix fx2ait max/avg_pool with stride=None

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -1397,9 +1397,8 @@ def acc_ops_max_pool3d(
     if not isinstance(input_val, AITTensor):
         raise RuntimeError(f"Non-tensor inputs for {name}: {input_val}")
 
-    if (
-        isinstance(kwargs["kernel_size"], tuple)
-        and isinstance(kwargs["padding"], tuple)
+    if isinstance(kwargs["kernel_size"], tuple) and isinstance(
+        kwargs["padding"], tuple
     ):
         kernel_size_tuple = kwargs["kernel_size"]
         stride_tuple = kwargs["stride"] if kwargs["stride"] else kwargs["kernel_size"]
@@ -1414,10 +1413,7 @@ def acc_ops_max_pool3d(
         kernel_size = identical_elem_tuple_to_int(kernel_size_tuple[1:])
         stride = identical_elem_tuple_to_int(stride_tuple[1:])
         padding = identical_elem_tuple_to_int(padding_tuple[1:])
-    elif (
-        isinstance(kwargs["kernel_size"], int)
-        and isinstance(kwargs["padding"], int)
-    ):
+    elif isinstance(kwargs["kernel_size"], int) and isinstance(kwargs["padding"], int):
         kernel_size = kwargs["kernel_size"]
         stride = kwargs["stride"] if kwargs["stride"] else kwargs["kernel_size"]
         padding = kwargs["padding"]

--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -1399,11 +1399,10 @@ def acc_ops_max_pool3d(
 
     if (
         isinstance(kwargs["kernel_size"], tuple)
-        and isinstance(kwargs["stride"], tuple)
         and isinstance(kwargs["padding"], tuple)
     ):
         kernel_size_tuple = kwargs["kernel_size"]
-        stride_tuple = kwargs["stride"]
+        stride_tuple = kwargs["stride"] if kwargs["stride"] else kwargs["kernel_size"]
         padding_tuple = kwargs["padding"]
 
         assert kernel_size_tuple[0] == 1, "max_pool3d only supports kT == 1 currently"
@@ -1417,11 +1416,10 @@ def acc_ops_max_pool3d(
         padding = identical_elem_tuple_to_int(padding_tuple[1:])
     elif (
         isinstance(kwargs["kernel_size"], int)
-        and isinstance(kwargs["stride"], int)
         and isinstance(kwargs["padding"], int)
     ):
         kernel_size = kwargs["kernel_size"]
-        stride = kwargs["stride"]
+        stride = kwargs["stride"] if kwargs["stride"] else kwargs["kernel_size"]
         padding = kwargs["padding"]
     else:
         raise RuntimeError("Only int or tuple types are supported")
@@ -1470,7 +1468,11 @@ def acc_ops_max_pool2d(
         raise RuntimeError(f"Non-tensor inputs for {name}: {input_val}")
 
     kernel_size = identical_elem_tuple_to_int(kwargs["kernel_size"])
-    stride = identical_elem_tuple_to_int(kwargs["stride"])
+    stride = (
+        identical_elem_tuple_to_int(kwargs["stride"])
+        if kwargs["stride"]
+        else kernel_size
+    )
     padding = identical_elem_tuple_to_int(kwargs["padding"])
     ceil_mode = kwargs["ceil_mode"]
     return_indices = kwargs["return_indices"]
@@ -1494,7 +1496,11 @@ def acc_ops_avg_pool2d(
         raise RuntimeError(f"Non-tensor inputs for {name}: {input_val}")
 
     kernel_size = identical_elem_tuple_to_int(kwargs["kernel_size"])
-    stride = identical_elem_tuple_to_int(kwargs["stride"])
+    stride = (
+        identical_elem_tuple_to_int(kwargs["stride"])
+        if kwargs["stride"]
+        else kernel_size
+    )
     padding = identical_elem_tuple_to_int(kwargs["padding"])
     ceil_mode = kwargs["ceil_mode"]
     count_include_pad = kwargs["count_include_pad"]

--- a/fx2ait/fx2ait/test/converters/test_ait_pooling_ops.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_pooling_ops.py
@@ -1,0 +1,67 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+import torch
+import torch.nn.functional as F
+from fx2ait.acc_tracer import acc_ops
+from fx2ait.tools.common_fx2ait import AITTestCase
+from parameterized import parameterized
+
+
+class TestAitPoolingConverter(AITTestCase):
+    @parameterized.expand(
+        [
+            "avg_pool2d",
+            "max_pool2d",
+        ]
+    )
+    def test_pooling2d_with_default_inputs(self, opname):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fn = getattr(F, opname)
+
+            def forward(self, x):
+                return self.fn(x, 2)
+
+        model = TestModule().half().cuda()
+        inputs = [torch.randn(1, 4, 256, 256).cuda().half()]
+        self.run_test(
+            model,
+            inputs,
+            expected_ops={getattr(acc_ops, opname)},
+        )
+
+    @parameterized.expand(
+        [
+            "max_pool3d",
+        ]
+    )
+    def test_pooling3d_with_default_inputs(self, opname):
+        class TestModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fn = getattr(F, opname)
+
+            def forward(self, x):
+                return self.fn(x, 1)
+
+        model = TestModule().half().cuda()
+        inputs = [torch.randn(1, 4, 8, 256, 256).cuda().half()]
+        self.run_test(
+            model,
+            inputs,
+            expected_ops={getattr(acc_ops, opname)},
+        )


### PR DESCRIPTION
This PR fixed a minor issue in max_pool2d/3d, avg_pool2d fx2ait converter when the user did not explicitly provide stride that should default to kernel_size.

This is mainly for the following model to work with fx2ait.
```py
class MNIST(nn.Module):

  def __init__(self):
    super(MNIST, self).__init__()
    self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
    self.bn1 = nn.BatchNorm2d(10)
    self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
    self.bn2 = nn.BatchNorm2d(20)
    self.fc1 = nn.Linear(320, 50)
    self.fc2 = nn.Linear(50, 10)

  def forward(self, x):
    x = F.relu(F.max_pool2d(self.conv1(x), 2))
    x = self.bn1(x)
    x = F.relu(F.max_pool2d(self.conv2(x), 2))
    x = self.bn2(x)
    x = torch.flatten(x, 1)
    x = F.relu(self.fc1(x))
    x = self.fc2(x)
    return F.log_softmax(x, dim=1)
```