### PR TITLE
Download SD model without token by default

### DIFF
--- a/examples/05_stable_diffusion/README.md
+++ b/examples/05_stable_diffusion/README.md
@@ -23,7 +23,7 @@ Verify the library versions. We have tested transformers==4.25, diffusers==0.11[
 ```
 
 ### Download the diffusers pipeline files
-You must first register in Hugging Face Hub to obtain an access token for the Stable Diffusion weights. See [user access tokens](https://huggingface.co/docs/hub/security-tokens) for more info. Your access tokens are listed in your [Hugging Face account settings](https://huggingface.co/settings/tokens).
+Optionally, you can use Hugging Face access token. You can register in Hugging Face Hub to obtain an access token for the Stable Diffusion weights. See [user access tokens](https://huggingface.co/docs/hub/security-tokens) for more info. Your access tokens are listed in your [Hugging Face account settings](https://huggingface.co/settings/tokens).
 
 stable-diffusion model has two variants - base and regular.
 For example:
@@ -32,7 +32,9 @@ For example:
 
 ```
 python3 scripts/download_pipeline.py \
---model-name "stabilityai/stable-diffusion-2-1-base" \
+--model-name "stabilityai/stable-diffusion-2-1-base"
+
+# Optionally, you can use access token
 --token ACCESS_TOKEN
 ```
 

--- a/examples/05_stable_diffusion/scripts/download_pipeline.py
+++ b/examples/05_stable_diffusion/scripts/download_pipeline.py
@@ -21,21 +21,27 @@ from diffusers import StableDiffusionPipeline
 @click.option(
     "--model-name",
     default="stabilityai/stable-diffusion-2-1-base",
-    help="Pretrained Model name",
+    help="Pretrained Model name.",
 )
-@click.option("--token", default="", help="access token")
+@click.option(
+    "--token",
+    default="",
+    help="Valid values: Huggingface user access token, 'true' to use token "
+    "generated with 'huggingface-cli login' (stored in ~/.huggingface) "
+    "or empty string to not use access token (default).",
+)
 @click.option(
     "--save-directory",
     default="./tmp/diffusers-pipeline/stabilityai/stable-diffusion-v2",
-    help="pipeline files local directory",
+    help="Pipeline files local directory.",
 )
 def download_pipeline_files(model_name, token, save_directory) -> None:
+
     StableDiffusionPipeline.from_pretrained(
         model_name,
         revision="fp16",
         torch_dtype=torch.float16,
-        # use provided token or the one generated with `huggingface-cli login``
-        use_auth_token=token if token != "" else True,
+        use_auth_token=token if len(token) > 5 else token.lower() == "true",
     ).save_pretrained(save_directory)
 
 


### PR DESCRIPTION
Huggingface allows to download Stable Diffusion model files without user access token.

To simplify `download_pipeline.py` user experience lets not mandate user to run  `huggingface-cli login` or explicitly provide user access token.
 
Internally `download_pipeline.py` will call `StableDiffusionPipeline.from_petrained()` with `use_auth_token=False` by default.

New `download_pipeline.py` Help for `--token`:
```
Usage: download_pipeline.py [OPTIONS]

Options:
...
  --token TEXT           Valid values: Huggingface user access token, 'true'
                         to use token generated with 'huggingface-cli login'
                         (stored in ~/.huggingface) or empty string to not use
                         access token (default).
```