### PR TITLE
Map VAE params without AIT_AutoencoderKL

### DIFF
--- a/examples/05_stable_diffusion/src/compile_lib/compile_vae.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_vae.py
@@ -23,13 +23,8 @@ from .util import mark_output
 
 
 def torch_dtype_from_str(dtype: str):
-    if dtype == "float16":
-        torch_dtype = torch.float16
-    elif dtype == "float32":
-        torch_dtype = torch.float32
-    else:
-        raise ValueError("dtype not supported yet!")
-    return torch_dtype
+    return torch.__dict__.get(dtype, None)
+
 
 def map_vae(pt_module, device="cuda", dtype="float16"):
     if not isinstance(pt_module, dict):

--- a/examples/05_stable_diffusion/src/compile_lib/compile_vae.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_vae.py
@@ -22,62 +22,103 @@ from ..modeling.vae import AutoencoderKL as ait_AutoencoderKL
 from .util import mark_output
 
 
-def map_vae_params(ait_module, pt_module):
-    pt_params = dict(pt_module.named_parameters())
-    mapped_pt_params = {}
-    for name, _ in ait_module.named_parameters():
-        ait_name = name.replace(".", "_")
-        if name in pt_params:
-            if (
-                "conv" in name
-                and "norm" not in name
-                and name.endswith(".weight")
-                and len(pt_params[name].shape) == 4
-            ):
-                mapped_pt_params[ait_name] = torch.permute(
-                    pt_params[name], [0, 2, 3, 1]
-                ).contiguous()
-            else:
-                mapped_pt_params[ait_name] = pt_params[name]
-        elif name.endswith("attention.proj.weight"):
-            prefix = name[: -len("attention.proj.weight")]
-            pt_name = prefix + "proj_attn.weight"
-            mapped_pt_params[ait_name] = pt_params[pt_name]
-        elif name.endswith("attention.proj.bias"):
-            prefix = name[: -len("attention.proj.bias")]
-            pt_name = prefix + "proj_attn.bias"
-            mapped_pt_params[ait_name] = pt_params[pt_name]
-        elif name.endswith("attention.cu_length"):
-            ...
-        elif name.endswith("attention.proj_q.weight"):
-            prefix = name[: -len("attention.proj_q.weight")]
-            pt_name = prefix + "query.weight"
-            mapped_pt_params[ait_name] = pt_params[pt_name]
-        elif name.endswith("attention.proj_q.bias"):
-            prefix = name[: -len("attention.proj_q.bias")]
-            pt_name = prefix + "query.bias"
-            mapped_pt_params[ait_name] = pt_params[pt_name]
-        elif name.endswith("attention.proj_k.weight"):
-            prefix = name[: -len("attention.proj_k.weight")]
-            pt_name = prefix + "key.weight"
-            mapped_pt_params[ait_name] = pt_params[pt_name]
-        elif name.endswith("attention.proj_k.bias"):
-            prefix = name[: -len("attention.proj_k.bias")]
-            pt_name = prefix + "key.bias"
-            mapped_pt_params[ait_name] = pt_params[pt_name]
-        elif name.endswith("attention.proj_v.weight"):
-            prefix = name[: -len("attention.proj_v.weight")]
-            pt_name = prefix + "value.weight"
-            mapped_pt_params[ait_name] = pt_params[pt_name]
-        elif name.endswith("attention.proj_v.bias"):
-            prefix = name[: -len("attention.proj_v.bias")]
-            pt_name = prefix + "value.bias"
-            mapped_pt_params[ait_name] = pt_params[pt_name]
-        else:
-            pt_param = pt_module.get_parameter(name)
-            mapped_pt_params[ait_name] = pt_param
+def torch_dtype_from_str(dtype: str):
+    if dtype == "float16":
+        torch_dtype = torch.float16
+    elif dtype == "float32":
+        torch_dtype = torch.float32
+    else:
+        raise ValueError("dtype not supported yet!")
+    return torch_dtype
 
-    return mapped_pt_params
+def map_vae(pt_module, device="cuda", dtype="float16"):
+    if not isinstance(pt_module, dict):
+        pt_params = dict(pt_module.named_parameters())
+    else:
+        pt_params = pt_module
+    params_ait = {}
+    for key, arr in pt_params.items():
+        if key.startswith("encoder"):
+            continue
+        if key.startswith("quant"):
+            continue
+        arr = arr.to(device, dtype=torch_dtype_from_str(dtype))
+        key = key.replace(".", "_")
+        if (
+            "conv" in key
+            and "norm" not in key
+            and key.endswith("_weight")
+            and len(arr.shape) == 4
+        ):
+            params_ait[key] = torch.permute(arr, [0, 2, 3, 1]).contiguous()
+        elif key.endswith("proj_attn_weight"):
+            prefix = key[: -len("proj_attn_weight")]
+            key = prefix + "attention_proj_weight"
+            params_ait[key] = arr
+        elif key.endswith("to_out_0_weight"):
+            prefix = key[: -len("to_out_0_weight")]
+            key = prefix + "attention_proj_weight"
+            params_ait[key] = arr
+        elif key.endswith("proj_attn_bias"):
+            prefix = key[: -len("proj_attn_bias")]
+            key = prefix + "attention_proj_bias"
+            params_ait[key] = arr
+        elif key.endswith("to_out_0_bias"):
+            prefix = key[: -len("to_out_0_bias")]
+            key = prefix + "attention_proj_bias"
+            params_ait[key] = arr
+        elif key.endswith("query_weight"):
+            prefix = key[: -len("query_weight")]
+            key = prefix + "attention_proj_q_weight"
+            params_ait[key] = arr
+        elif key.endswith("to_q_weight"):
+            prefix = key[: -len("to_q_weight")]
+            key = prefix + "attention_proj_q_weight"
+            params_ait[key] = arr
+        elif key.endswith("query_bias"):
+            prefix = key[: -len("query_bias")]
+            key = prefix + "attention_proj_q_bias"
+            params_ait[key] = arr
+        elif key.endswith("to_q_bias"):
+            prefix = key[: -len("to_q_bias")]
+            key = prefix + "attention_proj_q_bias"
+            params_ait[key] = arr
+        elif key.endswith("key_weight"):
+            prefix = key[: -len("key_weight")]
+            key = prefix + "attention_proj_k_weight"
+            params_ait[key] = arr
+        elif key.endswith("key_bias"):
+            prefix = key[: -len("key_bias")]
+            key = prefix + "attention_proj_k_bias"
+            params_ait[key] = arr
+        elif key.endswith("value_weight"):
+            prefix = key[: -len("value_weight")]
+            key = prefix + "attention_proj_v_weight"
+            params_ait[key] = arr
+        elif key.endswith("value_bias"):
+            prefix = key[: -len("value_bias")]
+            key = prefix + "attention_proj_v_bias"
+            params_ait[key] = arr
+        elif key.endswith("to_k_weight"):
+            prefix = key[: -len("to_k_weight")]
+            key = prefix + "attention_proj_k_weight"
+            params_ait[key] = arr
+        elif key.endswith("to_v_weight"):
+            prefix = key[: -len("to_v_weight")]
+            key = prefix + "attention_proj_v_weight"
+            params_ait[key] = arr
+        elif key.endswith("to_k_bias"):
+            prefix = key[: -len("to_k_bias")]
+            key = prefix + "attention_proj_k_bias"
+            params_ait[key] = arr
+        elif key.endswith("to_v_bias"):
+            prefix = key[: -len("to_v_bias")]
+            key = prefix + "attention_proj_v_bias"
+            params_ait[key] = arr
+        else:
+            params_ait[key] = arr
+
+    return params_ait
 
 
 def compile_vae(
@@ -132,7 +173,7 @@ def compile_vae(
     ait_vae.name_parameter_tensor()
 
     pt_mod = pt_mod.eval()
-    params_ait = map_vae_params(ait_vae, pt_mod)
+    params_ait = map_vae(pt_mod)
 
     Y = ait_vae.decode(ait_input)
     mark_output(Y)

--- a/examples/05_stable_diffusion/src/compile_lib/compile_vae_alt.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_vae_alt.py
@@ -23,13 +23,8 @@ from .util import mark_output
 
 
 def torch_dtype_from_str(dtype: str):
-    if dtype == "float16":
-        torch_dtype = torch.float16
-    elif dtype == "float32":
-        torch_dtype = torch.float32
-    else:
-        raise ValueError("dtype not supported yet!")
-    return torch_dtype
+    return torch.__dict__.get(dtype, None)
+
 
 def map_vae(pt_module, device="cuda", dtype="float16"):
     if not isinstance(pt_module, dict):

--- a/examples/05_stable_diffusion/src/pipeline_stable_diffusion_ait_alt.py
+++ b/examples/05_stable_diffusion/src/pipeline_stable_diffusion_ait_alt.py
@@ -30,7 +30,6 @@ from tqdm import tqdm
 from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 
 from .compile_lib.compile_vae_alt import map_vae
-from .modeling.vae import AutoencoderKL as ait_AutoencoderKL
 
 
 def shave_segments(path, n_shave_prefix_segments=1):

--- a/examples/05_stable_diffusion/src/pipeline_stable_diffusion_controlnet_ait.py
+++ b/examples/05_stable_diffusion/src/pipeline_stable_diffusion_controlnet_ait.py
@@ -29,7 +29,7 @@ from diffusers.utils.pil_utils import numpy_to_pil
 from tqdm import tqdm
 from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 
-from .compile_lib.compile_vae_alt import map_vae_params
+from .compile_lib.compile_vae_alt import map_vae
 from .modeling.vae import AutoencoderKL as ait_AutoencoderKL
 
 
@@ -720,49 +720,15 @@ class StableDiffusionAITPipeline:
             ).cuda()
         else:
             self.vae_pt = dict(vae_state_dict)
-        in_channels = 3
-        out_channels = 3
-        down_block_types = [
-            "DownEncoderBlock2D",
-            "DownEncoderBlock2D",
-            "DownEncoderBlock2D",
-            "DownEncoderBlock2D",
-        ]
-        up_block_types = [
-            "UpDecoderBlock2D",
-            "UpDecoderBlock2D",
-            "UpDecoderBlock2D",
-            "UpDecoderBlock2D",
-        ]
-        block_out_channels = [128, 256, 512, 512]
-        layers_per_block = 2
-        act_fn = "silu"
-        latent_channels = 4
-        sample_size = 512
 
-        ait_vae = ait_AutoencoderKL(
-            1,
-            64,
-            64,
-            in_channels=in_channels,
-            out_channels=out_channels,
-            down_block_types=down_block_types,
-            up_block_types=up_block_types,
-            block_out_channels=block_out_channels,
-            layers_per_block=layers_per_block,
-            act_fn=act_fn,
-            latent_channels=latent_channels,
-            sample_size=sample_size,
-        )
         print("Mapping parameters...")
-        vae_params_ait = map_vae_params(ait_vae, self.vae_pt)
+        vae_params_ait = map_vae(self.vae_pt)
         print("Setting constants")
         self.vae_ait_exe.set_many_constants_with_tensors(vae_params_ait)
         print("Folding constants")
         self.vae_ait_exe.fold_constants()
         # cleanup
         self.vae_pt = None
-        ait_vae = None
         vae_params_ait = None
 
         self.tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14")

--- a/examples/05_stable_diffusion/src/pipeline_stable_diffusion_controlnet_ait.py
+++ b/examples/05_stable_diffusion/src/pipeline_stable_diffusion_controlnet_ait.py
@@ -30,7 +30,6 @@ from tqdm import tqdm
 from transformers import CLIPTextConfig, CLIPTextModel, CLIPTokenizer
 
 from .compile_lib.compile_vae_alt import map_vae
-from .modeling.vae import AutoencoderKL as ait_AutoencoderKL
 
 
 def shave_segments(path, n_shave_prefix_segments=1):

--- a/python/aitemplate/frontend/nn/vision_transformers.py
+++ b/python/aitemplate/frontend/nn/vision_transformers.py
@@ -18,6 +18,7 @@ from functools import partial
 from typing import Callable, List, Optional, Tuple, Union
 
 import torch
+from pytorchvideo.layers.utils import round_width
 
 from aitemplate.frontend import Tensor
 from aitemplate.frontend.nn.batch_norm import BatchNorm1d, BatchNorm3d
@@ -35,7 +36,6 @@ from aitemplate.frontend.nn.patch_embed import create_conv_patch_embed
 from aitemplate.frontend.nn.positional_encoding import (
     SpatioTemporalClsPositionalEncoding,
 )
-from pytorchvideo.layers.utils import round_width
 
 
 class MultiscaleVisionTransformers(Module):


### PR DESCRIPTION
Mapping VAE params without AIT_AutoencoderKL, this removes the dependency on AITemplate package for loading weights to modules compiled without included constants, which was needed to improve user experience of [this plugin/demo repo](https://github.com/hlky/AIT)
