### PR TITLE
Disable residual in SM90 kernels of gemm_rcr / rrr

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_universal/bmm_common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/bmm_common.py
@@ -449,7 +449,7 @@ def gen_profiler(
 
     op_type = func_attrs["op"]
     op_instance = func_attrs["op_instance"]
-    op_instance = common.filter_cutlass_3x_ops(op_instance, func_attrs)
+    op_instance, _ = common.filter_cutlass_3x_ops(op_instance, func_attrs)
 
     backend_spec = CUDASpec()
     elem_type = backend_spec.dtype_to_backend_type(

--- a/python/aitemplate/backend/cuda/gemm_universal/common_bias_broadcast.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/common_bias_broadcast.py
@@ -610,7 +610,7 @@ def gen_profiler(
 
     op_type = func_attrs["op"]
     op_instance = func_attrs["op_instance"]
-    op_instance = common.filter_cutlass_3x_ops(op_instance, func_attrs)
+    op_instance, _ = common.filter_cutlass_3x_ops(op_instance, func_attrs)
 
     backend_spec = CUDASpec()
     elem_input_type = backend_spec.dtype_to_lib_type(


### PR DESCRIPTION
Summary: Since [7c04f95](https://github.com/NVIDIA/cutlass/commit/7c04f954151f606e60608061e891785fba229ae2) in `nvidia/cutlass` one can disable the residual to provide more SMEM for the mainloop. Here we're doing that for the bias-less GEMM ops.

Differential Revision: D46265004

