### PR TITLE
Move Pytorch Video related FE modules to fb/frontend/nn

### DIFF
--- a/python/aitemplate/frontend/nn/head.py
+++ b/python/aitemplate/frontend/nn/head.py
@@ -1,0 +1,177 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from typing import Callable
+
+from aitemplate.compiler import ops
+
+from aitemplate.frontend import Tensor
+from aitemplate.frontend.nn.dropout import Dropout
+from aitemplate.frontend.nn.linear import Linear
+from aitemplate.frontend.nn.module import Module
+from aitemplate.frontend.nn.softmax import Softmax
+
+
+class SequencePool(Module):
+    """
+    Sequence pool produces a single embedding from a sequence of embeddings. Currently
+    it supports "mean" and "cls".
+
+    """
+
+    def __init__(self, mode: str) -> None:
+        """
+        Args:
+            mode (str): Optionals include "cls" and "mean". If set to "cls", it assumes
+                the first element in the input is the cls token and returns it. If set
+                to "mean", it returns the mean of the entire sequence.
+        """
+        super().__init__()
+        assert mode in ["mean"], "Unsupported mode for SequencePool."
+        self.mode = mode
+
+    def forward(self, x: Tensor) -> Tensor:
+        # TODO: Add support for cls mode.
+        # if self.mode == "cls":
+        #     x = x[:, 0]
+        if self.mode == "mean":
+            x = ops.reduce_mean(1)(x)
+        else:
+            raise NotImplementedError
+        return x
+
+
+class VisionTransformerBasicHead(Module):
+    """
+    Vision transformer basic head.
+
+    ::
+
+                                      SequencePool
+                                           ↓
+                                        Dropout
+                                           ↓
+                                       Projection
+                                           ↓
+                                       Activation
+
+
+    The builder can be found in `create_vit_basic_head`.
+    """
+
+    def __init__(
+        self,
+        sequence_pool: Module = None,
+        dropout: Module = None,
+        proj: Module = None,
+        activation: Module = None,
+    ) -> None:
+        """
+        Args:
+            sequence_pool (torch.nn.modules): pooling module.
+            dropout(torch.nn.modules): dropout module.
+            proj (torch.nn.modules): project module.
+            activation (torch.nn.modules): activation module.
+        """
+        super().__init__()
+        self.sequence_pool = sequence_pool
+        self.dropout = dropout
+        self.proj = proj
+        self.activation = activation
+
+    def forward(self, x: Tensor) -> Tensor:
+        # Performs pooling.
+        if self.sequence_pool is not None:
+            x = self.sequence_pool(x)
+
+        # Performs dropout.
+        if self.dropout is not None:
+            x = self.dropout(x)
+        # Performs projection.
+        if self.proj is not None:
+            x = self.proj(x)
+        # Performs activation.
+        if self.activation is not None:
+            x = self.activation(x)
+        return x
+
+
+def create_vit_basic_head(
+    *,
+    # Projection configs.
+    in_features: int,
+    out_features: int,
+    # Pooling configs.
+    seq_pool_type: str = "cls",
+    # Dropout configs.
+    dropout_rate: float = 0.5,
+    # Activation configs.
+    activation: Callable = None,
+) -> Module:
+    """
+    Creates vision transformer basic head.
+
+    ::
+
+
+                                        Pooling
+                                           ↓
+                                        Dropout
+                                           ↓
+                                       Projection
+                                           ↓
+                                       Activation
+
+
+    Activation examples include: ReLU, Softmax, Sigmoid, and None.
+    Pool type examples include: cls, mean and none.
+
+    Args:
+
+        in_features: input channel size of the resnet head.
+        out_features: output channel size of the resnet head.
+
+        pool_type (str): Pooling type. It supports "cls", "mean " and "none". If set to
+            "cls", it assumes the first element in the input is the cls token and
+            returns it. If set to "mean", it returns the mean of the entire sequence.
+
+        activation (callable): a callable that constructs vision transformer head
+            activation layer, examples include: nn.ReLU, nn.Softmax, nn.Sigmoid, and
+            None (not applying activation).
+
+        dropout_rate (float): dropout rate.
+    """
+    assert seq_pool_type in ["cls", "mean", "none"]
+
+    if seq_pool_type in ["cls", "mean"]:
+        seq_pool_model = SequencePool(seq_pool_type)
+    elif seq_pool_type == "none":
+        seq_pool_model = None
+    else:
+        raise NotImplementedError
+
+    if activation is None:
+        activation_model = None
+    elif activation == Softmax:
+        activation_model = activation(dim=1)
+    else:
+        activation_model = activation()
+
+    return VisionTransformerBasicHead(
+        sequence_pool=seq_pool_model,
+        dropout=Dropout(dropout_rate) if dropout_rate > 0.0 else None,
+        proj=Linear(in_features, out_features),
+        activation=activation_model,
+    )

--- a/python/aitemplate/frontend/nn/patch_embed.py
+++ b/python/aitemplate/frontend/nn/patch_embed.py
@@ -1,0 +1,101 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+patch_embed Module.
+"""
+from typing import Callable, Tuple
+
+from aitemplate.compiler import ops
+from aitemplate.frontend import Tensor
+from aitemplate.frontend.nn.conv3d import Conv3d
+from aitemplate.frontend.nn.module import Module
+
+
+class PatchEmbed(Module):
+    """
+    Transformer basic patch embedding module. Performs patchifying input and flatten
+
+    ::
+
+                                       PatchModel
+                                           ↓
+                                        flatten
+
+    ::
+
+    output shape: [N, D*H*W, C]
+
+    """
+
+    def __init__(
+        self,
+        patch_model,
+    ) -> None:
+        super().__init__()
+        self.patch_model = patch_model
+
+    def forward(self, *args) -> Tensor:
+        assert len(args) == 1
+        x = args[0]
+
+        x = self.patch_model(x)
+        x = ops.flatten(start_dim=1, end_dim=-2)(x)
+        return x
+
+
+def create_conv_patch_embed(
+    *,
+    in_channels: int,
+    out_channels: int,
+    conv_kernel_size: Tuple[int] = (1, 16, 16),
+    conv_stride: Tuple[int] = (1, 4, 4),
+    conv_padding: Tuple[int] = (1, 7, 7),
+    conv_bias: bool = True,
+    conv: Callable = Conv3d,
+) -> Module:
+    """
+    Creates the transformer basic patch embedding. It performs Convolution, flatten and
+    transpose.
+
+    ::
+
+                                        Conv3d
+                                           ↓
+                                        flatten
+                                           ↓
+                                       transpose
+
+    Args:
+        in_channels (int): input channel size of the convolution.
+        out_channels (int): output channel size of the convolution.
+        conv_kernel_size (tuple): convolutional kernel size(s).
+        conv_stride (tuple): convolutional stride size(s).
+        conv_padding (tuple): convolutional padding size(s).
+        conv_bias (bool): convolutional bias. If true, adds a learnable bias to the
+            output.
+        conv (callable): Callable used to build the convolution layer.
+
+    Returns:
+        (nn.Module): transformer patch embedding layer.
+    """
+    conv_module = conv(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=conv_kernel_size,
+        stride=conv_stride,
+        padding=conv_padding,
+        bias=conv_bias,
+    )
+    return PatchEmbed(patch_model=conv_module)

--- a/python/aitemplate/frontend/nn/positional_encoding.py
+++ b/python/aitemplate/frontend/nn/positional_encoding.py
@@ -1,0 +1,200 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+positional_encoding Modules.
+"""
+import logging
+from typing import Tuple
+
+from aitemplate.compiler import ops
+from aitemplate.compiler.base import IntImm
+from aitemplate.compiler.ops.common.epilogue import FuncEnum
+from aitemplate.frontend import Tensor
+from aitemplate.frontend.nn.module import Module
+from aitemplate.frontend.nn.parameter import Parameter
+
+_LOGGER = logging.getLogger(__name__)
+
+# These op implementations are copied from: https://fburl.com/code/o0qhusw6.
+# TODO: Move these to proper AIT op FEs
+def tile(input_val, dims):
+    shape_dims = list(dims)
+    input_dim_len = len(input_val.shape())
+    result = input_val
+    if len(shape_dims) < input_dim_len:
+        for _ in range(input_dim_len - len(shape_dims)):
+            shape_dims.insert(0, 1)
+    if input_dim_len < len(shape_dims):
+        shape = input_val.shape()
+        for _ in range(len(shape_dims) - input_dim_len):
+            shape.insert(0, IntImm(1))
+        result = ops.expand()(input_val, shape)
+
+    for i, shape in enumerate(shape_dims):
+        # Avoid operate on batch_size dim
+        if input_val.shape()[i]._attrs["name"] is not None:
+            continue
+        cat_groups = [result] * shape
+        result = ops.concatenate()(cat_groups, dim=i)
+    return result
+
+
+def repeat(input_val, dims):
+    if (
+        isinstance(dims, (list, tuple))
+        and len(dims) > 0
+        and not all(isinstance(x, int) for x in dims)
+    ):
+        _LOGGER.info("Not mapping repeat to an op. We can't handle variable dims.")
+        return input_val
+    return tile(input_val, dims)
+
+
+def repeat_interleave(input_val, repeats, dim=None):
+    if not (type(repeats) is int):
+        _LOGGER.info(
+            "Not mapping repeat_interleave to an acc op. We currently only support `repeat_interleave` with int repeats"
+        )
+        return
+    assert (
+        type(repeats) is int
+    ), "We currently only support `repeat_interleave` with int repeats"
+    rank = len(input_val.shape())
+    if dim is None:
+        repeat_dim = rank - 1
+    else:
+        assert type(dim) is int, "dim should be an int"
+        repeat_dim = dim
+    tile_dims = [1] * (rank + 1)
+    tile_dims[repeat_dim + 1] = repeats
+
+    x = ops.unsqueeze(repeat_dim + 1)(input_val)
+    x = tile(x, tuple(tile_dims))
+    new_shape = []
+    if dim is not None:
+        if dim < 0:
+            repeat_dim = dim + rank
+        else:
+            repeat_dim = dim
+        size_node = input_val.shape()
+        for i in range(rank):
+            shape_i = ops.getitem()(size_node, i)
+            if i == repeat_dim:
+                new_shape.append(-1)
+            else:
+                new_shape.append(shape_i)
+    else:
+        new_shape.append(-1)
+
+    x = ops.reshape()(x, new_shape)
+    return x
+
+
+class SpatioTemporalClsPositionalEncoding(Module):
+    """
+    Add a cls token and apply a spatiotemporal encoding to a tensor.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int,
+        patch_embed_shape: Tuple[int, int, int],
+        sep_pos_embed: bool = False,
+        has_cls: bool = True,
+        dtype: str = "float16",
+    ) -> None:
+        """
+        Args:
+            embed_dim (int): Embedding dimension for input sequence.
+            patch_embed_shape (Tuple): The number of patches in each dimension
+                (T, H, W) after patch embedding.
+            sep_pos_embed (bool): If set to true, one positional encoding is used for
+                spatial patches and another positional encoding is used for temporal
+                sequence. Otherwise, only one positional encoding is used for all the
+                patches.
+            has_cls (bool): If set to true, a cls token is added in the beginning of each
+                input sequence.
+        """
+        super().__init__()
+        assert (
+            len(patch_embed_shape) == 3
+        ), "Patch_embed_shape should be in the form of (T, H, W)."
+        self.cls_embed_on = has_cls
+        self.sep_pos_embed = sep_pos_embed
+        self._patch_embed_shape = tuple(patch_embed_shape)
+        self.num_spatial_patch = patch_embed_shape[1] * patch_embed_shape[2]
+        self.num_temporal_patch = patch_embed_shape[0]
+
+        if self.cls_embed_on:
+            self.cls_token = Parameter(shape=[1, 1, embed_dim], dtype=dtype)
+            num_patches = self.num_spatial_patch * self.num_temporal_patch + 1
+        else:
+            self.cls_token = Parameter(shape=[], value=0, dtype=dtype)
+            num_patches = self.num_spatial_patch * self.num_temporal_patch
+
+        if self.sep_pos_embed:
+            self.pos_embed_spatial = Parameter(
+                shape=[1, self.num_spatial_patch, embed_dim],
+                dtype=dtype,
+            )
+            self.pos_embed_temporal = Parameter(
+                shape=[1, self.num_temporal_patch, embed_dim],
+                dtype=dtype,
+            )
+            if self.cls_embed_on:
+                self.pos_embed_class = Parameter(shape=[1, 1, embed_dim], dtype=dtype)
+            else:
+                self.pos_embed_class = Parameter(shape=[], dtype=dtype)
+            self.pos_embed = Parameter(shape=[], dtype=dtype)
+
+        else:
+            self.pos_embed = Parameter(shape=[1, num_patches, embed_dim], dtype=dtype)
+            # Placeholders for torchscriptability, won't be used
+            self.pos_embed_spatial = Parameter(shape=[], dtype=dtype)
+            self.pos_embed_temporal = Parameter(shape=[], dtype=dtype)
+            self.pos_embed_class = Parameter(shape=[], dtype=dtype)
+
+    def patch_embed_shape(self) -> Tuple[int, int, int]:
+        return self._patch_embed_shape
+
+    def forward(self, x: Tensor) -> Tensor:
+        """
+        Args:
+            x (Tensor): Input tensor.
+        """
+        B, N, C = x.shape()
+        if self.cls_embed_on:
+            cls_tokens = ops.expand()(self.cls_token.tensor(), [B, -1, -1])
+            x = ops.concatenate()([cls_tokens, x], dim=1)
+
+        if self.sep_pos_embed:
+            pos_embed = ops.elementwise(FuncEnum.ADD)(
+                repeat(
+                    self.pos_embed_spatial.tensor(), (1, self.num_temporal_patch, 1)
+                ),
+                repeat_interleave(
+                    self.pos_embed_temporal.tensor(), self.num_spatial_patch, dim=1
+                ),
+            )
+
+            if self.cls_embed_on:
+                pos_embed = ops.concatenate()(
+                    [self.pos_embed_class.tensor(), pos_embed], dim=1
+                )
+            x = ops.elementwise(FuncEnum.ADD)(x, pos_embed)
+        else:
+            x = ops.elementwise(FuncEnum.ADD)(x, self.pos_embed.tensor())
+
+        return x

--- a/python/aitemplate/frontend/nn/vision_transformers.py
+++ b/python/aitemplate/frontend/nn/vision_transformers.py
@@ -1,0 +1,443 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import warnings
+from functools import partial
+from typing import Callable, List, Optional, Tuple, Union
+
+import torch
+
+from aitemplate.frontend import Tensor
+from aitemplate.frontend.nn.batch_norm import BatchNorm1d, BatchNorm3d
+from aitemplate.frontend.nn.container import ModuleList
+from aitemplate.frontend.nn.conv2d import Conv2d
+from aitemplate.frontend.nn.conv3d import Conv3d
+from aitemplate.frontend.nn.dropout import Dropout
+
+from aitemplate.frontend.nn.head import create_vit_basic_head
+from aitemplate.frontend.nn.identity import Identity
+from aitemplate.frontend.nn.layer_norm import LayerNorm
+from aitemplate.frontend.nn.module import Module
+from aitemplate.frontend.nn.multiscale_attention import MultiScaleBlock
+from aitemplate.frontend.nn.patch_embed import create_conv_patch_embed
+from aitemplate.frontend.nn.positional_encoding import (
+    SpatioTemporalClsPositionalEncoding,
+)
+from pytorchvideo.layers.utils import round_width
+
+
+class MultiscaleVisionTransformers(Module):
+    """
+    Multiscale Vision Transformers
+    Haoqi Fan, Bo Xiong, Karttikeya Mangalam, Yanghao Li, Zhicheng Yan, Jitendra Malik,
+    Christoph Feichtenhofer
+    https://arxiv.org/abs/2104.11227
+
+    ::
+
+                                       PatchEmbed
+                                           ↓
+                                   PositionalEncoding
+                                           ↓
+                                        Dropout
+                                           ↓
+                                     Normalization
+                                           ↓
+                                         Block 1
+                                           ↓
+                                           .
+                                           .
+                                           .
+                                           ↓
+                                         Block N
+                                           ↓
+                                     Normalization
+                                           ↓
+                                          Head
+
+
+    The builder can be found in `create_mvit`.
+    """
+
+    def __init__(
+        self,
+        *,
+        patch_embed: Optional[Module],
+        cls_positional_encoding: Module,
+        pos_drop: Optional[Module],
+        blocks: ModuleList,
+        norm_embed: Optional[Module],
+        head: Optional[Module],
+    ) -> None:
+        """
+        Args:
+            patch_embed (nn.Module): Patch embed module.
+            cls_positional_encoding (nn.Module): Positional encoding module.
+            pos_drop (Optional[nn.Module]): Dropout module after patch embed.
+            blocks (nn.ModuleList): Stack of multi-scale transformer blocks.
+            norm_layer (nn.Module): Normalization layer before head.
+            head (Optional[nn.Module]): Head module.
+        """
+        super().__init__()
+
+        assert hasattr(
+            cls_positional_encoding, "patch_embed_shape"
+        ), "cls_positional_encoding should have method patch_embed_shape."
+
+        self.patch_embed = patch_embed or Identity()
+        self.cls_positional_encoding = cls_positional_encoding
+        self.pos_drop = pos_drop or Identity()
+        self.blocks = blocks
+        self.norm_embed = norm_embed or Identity()
+        self.head = head or Identity()
+
+    # TODO: Add support for batchnorm fusion
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.patch_embed(x)
+        x = self.cls_positional_encoding(x)
+        x = self.pos_drop(x)
+
+        thw = self.cls_positional_encoding.patch_embed_shape()
+        for blk in self.blocks:
+            t_shape, h_shape, w_shape = thw
+            x, thw = blk(x, t_shape, h_shape, w_shape)
+        x = self.norm_embed(x)
+        x = self.head(x)
+        return x
+
+
+def create_multiscale_vision_transformers(
+    *,
+    spatial_size: Union[int, Tuple[int, int]],
+    temporal_size: int,
+    cls_embed_on: bool = True,
+    sep_pos_embed: bool = True,
+    depth: int = 16,
+    norm: str = "layernorm",
+    # Patch embed config.
+    enable_patch_embed: bool = True,
+    input_channels: int = 3,
+    patch_embed_dim: int = 96,
+    conv_patch_embed_kernel: Tuple[int] = (3, 7, 7),
+    conv_patch_embed_stride: Tuple[int] = (2, 4, 4),
+    conv_patch_embed_padding: Tuple[int] = (1, 3, 3),
+    enable_patch_embed_norm: bool = False,
+    use_2d_patch: bool = False,
+    # Attention block config.
+    num_heads: int = 1,
+    mlp_ratio: float = 4.0,
+    qkv_bias: bool = True,
+    dropout_rate_block: float = 0.0,
+    droppath_rate_block: float = 0.0,
+    pooling_mode: str = "conv",
+    pool_first: bool = False,
+    residual_pool: bool = False,
+    depthwise_conv: bool = True,
+    bias_on: bool = True,
+    separate_qkv: bool = True,
+    embed_dim_mul: Optional[List[List[int]]] = None,
+    atten_head_mul: Optional[List[List[int]]] = None,
+    dim_mul_in_att: bool = False,
+    pool_q_stride_size: Optional[List[List[int]]] = None,
+    pool_kv_stride_size: Optional[List[List[int]]] = None,
+    pool_kv_stride_adaptive: Optional[Union[int, Tuple[int, int, int]]] = None,
+    pool_kvq_kernel: Optional[Union[int, Tuple[int, int, int]]] = None,
+    # Head config.
+    head: Optional[Callable] = create_vit_basic_head,
+    head_dropout_rate: float = 0.5,
+    head_activation: Callable = None,
+    head_num_classes: int = 400,
+    # The default model definition is not TorchScript-friendly.
+    # Set create_scriptable_model=True to create a TorchScriptable model.
+    create_scriptable_model: bool = False,
+    multiscale_vit_class: Callable = MultiscaleVisionTransformers,
+) -> Module:
+    """
+    Build Multiscale Vision Transformers (MViT) for recognition. A Vision Transformer
+    (ViT) is a specific case of MViT that only uses a single scale attention block.
+
+    Args:
+        spatial_size (_size_2_t): Input video spatial resolution (H, W). If a single
+            int is given, it assumes the width and the height are the same.
+        temporal_size (int): Number of frames in the input video.
+        cls_embed_on (bool): If True, use cls embed in the model. Otherwise features
+            are average pooled before going to the final classifier.
+        sep_pos_embed (bool): If True, perform separate spatiotemporal embedding.
+        depth (int): The depth of the model.
+        norm (str): Normalization layer. It currently supports "layernorm".
+
+        enable_patch_embed (bool): If true, patchify the input video. If false, it
+            assumes the input should have the feature dimension of patch_embed_dim.
+        input_channels (int): Channel dimension of the input video.
+        patch_embed_dim (int): Embedding dimension after patchifing the video input.
+        conv_patch_embed_kernel (Tuple[int]): Kernel size of the convolution for
+            patchifing the video input.
+        conv_patch_embed_stride (Tuple[int]): Stride size of the convolution for
+            patchifing the video input.
+        conv_patch_embed_padding (Tuple[int]): Padding size of the convolution for
+            patchifing the video input.
+        enable_patch_embed_norm (bool): If True, apply normalization after patchifing
+            the video input.
+        use_2d_patch (bool): If True, use 2D convolutions to get patch embed.
+            Otherwise, use 3D convolutions.
+
+        num_heads (int): Number of heads in the first transformer block.
+        mlp_ratio (float): Mlp ratio which controls the feature dimension in the
+            hidden layer of the Mlp block.
+        qkv_bias (bool): If set to False, the qkv layer will not learn an additive
+            bias. Default: True.
+        dropout_rate_block (float): Dropout rate for the attention block.
+        droppath_rate_block (float): Droppath rate for the attention block.
+        pooling_mode (str): Pooling mode. Option includes "conv" (learned pooling), "avg"
+            (average pooling), and "max" (max pooling).
+        pool_first (bool): If set to True, pool is applied before qkv projection.
+            Otherwise, pool is applied after qkv projection. Default: False.
+        residual_pool (bool): If set to True, use Improved Multiscale Vision
+                Transformer's pooling residual connection.
+        depthwise_conv (bool): Whether use depthwise or full convolution for pooling.
+        bias_on (bool): Whether use biases for linear layers.
+        separate_qkv (bool): Whether to use separate or one layer for qkv projections.
+        embed_dim_mul (Optional[List[List[int]]]): Dimension multiplication at layer i.
+            If X is used, then the next block will increase the embed dimension by X
+            times. Format: [depth_i, mul_dim_ratio].
+        atten_head_mul (Optional[List[List[int]]]): Head dimension multiplication at
+            layer i. If X is used, then the next block will increase the head by
+            X times. Format: [depth_i, mul_dim_ratio].
+        dim_mul_in_att (bool): If set to True, dimension expansion happens inside
+                the attention module, otherwise it happens in the Mlp block. Default: False.
+        pool_q_stride_size (Optional[List[List[int]]]): List of stride sizes for the
+            pool q at each layer. Format:
+            [[i, stride_t_i, stride_h_i, stride_w_i], ...,].
+        pool_kv_stride_size (Optional[List[List[int]]]): List of stride sizes for the
+            pool kv at each layer. Format:
+            [[i, stride_t_i, stride_h_i, stride_w_i], ...,].
+        pool_kv_stride_adaptive (Optional[_size_3_t]): Initial kv stride size for the
+            first block. The stride size will be further reduced at the layer where q
+            is pooled with the ratio of the stride of q pooling. If
+            pool_kv_stride_adaptive is set, then pool_kv_stride_size should be none.
+        pool_kvq_kernel (Optional[_size_3_t]): Pooling kernel size for q and kv. It None,
+            the kernel_size is [s + 1 if s > 1 else s for s in stride_size].
+
+        head (Callable): Head model.
+        head_dropout_rate (float): Dropout rate in the head.
+        head_activation (Callable): Activation in the head.
+        head_num_classes (int): Number of classes in the final classification head.
+        multiscale_vit_class (Callable): MViT transformer class. Default to
+            MultiscaleVisionTransformers.
+
+    Example usage (building a MViT_B model for Kinetics400):
+
+        spatial_size = 224
+        temporal_size = 16
+        embed_dim_mul = [[1, 2.0], [3, 2.0], [14, 2.0]]
+        atten_head_mul = [[1, 2.0], [3, 2.0], [14, 2.0]]
+        pool_q_stride_size = [[1, 1, 2, 2], [3, 1, 2, 2], [14, 1, 2, 2]]
+        pool_kv_stride_adaptive = [1, 8, 8]
+        pool_kvq_kernel = [3, 3, 3]
+        head_num_classes = 400
+        MViT_B = create_multiscale_vision_transformers(
+            spatial_size=spatial_size,
+            temporal_size=temporal_size,
+            embed_dim_mul=embed_dim_mul,
+            atten_head_mul=atten_head_mul,
+            pool_q_stride_size=pool_q_stride_size,
+            pool_kv_stride_adaptive=pool_kv_stride_adaptive,
+            pool_kvq_kernel=pool_kvq_kernel,
+            head_num_classes=head_num_classes,
+        )
+    """
+
+    if use_2d_patch:
+        assert temporal_size == 1, "If use_2d_patch, temporal_size needs to be 1."
+    if pool_kv_stride_adaptive is not None:
+        assert (
+            pool_kv_stride_size is None
+        ), "pool_kv_stride_size should be none if pool_kv_stride_adaptive is set."
+    if norm == "layernorm":
+        norm_layer = partial(LayerNorm, eps=1e-6)
+        block_norm_layer = partial(LayerNorm, eps=1e-6)
+        attn_norm_layer = partial(LayerNorm, eps=1e-6)
+    elif norm == "batchnorm":
+        norm_layer = None
+        block_norm_layer = BatchNorm1d
+        attn_norm_layer = BatchNorm3d
+    else:
+        raise NotImplementedError("Only supports layernorm.")
+    if create_scriptable_model:
+        assert (
+            norm == "batchnorm"
+        ), "The scriptable model supports only the batchnorm-based model."
+        warnings.warn(
+            "`create_scriptable_model` is deprecated. MultiscaleVisionTransformers"
+            " now supports scripting without this flag.",
+            DeprecationWarning,
+        )
+
+    if isinstance(spatial_size, int):
+        spatial_size = (spatial_size, spatial_size)
+
+    conv_patch_op = Conv2d if use_2d_patch else Conv3d
+
+    patch_embed = (
+        create_conv_patch_embed(
+            in_channels=input_channels,
+            out_channels=patch_embed_dim,
+            conv_kernel_size=conv_patch_embed_kernel,
+            conv_stride=conv_patch_embed_stride,
+            conv_padding=conv_patch_embed_padding,
+            conv=conv_patch_op,
+        )
+        if enable_patch_embed
+        else None
+    )
+
+    input_dims = [temporal_size, spatial_size[0], spatial_size[1]]
+    input_stride = (
+        (1,) + tuple(conv_patch_embed_stride)
+        if use_2d_patch
+        else conv_patch_embed_stride
+    )
+
+    patch_embed_shape = (
+        [input_dims[i] // input_stride[i] for i in range(len(input_dims))]
+        if enable_patch_embed
+        else input_dims
+    )
+
+    cls_positional_encoding = SpatioTemporalClsPositionalEncoding(
+        embed_dim=patch_embed_dim,
+        patch_embed_shape=patch_embed_shape,
+        sep_pos_embed=sep_pos_embed,
+        has_cls=cls_embed_on,
+    )
+
+    dpr = [
+        x.item() for x in torch.linspace(0, droppath_rate_block, depth)
+    ]  # stochastic depth decay rule
+
+    if dropout_rate_block > 0.0:
+        pos_drop = Dropout(p=dropout_rate_block)
+
+    dim_mul, head_mul = torch.ones(depth + 1), torch.ones(depth + 1)
+    if embed_dim_mul is not None:
+        for i in range(len(embed_dim_mul)):
+            dim_mul[embed_dim_mul[i][0]] = embed_dim_mul[i][1]
+    if atten_head_mul is not None:
+        for i in range(len(atten_head_mul)):
+            head_mul[atten_head_mul[i][0]] = atten_head_mul[i][1]
+
+    mvit_blocks = ModuleList()
+
+    pool_q = [[] for i in range(depth)]
+    pool_kv = [[] for i in range(depth)]
+    stride_q = [[] for i in range(depth)]
+    stride_kv = [[] for i in range(depth)]
+
+    if pool_q_stride_size is not None:
+        for i in range(len(pool_q_stride_size)):
+            stride_q[pool_q_stride_size[i][0]] = pool_q_stride_size[i][1:]
+            if pool_kvq_kernel is not None:
+                pool_q[pool_q_stride_size[i][0]] = pool_kvq_kernel
+            else:
+                pool_q[pool_q_stride_size[i][0]] = [
+                    s + 1 if s > 1 else s for s in pool_q_stride_size[i][1:]
+                ]
+
+    # If POOL_KV_STRIDE_ADAPTIVE is not None, initialize POOL_KV_STRIDE.
+    if pool_kv_stride_adaptive is not None:
+        _stride_kv = pool_kv_stride_adaptive
+        pool_kv_stride_size = []
+        for i in range(depth):
+            if len(stride_q[i]) > 0:
+                _stride_kv = [
+                    max(_stride_kv[d] // stride_q[i][d], 1)
+                    for d in range(len(_stride_kv))
+                ]
+            pool_kv_stride_size.append([i] + _stride_kv)
+
+    if pool_kv_stride_size is not None:
+        for i in range(len(pool_kv_stride_size)):
+            stride_kv[pool_kv_stride_size[i][0]] = pool_kv_stride_size[i][1:]
+            if pool_kvq_kernel is not None:
+                pool_kv[pool_kv_stride_size[i][0]] = pool_kvq_kernel
+            else:
+                pool_kv[pool_kv_stride_size[i][0]] = [
+                    s + 1 if s > 1 else s for s in pool_kv_stride_size[i][1:]
+                ]
+
+    dim_in = patch_embed_dim
+    for i in range(depth):
+        num_heads = round_width(num_heads, head_mul[i], min_width=1, divisor=1)
+        if dim_mul_in_att:
+            dim_out = round_width(
+                dim_in,
+                dim_mul[i],
+                divisor=round_width(num_heads, head_mul[i]),
+            )
+        else:
+            dim_out = round_width(
+                dim_in,
+                dim_mul[i + 1],
+                divisor=round_width(num_heads, head_mul[i + 1]),
+            )
+
+        mvit_blocks.append(
+            MultiScaleBlock(
+                dim=dim_in,
+                dim_out=dim_out,
+                num_heads=num_heads,
+                seq_len=6272,
+                mlp_ratio=mlp_ratio,
+                qkv_bias=qkv_bias,
+                dropout_rate=dropout_rate_block,
+                droppath_rate=dpr[i],
+                norm_layer=block_norm_layer,
+                attn_norm_layer=attn_norm_layer,
+                kernel_q=pool_q[i],
+                kernel_kv=pool_kv[i],
+                stride_q=stride_q[i],
+                stride_kv=stride_kv[i],
+                pool_mode=pooling_mode,
+                has_cls_embed=cls_embed_on,
+                pool_first=pool_first,
+                residual_pool=residual_pool,
+                bias_on=bias_on,
+                depthwise_conv=depthwise_conv,
+                separate_qkv=separate_qkv,
+            )
+        )
+        dim_in = dim_out
+
+    norm_embed = None if norm_layer is None else norm_layer(dim_in)
+    if head is not None:
+        head_model = head(
+            in_features=dim_in,
+            out_features=head_num_classes,
+            seq_pool_type="cls" if cls_embed_on else "mean",
+            dropout_rate=head_dropout_rate,
+            activation=head_activation,
+        )
+    else:
+        head_model = None
+
+    return multiscale_vit_class(
+        patch_embed=patch_embed,
+        cls_positional_encoding=cls_positional_encoding,
+        pos_drop=pos_drop if dropout_rate_block > 0.0 else None,
+        blocks=mvit_blocks,
+        norm_embed=norm_embed,
+        head=head_model,
+    )


### PR DESCRIPTION
Summary: This diff moves mvit related FE modules over from internal folder to appropriate `frontend/nn` folder and disambiguates test names to avoid race conditions during parallel test runs

Differential Revision: D46442470

