### PR TITLE
Pass bias vector via epilogue schedule in SM90 gemm_rcr_bias

### DIFF
--- a/python/aitemplate/backend/cuda/gemm_universal/bmm_common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/bmm_common.py
@@ -449,7 +449,7 @@ def gen_profiler(
 
     op_type = func_attrs["op"]
     op_instance = func_attrs["op_instance"]
-    op_instance = common.filter_cutlass_3x_ops(op_instance, func_attrs)
+    op_instance, _ = common.filter_cutlass_3x_ops(op_instance, func_attrs)
 
     backend_spec = CUDASpec()
     elem_type = backend_spec.dtype_to_backend_type(

--- a/python/aitemplate/backend/cuda/gemm_universal/common_bias_broadcast.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/common_bias_broadcast.py
@@ -610,7 +610,7 @@ def gen_profiler(
 
     op_type = func_attrs["op"]
     op_instance = func_attrs["op_instance"]
-    op_instance = common.filter_cutlass_3x_ops(op_instance, func_attrs)
+    op_instance, _ = common.filter_cutlass_3x_ops(op_instance, func_attrs)
 
     backend_spec = CUDASpec()
     elem_input_type = backend_spec.dtype_to_lib_type(

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias.py
@@ -28,6 +28,14 @@ from aitemplate.backend.cuda.gemm_universal.layout import RCR
 # pylint: disable=C0103,C0415,W0613,C0301,R1705,R1703
 
 
+EXTRA_CODE = jinja2.Template(
+    """
+using elem_input_type = {{elem_input_type}};
+using elem_output_type = {{elem_output_type}};
+"""
+)
+
+
 # used for real execution
 PROBLEM_ARGS_TEMPLATE = jinja2.Template(
     """
@@ -55,9 +63,31 @@ PROBLEM_ARGS_TEMPLATE = jinja2.Template(
 )
 
 
+# in case of TMA epilogue schedule, use the transposed problem to pass the
+# column-major bias vector through the bias + elementwise epilogue (not residual)
 PROBLEM_ARGS_TEMPLATE_CUTLASS_3X = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                     // GemmUniversalMode mode
+{% if has_tma_epilogue %}
+    {
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(K),
+        static_cast<coord_t>(1)
+    },                                                           // ProblemShape problem_shape
+    ({{elem_input_type}}*)(b_ptr) + input_b_offset,              // ElementA const* ptr_A
+    {input_b_stride, cute::Int<1>{}, cute::Int<0>{}},            // StrideA dA
+    ({{elem_input_type}}*)(a_ptr) + input_a_offset,              // ElementB const* ptr_B
+    {input_a_stride, cute::Int<1>{}, cute::Int<0>{}},            // StrideB dB
+    {
+        {ElementComputeEpilogue(1), ElementComputeEpilogue(0)},  // typename ThreadEpilogueOp::Params thread
+        nullptr,                                                 // ElementC const* ptr_C
+        {cute::Int<1>{}, cute::Int<0>{}, cute::Int<0>{}},        // StrideC dC
+        ({{elem_output_type}}*)(c_ptr) + output_offset,          // ElementD const* ptr_D
+        {cute::Int<1>{}, output_stride, cute::Int<0>{}},         // StrideD dD
+        ({{elem_input_type}}*)(bias_ptr),                        // ElementBias const* ptr_Bias
+    },                                                           // EpilogueArguments epilogue
+{% else %}
     {
         static_cast<coord_t>(M),
         static_cast<coord_t>(N),
@@ -75,6 +105,7 @@ PROBLEM_ARGS_TEMPLATE_CUTLASS_3X = jinja2.Template(
         ({{elem_output_type}}*)(c_ptr) + output_offset,          // ElementD const* ptr_D
         {output_stride, cute::Int<1>{}, cute::Int<0>{}},         // StrideD dD
     },                                                           // EpilogueArguments epilogue
+{% endif %}
 """
 )
 
@@ -106,9 +137,31 @@ PROFILER_PROBLEM_ARGS_TEMPLATE = jinja2.Template(
 )
 
 
+# in case of TMA epilogue schedule, use the transposed problem to pass the
+# column-major bias vector through the bias + elementwise epilogue (not residual)
 PROFILER_PROBLEM_ARGS_TEMPLATE_CUTLASS_3X = jinja2.Template(
     """
     cutlass::gemm::GemmUniversalMode::kGemm,                     // GemmUniversalMode mode
+{% if has_tma_epilogue %}
+    {
+        static_cast<coord_t>(N),
+        static_cast<coord_t>(M),
+        static_cast<coord_t>(K),
+        static_cast<coord_t>(1)
+    },                                                           // ProblemShape problem_shape
+    ({{elem_input_type}}*)(b_ptr),                               // ElementA const* ptr_A
+    {K, cute::Int<1>{}, cute::Int<0>{}},                         // StrideA dA
+    ({{elem_input_type}}*)(a_ptr),                               // ElementB const* ptr_B
+    {K, cute::Int<1>{}, cute::Int<0>{}},                         // StrideB dB
+    {
+        {ElementComputeEpilogue(1), ElementComputeEpilogue(0)},  // typename ThreadEpilogueOp::Params thread
+        nullptr,                                                 // ElementC const* ptr_C
+        {cute::Int<1>{}, cute::Int<0>{}, cute::Int<0>{}},        // StrideC dC
+        ({{elem_output_type}}*)(c_ptr) + output_offset,          // ElementD const* ptr_D
+        {cute::Int<1>{}, output_stride, cute::Int<0>{}},         // StrideD dD
+        ({{elem_input_type}}*)(bias_ptr),                        // ElementBias const* ptr_Bias
+    },                                                           // EpilogueArguments epilogue
+{% else %}
     {
         static_cast<coord_t>(M),
         static_cast<coord_t>(N),
@@ -126,6 +179,7 @@ PROFILER_PROBLEM_ARGS_TEMPLATE_CUTLASS_3X = jinja2.Template(
         ({{elem_output_type}}*)(c_ptr) + output_offset,          // ElementD const* ptr_D
         {output_stride, cute::Int<1>{}, cute::Int<0>{}},         // StrideD dD
     },                                                           // EpilogueArguments epilogue
+{% endif %}
 """
 )
 
@@ -134,9 +188,52 @@ PROFILER_PROBLEM_ARGS_TEMPLATE_CUTLASS_3X = jinja2.Template(
 def gemm_rcr_config(func_attrs, dtype="float16"):
     common.make_fproc(func_attrs, RCR, include_cutlass_3x_ops=True)
 
+    import cutlass_lib
+
+    for op in func_attrs["op_instance"].values():
+        if common.has_tma_epilogue(op):
+            # disable residual to leave more SMEM for the mainloop
+            op.C.element = cutlass_lib.library.DataType.void
+
+            # swap the output layout to the transposed problem
+            op.C.layout = cutlass_lib.library.LayoutType.ColumnMajor
+            op.D.layout = cutlass_lib.library.LayoutType.ColumnMajor
+
+            # change the TMA epilogue schedule to
+            # the corresponding bias + elementwise one
+            if (
+                op.epilogue_schedule
+                == cutlass_lib.library.EpilogueScheduleType.TmaWarpSpecialized
+            ):
+                op.epilogue_schedule = (
+                    cutlass_lib.library.EpilogueScheduleType.TmaWarpSpecializedBiasElementwise
+                )
+            elif (
+                op.epilogue_schedule
+                == cutlass_lib.library.EpilogueScheduleType.TmaWarpSpecializedCooperative
+            ):
+                op.epilogue_schedule = (
+                    cutlass_lib.library.EpilogueScheduleType.TmaWarpSpecializedCooperativeBiasElementwise
+                )
+            else:
+                raise ValueError(
+                    f"Unexpected epilouge schedule type: {op.epilogue_schedule}."
+                )
+
 
 @registry.reg("cuda.gemm_rcr_bias.gen_profiler")
 def gen_profiler(func_attrs, workdir, profiler_filename, dim_info_dict):
+    backend_spec = CUDASpec()
+    elem_input_type = backend_spec.dtype_to_lib_type(
+        func_attrs["inputs"][0]._attrs["dtype"]
+    )
+    elem_output_type = backend_spec.dtype_to_lib_type(
+        func_attrs["outputs"][0]._attrs["dtype"]
+    )
+    extra_code = EXTRA_CODE.render(
+        elem_input_type=elem_input_type,
+        elem_output_type=elem_output_type,
+    )
     return gemm_rcr.common_gen_profiler(
         func_attrs=func_attrs,
         workdir=workdir,
@@ -146,6 +243,7 @@ def gen_profiler(func_attrs, workdir, profiler_filename, dim_info_dict):
         problem_args_template=PROFILER_PROBLEM_ARGS_TEMPLATE,
         problem_args_template_cutlass_3x=PROFILER_PROBLEM_ARGS_TEMPLATE_CUTLASS_3X,
         bias_ptr_arg="memory_pool->RequestTensorByIdx(3)",
+        extra_code=extra_code,
     )
 
 
@@ -173,6 +271,14 @@ def gen_function(
     problem_args_cutlass_3x = PROBLEM_ARGS_TEMPLATE_CUTLASS_3X.render(
         elem_input_type=elem_input_type,
         elem_output_type=elem_output_type,
+        has_tma_epilogue=any(
+            common.has_tma_epilogue(func_attrs["op_instance"][exec_item.algo])
+            for exec_item in func_attrs["exec_path"].values()
+        ),
+    )
+    extra_code = EXTRA_CODE.render(
+        elem_input_type=elem_input_type,
+        elem_output_type=elem_output_type,
     )
     return common.gen_function(
         func_attrs=func_attrs,
@@ -189,6 +295,7 @@ def gen_function(
         output_addr_calculator=common.OUTPUT_ADDR_CALCULATOR.render(
             stride_dim="N", output_accessor=func_attrs["output_accessors"][0]
         ),
+        extra_code=extra_code,
     )
 
 

--- a/python/aitemplate/utils/mk_cutlass_lib/extra_enum.py
+++ b/python/aitemplate/utils/mk_cutlass_lib/extra_enum.py
@@ -166,6 +166,8 @@ class EpilogueScheduleType(enum.Enum):
   TmaWarpSpecializedCooperativeElementwiseGELU = enum_auto()
   TmaWarpSpecializedElementwiseFastGELU = enum_auto()
   TmaWarpSpecializedCooperativeElementwiseFastGELU = enum_auto()
+  TmaWarpSpecializedBiasElementwise = enum_auto()
+  TmaWarpSpecializedCooperativeBiasElementwise = enum_auto()
 
 EpilogueScheduleTag = {
   EpilogueScheduleType.ScheduleAuto: 'cutlass::epilogue::collective::EpilogueScheduleAuto',
@@ -187,6 +189,8 @@ EpilogueScheduleTag = {
   EpilogueScheduleType.TmaWarpSpecializedCooperativeElementwiseGELU: 'cutlass::epilogue::TmaWarpSpecializedCooperativeElementwise<cutlass::epilogue::thread::GELU>',
   EpilogueScheduleType.TmaWarpSpecializedElementwiseFastGELU: 'cutlass::epilogue::TmaWarpSpecializedElementwise<cutlass::epilogue::thread::GELU_taylor>',
   EpilogueScheduleType.TmaWarpSpecializedCooperativeElementwiseFastGELU: 'cutlass::epilogue::TmaWarpSpecializedCooperativeElementwise<cutlass::epilogue::thread::GELU_taylor>',
+  EpilogueScheduleType.TmaWarpSpecializedBiasElementwise: 'cutlass::epilogue::TmaWarpSpecializedBiasElementwise<cutlass::epilogue::thread::Identity, elem_input_type, cutlass::plus, false, elem_input_type>',
+  EpilogueScheduleType.TmaWarpSpecializedCooperativeBiasElementwise: 'cutlass::epilogue::TmaWarpSpecializedCooperativeBiasElementwise<cutlass::epilogue::thread::Identity, elem_input_type, cutlass::plus, false, elem_input_type>',
 }
 
 EpilogueScheduleSuffixes = {
@@ -209,6 +213,8 @@ EpilogueScheduleSuffixes = {
   EpilogueScheduleType.TmaWarpSpecializedCooperativeElementwiseGELU: '_epi_tma_gelu',
   EpilogueScheduleType.TmaWarpSpecializedElementwiseFastGELU: '_epi_tma_fast_gelu',
   EpilogueScheduleType.TmaWarpSpecializedCooperativeElementwiseFastGELU: '_epi_tma_fast_gelu',
+  EpilogueScheduleType.TmaWarpSpecializedBiasElementwise: '_epi_tma_bias',
+  EpilogueScheduleType.TmaWarpSpecializedCooperativeBiasElementwise: '_epi_tma_bias',
 }
 
 EpilogueScheduleMapping = {

--- a/tests/unittest/ops/test_gemm_bias.py
+++ b/tests/unittest/ops/test_gemm_bias.py
@@ -111,6 +111,7 @@ class GEMMBiasTestCase(unittest.TestCase):
         with env_variables(
             AIT_FORCE_CUTLASS_SM90_KERNELS="1",
             INSIDE_RE_WORKER="1",
+            FORCE_PROFILE="1",
         ):
             with self.assertRaisesRegex(
                 expected_exception=RuntimeError,


### PR DESCRIPTION
Summary: Since [7dbf423](https://github.com/NVIDIA/cutlass/commit/7dbf42376330230b9c5f0fe2a0ac1c167d1f1889) in `nvidia/cutlass` one can disable the residual and pass the bias vector through the `TmaWarpSpecializedBiasElementwise` epilogue schedule. When the bias vector is column-major, this leads to better performance. For that to work with the `gemm_rcr_bias` op (with the row-major bias and output) we use the transposed problem with swapped A / B and column-major bias and C.

Differential Revision: D46265703

