### PR TITLE
skip fusing slice with a strided op if the relevant tensor accessors …

### DIFF
--- a/python/aitemplate/compiler/ops/tensor/slice_scatter.py
+++ b/python/aitemplate/compiler/ops/tensor/slice_scatter.py
@@ -35,6 +35,11 @@ class slice_scatter(Operator):
     def is_valid(cat_op: Operator) -> bool:
         if cat_op._attrs["op"] != "concatenate":
             return False
+        if any(
+            input_accessor.stride_dim is not None
+            for input_accessor in cat_op._attrs["input_accessors"]
+        ):
+            return False
         return all(
             x._attrs["src_ops"] is not None
             and len(x._attrs["src_ops"]) == 1

--- a/python/aitemplate/compiler/transform/transform_strided_slice.py
+++ b/python/aitemplate/compiler/transform/transform_strided_slice.py
@@ -245,6 +245,8 @@ def _process_one_slice_dst(
         if input_tensor is not slice_output_tensor:
             continue
         input_accessors = strided_op._attrs["input_accessors"]
+        if input_accessors[idx].stride_dim is not None:
+            return False
 
         if any(strided_op_name.startswith(n) for n in ("gemm", "group_gemm", "bmm")):
             if not transform_strided_ops_utils.gemm_stride_checker(


### PR DESCRIPTION
…are already set

In some cases, when we fuse a slice op with a strided op (e.g. concat), the relevant tensor accessors in the strided op's input tensors may have already be updated. Let's skip fusion in such a case.

Note that technically, we might be able to perform fusion in some senarios, but let's handle those later if we see needs.