### PR TITLE
Fix SD compilation example to use user provided H and W

### DIFF
--- a/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
@@ -14,14 +14,14 @@
 #
 
 from aitemplate.compiler import compile_model
-from aitemplate.frontend import IntVar, Tensor
+from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 
 from ..modeling.clip import CLIPTextTransformer as ait_CLIPTextTransformer
 from .util import mark_output
 
 
-def map_clip_params(pt_mod, batch_size, seqlen, depth):
+def map_clip_params(pt_mod):
     params_ait = {}
     pt_params = dict(pt_mod.named_parameters())
     for key, arr in pt_params.items():
@@ -69,8 +69,7 @@ def compile_clip(
     ait_mod.name_parameter_tensor()
 
     pt_mod = pt_mod.eval()
-    params_ait = map_clip_params(pt_mod, batch_size, seqlen, depth)
-    batch_size = IntVar(values=[1, 8], name="batch_size")
+    params_ait = map_clip_params(pt_mod)
 
     input_ids_ait = Tensor(
         [batch_size, seqlen], name="input0", dtype="int64", is_input=True

--- a/examples/05_stable_diffusion/src/compile_lib/compile_unet.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_unet.py
@@ -15,7 +15,7 @@
 import torch
 
 from aitemplate.compiler import compile_model
-from aitemplate.frontend import IntVar, Tensor
+from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
 
 from ..modeling.unet_2d_condition import (
@@ -72,12 +72,9 @@ def compile_unet(
     # set AIT parameters
     pt_mod = pt_mod.eval()
     params_ait = map_unet_params(pt_mod, dim)
-    # batch_size = IntVar(values=[1, 8], name="batch_size")
-    height_d = IntVar(values=[32, 64], name="height")
-    width_d = IntVar(values=[32, 64], name="width")
 
     latent_model_input_ait = Tensor(
-        [batch_size, height_d, width_d, 4], name="input0", is_input=True
+        [batch_size, height, width, 4], name="input0", is_input=True
     )
     timesteps_ait = Tensor([batch_size], name="input1", is_input=True)
     text_embeddings_pt_ait = Tensor(

--- a/python/aitemplate/frontend/nn/vision_transformers.py
+++ b/python/aitemplate/frontend/nn/vision_transformers.py
@@ -18,6 +18,7 @@ from functools import partial
 from typing import Callable, List, Optional, Tuple, Union
 
 import torch
+from pytorchvideo.layers.utils import round_width
 
 from aitemplate.frontend import Tensor
 from aitemplate.frontend.nn.batch_norm import BatchNorm1d, BatchNorm3d
@@ -35,7 +36,6 @@ from aitemplate.frontend.nn.patch_embed import create_conv_patch_embed
 from aitemplate.frontend.nn.positional_encoding import (
     SpatioTemporalClsPositionalEncoding,
 )
-from pytorchvideo.layers.utils import round_width
 
 
 class MultiscaleVisionTransformers(Module):


### PR DESCRIPTION
This fix allows to compile and demo SD model for both model editions
- base model edition - 512x512 - `stabilityai/stable-diffusion-2-1-base`
- regular model edition - 768x768  - `stabilityai/stable-diffusion-2-1`

Additional minor fixes:
- remove unused params from `map_clip_params` and `map_vae_params` to avoid confusion.

Related issue https://github.com/facebookincubator/AITemplate/issues/751