### PR TITLE
Add BFloat16 for debugging and messaging

### DIFF
--- a/static/csrc/model_container.cpp
+++ b/static/csrc/model_container.cpp
@@ -30,6 +30,8 @@ std::string GetEnumString(AITemplateDtype dtype) {
       return "kInt";
     case AITemplateDtype::kLong:
       return "kLong";
+    case AITemplateDtype::kBFloat16:
+      return "kBFloat16";
     default:
       return "unknown";
   }


### PR DESCRIPTION
Summary:
(1) We add the mapping of BFloat16 for printing out BFloat16's enum
(2) We add BFloat16 into debugging function in load_merge_net

Reviewed By: khabinov

Differential Revision: D46362371

