### PR TITLE
Add --model-name param to SD download_pipeline script

### DIFF
--- a/examples/05_stable_diffusion/README.md
+++ b/examples/05_stable_diffusion/README.md
@@ -25,16 +25,24 @@ Verify the library versions. We have tested transformers==4.25, diffusers==0.11[
 ### Download the diffusers pipeline files
 You must first register in Hugging Face Hub to obtain an access token for the Stable Diffusion weights. See [user access tokens](https://huggingface.co/docs/hub/security-tokens) for more info. Your access tokens are listed in your [Hugging Face account settings](https://huggingface.co/settings/tokens).
 
+stable-diffusion model has two variants - base and regular.
+For example:
+- `stabilityai/stable-diffusion-2-1-base` - image resolution 512x512
+- `stabilityai/stable-diffusion-2-1` - image resolution 768x768
+
 ```
-python3 scripts/download_pipeline.py --token ACCESS_TOKEN
+python3 scripts/download_pipeline.py \
+--model-name "stabilityai/stable-diffusion-2-1-base" \
+--token ACCESS_TOKEN
 ```
 
 ### Build AIT modules for CLIP, UNet, VAE
 
 Build the AIT modules by running `compile.py`.
 
+Set correct width and height depending on the model variant
 ```
-python3 scripts/compile.py
+python3 scripts/compile.py --width 512 --height 512
 ```
 It generates three folders: `./tmp/CLIPTextModel`, `./tmp/UNet2DConditionModel`, `./tmp/AutoencoderKL`. In each folder, there is a `test.so` file which is the generated AIT module for the model.
 
@@ -71,6 +79,7 @@ To enable multiple GPUs for profiling, use the environment variable `CUDA_VISIBL
 
 This step is optional. You can run `benchmark.py` to measure throughput for each of the subnets.
 
+Benchmark script supports base model variant only for now - 512x512
 ```
 python3 src/benchmark.py
 ```
@@ -87,14 +96,16 @@ HUGGINGFACE_AUTH_TOKEN=ACCESS_TOKEN python3 -m unittest src/test_correctness.py
 
 Run AIT models with an example image:
 
+Set correct width and height depending on the model variant
 ```
-python3 scripts/demo.py
+python3 scripts/demo.py --width 512 --height 512
 ```
 
 Img2img demo:
 
+Set correct width and height depending on the model variant
 ```
-python3 scripts/demo_img2img.py
+python3 scripts/demo_img2img.py --width 512 --height 512
 ```
 
 Check the resulted image: `example_ait.png`

--- a/examples/05_stable_diffusion/scripts/download_pipeline.py
+++ b/examples/05_stable_diffusion/scripts/download_pipeline.py
@@ -18,15 +18,20 @@ from diffusers import StableDiffusionPipeline
 
 
 @click.command()
+@click.option(
+    "--model-name",
+    default="stabilityai/stable-diffusion-2-1-base",
+    help="Pretrained Model name",
+)
 @click.option("--token", default="", help="access token")
 @click.option(
-    "--save_directory",
+    "--save-directory",
     default="./tmp/diffusers-pipeline/stabilityai/stable-diffusion-v2",
     help="pipeline files local directory",
 )
-def download_pipeline_files(token, save_directory) -> None:
+def download_pipeline_files(model_name, token, save_directory) -> None:
     StableDiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-2",
+        model_name,
         revision="fp16",
         torch_dtype=torch.float16,
         # use provided token or the one generated with `huggingface-cli login``

--- a/python/aitemplate/frontend/nn/vision_transformers.py
+++ b/python/aitemplate/frontend/nn/vision_transformers.py
@@ -18,6 +18,7 @@ from functools import partial
 from typing import Callable, List, Optional, Tuple, Union
 
 import torch
+from pytorchvideo.layers.utils import round_width
 
 from aitemplate.frontend import Tensor
 from aitemplate.frontend.nn.batch_norm import BatchNorm1d, BatchNorm3d
@@ -35,7 +36,6 @@ from aitemplate.frontend.nn.patch_embed import create_conv_patch_embed
 from aitemplate.frontend.nn.positional_encoding import (
     SpatioTemporalClsPositionalEncoding,
 )
-from pytorchvideo.layers.utils import round_width
 
 
 class MultiscaleVisionTransformers(Module):


### PR DESCRIPTION
stable-diffusion model has two variants - base and regular.
- "base" variant image resolution is 512x512 - `stabilityai/stable-diffusion-2-1-base`
- "regular" variant image resolution is 768x768 - `stabilityai/stable-diffusion-2-1`

This PR adds `--model-name` param to `download_pipeline.py` script and sets default model name as 
```
stabilityai/stable-diffusion-2-1-base
```
which matches to default `--width` and `--height` parameters (512x512) in `compile.py` and `demo.py` scripts.

To run the whole example we can:
```
# for default "base" model variant (512x512)
python scripts/download_pipeline.py
python scripts/compile.py
python scripts/demo.py

# for "regular" model variant (768x768)
python scripts/download_pipeline.py --model-name "stabilityai/stable-diffusion-2-1"
python scripts/compile.py --width 768 --height 768
python scripts/demo.py --width 768 --height 768
```

small additional fix - rename `--save_directory` click option to `--save-directory` - all other scripts use dash (-) in click options names

Related PR - https://github.com/facebookincubator/AITemplate/pull/755
Related Issue - https://github.com/facebookincubator/AITemplate/issues/751