### PR TITLE
Add jagged_lengths_to_offsets op

### DIFF
--- a/python/aitemplate/backend/cuda/__init__.py
+++ b/python/aitemplate/backend/cuda/__init__.py
@@ -31,6 +31,7 @@ from aitemplate.backend.cuda.embedding import *
 from aitemplate.backend.cuda.gemm_special import *
 from aitemplate.backend.cuda.gemm_universal import *
 from aitemplate.backend.cuda.gemm_epilogue_vistor import *
+from aitemplate.backend.cuda.jagged import *
 from aitemplate.backend.cuda.layernorm_sigmoid_mul import *
 from aitemplate.backend.cuda.padding import *
 from aitemplate.backend.cuda.pool2d import *

--- a/python/aitemplate/backend/cuda/jagged/__init__.py
+++ b/python/aitemplate/backend/cuda/jagged/__init__.py
@@ -1,0 +1,22 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+CUDA jagged tensor-specific ops module init
+"""
+from aitemplate.backend.cuda.jagged import jagged_lengths_to_offsets
+
+__all__ = [
+    "jagged_lengths_to_offsets",
+]

--- a/python/aitemplate/backend/cuda/jagged/jagged_lengths_to_offsets.py
+++ b/python/aitemplate/backend/cuda/jagged/jagged_lengths_to_offsets.py
@@ -1,0 +1,149 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Codegen functions for the jagged_lengths_to_offsets op.
+"""
+import jinja2
+
+from aitemplate.backend import registry
+from aitemplate.backend.backend_spec import CUDASpec
+
+
+SRC_TEMPLATE = jinja2.Template(
+    """
+#include <stdexcept>
+
+#include <cub/cub.cuh>
+
+void {{func_name}}(
+    const void* lengths,
+    void* offsets,
+    {{index_type}} batch_size,
+    {{index_type}}* offsets_size,
+    void* workspace,
+    cudaStream_t stream
+) {
+    *offsets_size = batch_size + 1;
+
+    // pre-initialize all offset values to zero
+    cudaMemsetAsync(offsets, 0, (*offsets_size) * sizeof({{offsets_type}}), stream);
+
+    // no-op call to determine the temp storage size;
+    // although we don't need this call (because the workspace
+    // is pre-allocated to a sufficiently large size), unless
+    // the exact size determined by it is passed to the
+    // following call, it won't perform any computation
+    size_t temp_storage_bytes = 0;
+    cub::DeviceScan::InclusiveSum(
+        nullptr,
+        temp_storage_bytes,
+        reinterpret_cast<const {{offsets_type}}*>(lengths),
+        reinterpret_cast<{{offsets_type}}*>(offsets) + 1,
+        (int)batch_size,
+        stream
+    );
+
+    if (temp_storage_bytes > {{workspace_size}}) {
+        throw std::runtime_error("Pre-allocated workspace size ({{workspace_size}} bytes) is too small.");
+    }
+
+    // compute the actual offsets, starting from the offsets[1]
+    cub::DeviceScan::InclusiveSum(
+        workspace,
+        temp_storage_bytes,
+        reinterpret_cast<const {{offsets_type}}*>(lengths),
+        reinterpret_cast<{{offsets_type}}*>(offsets) + 1,
+        (int)batch_size,
+        stream
+    );
+}
+""",
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+FUNC_DECL_TEMPLATE = jinja2.Template(
+    """
+void {{func_name}}(
+    const void*,      /* lengths */
+    void*,            /* offsets */
+    {{index_type}},   /* batch_size */
+    {{index_type}}*,  /* offsets_size */
+    void*,            /* workspace */
+    cudaStream_t      /* stream */
+);
+""",
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+FUNC_CALL_TEMPLATE = jinja2.Template(
+    """
+{{indent}}{{func_name}}(
+{{indent}}    {{lengths}},
+{{indent}}    {{offsets}},
+{{indent}}    {{batch_size}},
+{{indent}}    &{{offsets_size}},
+{{indent}}    global_workspace_,
+{{indent}}    stream
+{{indent}});
+""",
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+
+@registry.reg("cuda.jagged_lengths_to_offsets.gen_function")
+def jagged_lengths_to_offsets_gen_function(func_attrs):
+    func_name = func_attrs["name"]
+    backend_spec = CUDASpec()
+    offsets = func_attrs["outputs"][0]
+    offsets_type = backend_spec.dtype_to_backend_type(offsets.dtype())
+
+    return SRC_TEMPLATE.render(
+        func_name=func_name,
+        index_type=backend_spec.index_type,
+        offsets_type=offsets_type,
+        workspace_size=func_attrs["workspace"],
+    )
+
+
+@registry.reg("cuda.jagged_lengths_to_offsets.func_decl")
+def jagged_lengths_to_offsets_gen_function_decl(func_attrs):
+    func_name = func_attrs["name"]
+    backend_spec = CUDASpec()
+
+    return FUNC_DECL_TEMPLATE.render(
+        func_name=func_name,
+        index_type=backend_spec.index_type,
+    )
+
+
+@registry.reg("cuda.jagged_lengths_to_offsets.func_call")
+def jagged_lengths_to_offsets_gen_function_call(func_attrs, indent="  "):
+    func_name = func_attrs["name"]
+    lengths = func_attrs["inputs"][0]
+    offsets = func_attrs["outputs"][0]
+    batch_size = lengths.shape()[0]
+    offsets_size = offsets.shape()[0]
+
+    return FUNC_CALL_TEMPLATE.render(
+        indent="      ",
+        func_name=func_name,
+        lengths=lengths._attrs["name"],
+        offsets=offsets._attrs["name"],
+        batch_size=batch_size._attrs["name"],
+        offsets_size=offsets_size._attrs["name"],
+    )

--- a/python/aitemplate/compiler/ops/__init__.py
+++ b/python/aitemplate/compiler/ops/__init__.py
@@ -22,6 +22,7 @@ from aitemplate.compiler.ops.embedding import *
 from aitemplate.compiler.ops.gemm_special import *
 from aitemplate.compiler.ops.gemm_universal import *
 from aitemplate.compiler.ops.gemm_epilogue_vistor import *
+from aitemplate.compiler.ops.jagged import *
 from aitemplate.compiler.ops.layernorm import *
 from aitemplate.compiler.ops.padding import *
 from aitemplate.compiler.ops.pool import *

--- a/python/aitemplate/compiler/ops/jagged/__init__.py
+++ b/python/aitemplate/compiler/ops/jagged/__init__.py
@@ -1,0 +1,21 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+from aitemplate.compiler.ops.jagged.jagged_lengths_to_offsets import (
+    jagged_lengths_to_offsets,
+)
+
+__all__ = [
+    "jagged_lengths_to_offsets",
+]

--- a/python/aitemplate/compiler/ops/jagged/jagged_lengths_to_offsets.py
+++ b/python/aitemplate/compiler/ops/jagged/jagged_lengths_to_offsets.py
@@ -1,0 +1,86 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Define jagged_lengths_to_offsets op
+"""
+from typing import List
+
+from aitemplate.backend import registry
+from aitemplate.backend.target import Target
+from aitemplate.compiler.base import IntVar, Operator, Tensor
+
+
+class jagged_lengths_to_offsets(Operator):
+    """
+    Given a 1D Tensor of lengths of the sequences in a jagged Tensor,
+    returns the corresponding 1D Tensor of offsets. The latter is the
+    inclusive sum of the lengths prepended by a zero.
+
+    Args:
+        lengths (Tensor): 1D Tensor of sequence lengths, [B]-shaped.
+    Returns:
+        offsets (Tensor): 1D Tensor of sequence offsets, [B+1]-shaped.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._attrs["op"] = "jagged_lengths_to_offsets"
+        self._attrs["has_profiler"] = False
+
+    def _infer_shape(self, lengths: Tensor) -> List[IntVar]:
+        batch_size = lengths.shape()[0]
+        # the offsets are 1 element longer than the lengths
+        offsets_size = IntVar(
+            values=[
+                batch_size.lower_bound() + 1,
+                batch_size.upper_bound() + 1,
+            ]
+        )
+        return [offsets_size]
+
+    def __call__(
+        self,
+        lengths: Tensor,
+    ) -> Tensor:
+        if len(lengths.shape()) != 1:
+            raise ValueError(f"The lengths Tensor must be 1D, but got {lengths=}.")
+        if lengths._attrs["dtype"] not in ("int32", "int64"):
+            raise ValueError(
+                f"The lengths Tensor must be int32 or int64, but got {lengths=}."
+            )
+
+        self._attrs["inputs"] = [lengths]
+        self._set_depth()
+        output_shape = self._infer_shape(lengths)
+        offsets = Tensor(
+            output_shape,
+            src_ops={self},
+            dtype=lengths._attrs["dtype"],
+        )
+
+        # set the workspace to empirically determined large enough value
+        sizeof_dtype = 4 if lengths._attrs["dtype"] == "int32" else 8
+        self._attrs["workspace"] = max(
+            2**16,
+            16 * sizeof_dtype * offsets.shape()[0].upper_bound(),
+        )
+
+        self._attrs["outputs"] = [offsets]
+        return offsets
+
+    def gen_function(self) -> str:
+        target = Target.current()
+        func = registry.get(f"{target.name()}.{self._attrs['op']}.gen_function")
+        return func(self._attrs)

--- a/tests/unittest/ops/test_jagged_lengths_to_offsets.py
+++ b/tests/unittest/ops/test_jagged_lengths_to_offsets.py
@@ -1,0 +1,101 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Unittests for the jagged_lengths_to_offsets op.
+"""
+
+import unittest
+
+import torch
+
+from aitemplate.compiler import compile_model, ops
+from aitemplate.frontend import IntVar, Tensor
+from aitemplate.testing import detect_target
+from aitemplate.utils.torch_utils import string_to_torch_dtype
+from parameterized import param, parameterized
+
+
+class JaggedLengthsToOffsetsTestCase(unittest.TestCase):
+    def _test_jagged_lengths_to_offsets(
+        self,
+        batch_size: int,
+        offsets_dtype: str = "int32",
+        test_suffix: str = "",
+    ):
+        LENGTHS = Tensor(
+            shape=[IntVar([1, batch_size], name="batch_size")],
+            name="lengths",
+            dtype=offsets_dtype,
+            is_input=True,
+        )
+
+        OFFSETS = ops.jagged_lengths_to_offsets()(LENGTHS)
+
+        OFFSETS._attrs["name"] = "offsets"
+        OFFSETS._attrs["is_output"] = True
+
+        model = compile_model(
+            [OFFSETS],
+            detect_target(),
+            "./tmp",
+            f"test_jagged_lengths_to_offsets_{test_suffix}",
+        )
+
+        torch_dtype = string_to_torch_dtype(offsets_dtype)
+
+        for seed in range(10):
+            torch.manual_seed(seed)
+            lengths_pt = torch.randint(
+                low=0,
+                high=1024,
+                size=(batch_size,),
+                dtype=torch_dtype,
+            )
+            offsets_pt = torch.cat(
+                [
+                    torch.zeros((1,), dtype=torch_dtype),
+                    torch.cumsum(lengths_pt, dim=0, dtype=torch_dtype),
+                ],
+            ).cuda()
+
+            offsets = torch.empty(
+                size=(batch_size + 1,),
+                dtype=torch_dtype,
+            ).cuda()
+            model.run_with_tensors(
+                inputs={"lengths": lengths_pt.cuda()},
+                outputs=[offsets],
+            )
+
+            torch.testing.assert_close(offsets, offsets_pt)
+
+    @parameterized.expand(
+        [
+            param(1, 1, "int32"),
+            param(2, 10, "int64"),
+            param(3, 16384, "int32"),
+            param(4, 65537, "int64"),
+        ]
+    )
+    def test_jagged_lengths_to_offsets(self, i, batch_size, offsets_dtype):
+        self._test_jagged_lengths_to_offsets(
+            batch_size=batch_size,
+            offsets_dtype=offsets_dtype,
+            test_suffix=str(i),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: New operator for converting [B]-shaped 1D `lenghts` tensor to the [B+1]-shaped 1D `offsets` tensor used in the jagged tensor context.

Differential Revision: D46685031

