### PR TITLE
[FX2AIT] Fix 02_vision_model example

### DIFF
--- a/fx2ait/fx2ait/example/02_vision_model/README.md
+++ b/fx2ait/fx2ait/example/02_vision_model/README.md
@@ -20,10 +20,8 @@ Therefore the definition of model is as simple as
             def forward(self, x):
                 return self.mod(x)
 ```
-Notice that because AIT supports channel last, while pytorch supports channel first operation, we need to permute the input
-```
-inputs = [inp.permute([0, 2, 3, 1]).contiguous() for inp in inputs]
-``
+Notice that because AIT supports channel last, while pytorch supports channel first operation, FX2AIT automatically performs this layout conversion for you.
+
 To run the test and benchmark,
 ```
 python fx2ait/fx2ait/example/02_vision_model/test_vision_model.py

--- a/fx2ait/fx2ait/example/02_vision_model/test_vision_model.py
+++ b/fx2ait/fx2ait/example/02_vision_model/test_vision_model.py
@@ -36,7 +36,6 @@ class TestResNet(unittest.TestCase):
         verify_accuracy(
             model,
             inputs,
-            permute_inputs=[0, 2, 3, 1],
         )
         results = []
         for batch_size in [1, 8, 16, 32, 256, 512]:
@@ -47,7 +46,6 @@ class TestResNet(unittest.TestCase):
                     100,
                     model,
                     inputs,
-                    permute_inputs=[0, 2, 3, 1],
                 )
             )
         for res in results:


### PR DESCRIPTION
It appears fx2ait now automatically performs nchw to nhwc conversion for the user.

For some reason I didn't get good perf numbers but it should be a separate issue.
```
== Benchmark Result for: TestResNet
BS: 1, PT Eager time per iter: 0.0019565773010253905ms, PT Eager QPS: 511.10, FX2AIT time per iter: 0.001033175048828125ms, FX2AIT Eager QPS: 967.89, Speedup: 1.89, 
== Benchmark Result for: TestResNet
BS: 8, PT Eager time per iter: 0.002017873992919922ms, PT Eager QPS: 3964.57, FX2AIT time per iter: 0.0021129624938964844ms, FX2AIT Eager QPS: 3786.15, Speedup: 0.95, 
== Benchmark Result for: TestResNet
BS: 16, PT Eager time per iter: 0.0020058624267578124ms, PT Eager QPS: 7976.62, FX2AIT time per iter: 0.003464407043457031ms, FX2AIT Eager QPS: 4618.39, Speedup: 0.58, 
== Benchmark Result for: TestResNet
BS: 32, PT Eager time per iter: 0.0028792626953125ms, PT Eager QPS: 11113.96, FX2AIT time per iter: 0.006071419067382813ms, FX2AIT Eager QPS: 5270.60, Speedup: 0.47, 
== Benchmark Result for: TestResNet
BS: 256, PT Eager time per iter: 0.016274913330078123ms, PT Eager QPS: 15729.73, FX2AIT time per iter: 0.0487688818359375ms, FX2AIT Eager QPS: 5249.25, Speedup: 0.33, 
== Benchmark Result for: TestResNet
BS: 512, PT Eager time per iter: 0.031698186035156256ms, PT Eager QPS: 16152.34, FX2AIT time per iter: 0.100773662109375ms, FX2AIT Eager QPS: 5080.69, Speedup: 0.31, 
```