### PR TITLE
Fix SD image quality on some GPUs

### DIFF
--- a/examples/05_stable_diffusion/scripts/demo.py
+++ b/examples/05_stable_diffusion/scripts/demo.py
@@ -52,14 +52,14 @@ def run(local_dir, width, height, batch, prompt, negative_prompt, benchmark):
 
     prompt = [prompt] * batch
     with torch.autocast("cuda"):
-        image = pipe(prompt, height, width).images[0]
+        images = pipe(prompt, height, width).images
         if benchmark:
             t = benchmark_torch_function(10, pipe, prompt, height=height, width=width)
             print(
                 f"sd e2e: width={width}, height={height}, batchsize={batch}, latency={t} ms"
             )
-
-    image.save("example_ait.png")
+    for i, image in enumerate(images):
+        image.save(f"example_ait_{i}.png")
 
 
 if __name__ == "__main__":

--- a/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_clip.py
@@ -14,7 +14,7 @@
 #
 
 from aitemplate.compiler import compile_model
-from aitemplate.frontend import Tensor
+from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
 
 from ..modeling.clip import CLIPTextTransformer as ait_CLIPTextTransformer
@@ -70,12 +70,13 @@ def compile_clip(
 
     pt_mod = pt_mod.eval()
     params_ait = map_clip_params(pt_mod)
+    batch_size_d = IntVar(values=[1, max(8, batch_size)], name="batch_size")
 
     input_ids_ait = Tensor(
-        [batch_size, seqlen], name="input0", dtype="int64", is_input=True
+        [batch_size_d, seqlen], name="input0", dtype="int64", is_input=True
     )
     position_ids_ait = Tensor(
-        [batch_size, seqlen], name="input1", dtype="int64", is_input=True
+        [batch_size_d, seqlen], name="input1", dtype="int64", is_input=True
     )
     Y = ait_mod(input_ids=input_ids_ait, position_ids=position_ids_ait)
     mark_output(Y)


### PR DESCRIPTION
compile_clip.py fix.

Recently `batch_size` in `input_ids_ait` and `position_ids_ait` Tensors descriptions [was changed ](https://github.com/facebookincubator/AITemplate/commit/e23d04f16d99a82ddb2cbcac53695414663ea823)from hardcoded dynamic IntVar(1,8) to static user provided batch_size.

It worked fine on A100 and A10G GPUs but generated bad image on T4. 

Looks like we need to return `batch_size` back to dynamic IntVar (1,8).

Additional improvements:
- Instead of using hardcoded batch_size upper bound  we can use user provided batch size or 8 depending on what is bigger.
- Demo script will save all generated images, not just image 0.

### Testing
Tested compile/demo workflow on T4 with  batch-size 1, 8, 12 and resolution 512x512 and 768x768 - all images look good

Related Issue: https://github.com/facebookincubator/AITemplate/issues/758