### PR TITLE
fx2ait: explicitly ensure workdir's existence

### DIFF
--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -207,6 +207,7 @@ def compile_model(
 
     recompile = os.getenv("AIT_RECOMPILE", "1")
     graph = None
+    os.makedirs(workdir, exist_ok=True)  # explicitly ensure workdir exists
     # Super important: we cannot have commas in the test name.
     # We want to add a -Iworkdir/test_name flag to nvcc, but
     # if the name has a comma in it, it will be parsed as two


### PR DESCRIPTION
Summary:
Right now the only thing that prevent a non-existent workdir from breaking the ait system, is an indirect mkdir call to create the `test_dir`, which is `workdir/ait_name`.

We shouldn't have just replied on that. We should have explicitly make sure workdir exist in the first place.

Reviewed By: amateurcoffee

Differential Revision: D46036294

