### PR TITLE
[fx2ait] Package libait_model.so with fx2ait

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ setup_fx2ait_env: &setup_fx2ait_env
           sudo chmod a+r /usr/local/cuda/include/cudnn*.h /usr/local/cuda/lib64/libcudnn*
           python3.8 -m pip install --ignore-installed --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118
           pushd fx2ait
-          python3.8 setup.py develop
+          python3.8 setup.py develop --user
           popd
           break || sleep 5;
         done
@@ -79,10 +79,8 @@ fx2ait_tests: &fx2ait_tests
       command: |
         source $BASH_ENV
         mkdir -p ~/test-fx2ait-results
-        pushd fx2ait/fx2ait/test
-        TEST_FILES=$(circleci tests glob "test_*.py" "converters/**/test_*.py")
+        TEST_FILES=$(circleci tests glob "fx2ait/fx2ait/test/test_*.py" "fx2ait/fx2ait/test/converters/**/test_*.py")
         python3.8 -m pytest $TEST_FILES -o junit_family=xunit1 --junitxml=~/test-fx2ait-results/junit.xml --verbose --continue-on-collection-errors -rA
-        popd
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,9 @@ setup_fx2ait_env: &setup_fx2ait_env
           sudo cp -P cudnn-*-archive/lib/libcudnn* /usr/local/cuda/lib64
           sudo chmod a+r /usr/local/cuda/include/cudnn*.h /usr/local/cuda/lib64/libcudnn*
           python3.8 -m pip install --ignore-installed --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118
-          python3.8 fx2ait/setup.py install --prefix=/home/circleci/
-          echo 'export PYTHONPATH=$PWD/fx2ait:$PYTHONPATH' >> $BASH_ENV
+          pushd fx2ait
+          python3.8 setup.py develop
+          popd
           break || sleep 5;
         done
 
@@ -78,8 +79,10 @@ fx2ait_tests: &fx2ait_tests
       command: |
         source $BASH_ENV
         mkdir -p ~/test-fx2ait-results
-        TEST_FILES=$(circleci tests glob "fx2ait/fx2ait/test/test_*.py" "fx2ait/fx2ait/test/converters/**/test_*.py")
+        pushd fx2ait/fx2ait/test
+        TEST_FILES=$(circleci tests glob "test_*.py" "converters/**/test_*.py")
         python3.8 -m pytest $TEST_FILES -o junit_family=xunit1 --junitxml=~/test-fx2ait-results/junit.xml --verbose --continue-on-collection-errors -rA
+        popd
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs

--- a/fx2ait/fx2ait/__init__.py
+++ b/fx2ait/fx2ait/__init__.py
@@ -14,7 +14,7 @@
 #
 import sys
 
-from . import acc_tracer, converters  # noqa
+from . import acc_tracer, converters, extension  # noqa
 
 if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 7):
     PY3STATEMENT = "The minimal Python requirement is Python 3.7"
@@ -24,6 +24,7 @@ __all__ = [
     "acc_tracer",
     "converters",
     "core",
+    "extension",
     "lower",
     "test",
 ]

--- a/fx2ait/fx2ait/ait_splitter.py
+++ b/fx2ait/fx2ait/ait_splitter.py
@@ -25,11 +25,6 @@ from fx2ait.fx2ait import AITInterpreter
 from torch.fx.passes.operator_support import create_op_support, OperatorSupportBase
 from torch.fx.passes.tools_common import get_acc_ops_name
 
-try:
-    torch.ops.load_library("//deeplearning/ait:AITModel")
-except BaseException:
-    torch.ops.load_library("build/libait_model.so")
-
 
 _VIEW_OPS = frozenset(
     (

--- a/fx2ait/fx2ait/example/benchmark_utils.py
+++ b/fx2ait/fx2ait/example/benchmark_utils.py
@@ -24,8 +24,6 @@ from fx2ait.ait_module import AITModule
 
 from fx2ait.fx2ait import AITInterpreter
 
-torch.ops.load_library("build/libait_model.so")
-
 
 def verify_accuracy(
     mod: torch.nn.Module,

--- a/fx2ait/fx2ait/extension.py
+++ b/fx2ait/fx2ait/extension.py
@@ -1,0 +1,40 @@
+import logging
+import os
+import torch
+import importlib.machinery
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def is_oss_ait_model():
+    return False
+
+
+def _get_extension_path(lib_name):
+
+    lib_dir = os.path.dirname(__file__)
+
+    loader_details = (
+        importlib.machinery.ExtensionFileLoader,
+        importlib.machinery.EXTENSION_SUFFIXES,
+    )
+
+    extfinder = importlib.machinery.FileFinder(lib_dir, loader_details)
+    ext_specs = extfinder.find_spec(lib_name)
+    if ext_specs is None:
+        raise ImportError
+
+    return ext_specs.origin
+
+
+try:
+    torch.ops.load_library("//deeplearning/ait:AITModel")
+    logger.info("===Load non-OSS AITModel===")
+
+except (ImportError, OSError):
+    lib_path = _get_extension_path("libait_model")
+    torch.ops.load_library(lib_path)
+    logger.info("===Load OSS AITModel===")
+
+    def is_oss_ait_model():  # noqa: F811
+        return True

--- a/fx2ait/fx2ait/extension.py
+++ b/fx2ait/fx2ait/extension.py
@@ -1,3 +1,18 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
 import logging
 import os
 import torch

--- a/fx2ait/fx2ait/lower/lower.py
+++ b/fx2ait/fx2ait/lower/lower.py
@@ -36,8 +36,6 @@ from .lower_settings import LowerPrecision, LowerSettings
 logger: logging.Logger = logging.getLogger(__name__)
 Input = Sequence[Any]
 
-torch.ops.load_library("build/libait_model.so")
-
 
 # A list of (function, target) pairs to not apply acc normalization
 # to when scripting. For one reason or another, these targets do

--- a/fx2ait/fx2ait/test/test_fx2ait.py
+++ b/fx2ait/fx2ait/test/test_fx2ait.py
@@ -21,16 +21,10 @@ import torch
 from fx2ait.acc_tracer import acc_tracer
 from fx2ait.ait_module import AITModule
 from fx2ait.fx2ait import AITInterpreter
-
-OSS_AIT_MODEL = False
-try:
-    torch.ops.load_library("//deeplearning/ait:AITModel")
-except Exception:
-    torch.ops.load_library("build/libait_model.so")
-    OSS_AIT_MODEL = True
+from fx2ait.extension import is_oss_ait_model
 
 AIT_MODEL_CLASS = (
-    torch.classes.ait.AITModel if OSS_AIT_MODEL else torch.classes.fb.AITModel
+    torch.classes.ait.AITModel if is_oss_ait_model() else torch.classes.fb.AITModel
 )
 
 
@@ -95,7 +89,7 @@ class TestAITModule(unittest.TestCase):
             ait_mod = torch.jit.load(buf)
         ait_output = ait_mod(*inputs)
         torch.testing.assert_close(ait_output, ref_output, atol=0.1, rtol=0.1)
-        if not OSS_AIT_MODEL:
+        if not is_oss_ait_model():
             weights = {
                 "_0_weight": torch.ones(3, 4).cuda().half(),
                 "_0_bias": torch.randn(4).cuda().half(),

--- a/fx2ait/fx2ait/tools/common_fx2ait.py
+++ b/fx2ait/fx2ait/tools/common_fx2ait.py
@@ -28,18 +28,10 @@ from fx2ait.acc_tracer.ait_acc_normalizer import update_acc_op_mappers_for_ait
 from fx2ait.ait_module import AITModule
 from fx2ait.fx2ait import AITInterpreter
 from fx2ait.tensor_spec import TensorSpec
+from fx2ait.extension import is_oss_ait_model
 from torch.fx.node import map_aggregate
 
 logger: logging.Logger = logging.getLogger(__name__)
-
-OSS_AITModel = False
-try:
-    torch.ops.load_library("//deeplearning/ait:AITModel")
-    logger.info("===Load non-OSS AITModel===")
-except Exception:
-    torch.ops.load_library("build/libait_model.so")
-    logger.info("===Load OSS AITModel===")
-    OSS_AITModel = True
 
 
 class LowerPrecision(Enum):
@@ -165,7 +157,7 @@ class AITTestCase(TestCase):
             interp_result = interp.run()
             sec = time.perf_counter() - start
             logger.info(f"Interpreter run time(s):{sec}")
-            if OSS_AITModel:
+            if is_oss_ait_model():
                 ait_mod = AITModule(
                     torch.classes.ait.AITModel(
                         interp_result.engine.lib_path,
@@ -291,7 +283,7 @@ class AITTestCase(TestCase):
             interp_result = interp.run()
             sec = time.perf_counter() - start
             logger.info(f"Interpreter run time(s):{sec}")
-            if OSS_AITModel:
+            if is_oss_ait_model():
                 ait_mod = AITModule(
                     torch.classes.ait.AITModel(
                         interp_result.engine.lib_path,

--- a/fx2ait/setup.py
+++ b/fx2ait/setup.py
@@ -14,97 +14,66 @@
 #
 
 import os
-import subprocess
-import sys
-from pathlib import Path
+import glob
 
-from setuptools import Extension, find_packages, setup
-from setuptools.command.build_ext import build_ext
+from setuptools import find_packages, setup
 
-
-class CMakeExtension(Extension):
-    def __init__(self, name):
-        Extension.__init__(self, name, sources=[])
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 
-class CMakeBuild(build_ext):
-    def run(self):
-        try:
-            subprocess.check_output(["cmake", "--version"])
-        except OSError as exc:
-            raise RuntimeError(
-                "CMake must be installed to build the following extensions: "
-                + ", ".join(e.name for e in self.extensions)
-            ) from exc
+def get_extensions():
+    print("Compiling extensions with following flags:")
+    debug_mode = os.getenv("DEBUG", "0") == "1"
+    print(f"  DEBUG: {debug_mode}")
+    nvcc_flags = os.getenv("NVCC_FLAGS", "")
+    print(f"  NVCC_FLAGS: {nvcc_flags}")
+    if nvcc_flags == "":
+        nvcc_flags = []
+    else:
+        nvcc_flags = nvcc_flags.split(" ")
+    extra_compile_args = {"cxx": [], "nvcc": nvcc_flags}
 
-        try:
-            import torch.utils
+    if debug_mode:
+        print("Compiling in debug mode")
+        extra_compile_args["cxx"].append("-g")
+        extra_compile_args["cxx"].append("-O0")
+        if "nvcc" in extra_compile_args:
+            # we have to remove "-OX" and "-g" flag if exists and append
+            nvcc_flags = extra_compile_args["nvcc"]
+            extra_compile_args["nvcc"] = [
+                f for f in nvcc_flags if not ("-O" in f or "-g" in f)
+            ]
+            extra_compile_args["nvcc"].append("-O0")
+            extra_compile_args["nvcc"].append("-g")
 
-            cmake_prefix_path = torch.utils.cmake_prefix_path
-        except ModuleNotFoundError as exc:
-            raise RuntimeError(
-                "Cannot import torch.utils. Check torch installation."
-            ) from exc
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    extensions_dir = os.path.join(this_dir, "fx2ait", "csrc")
 
-        build_directory = os.path.abspath(self.build_temp)
-        cmake_args = [
-            "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + build_directory,
-            "-DPYTHON_EXECUTABLE=" + sys.executable,
-            "-DCMAKE_PREFIX_PATH=" + cmake_prefix_path,
-        ]
+    src = glob.glob(os.path.join(extensions_dir, "*.cpp"))
+    inc = [extensions_dir]
+    inc += [os.path.abspath(os.path.join(this_dir, "../static/include"))]
+    inc += [os.path.abspath(os.path.join(this_dir, "../3rdparty/picojson"))]
+    define_macros = []
 
-        cfg = "Debug" if self.debug else "Release"
-        build_args = ["--config", cfg]
-
-        # cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
-
-        # Assuming Makefiles
-        build_args += ["--", "-j2"]
-
-        self.build_args = build_args
-
-        env = os.environ.copy()
-        env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(
-            env.get("CXXFLAGS", ""), self.distribution.get_version()
+    ext_modules = [
+        CUDAExtension(
+            name="fx2ait.libait_model",
+            sources=src,
+            include_dirs=inc,
+            define_macros=define_macros,
+            extra_compile_args=extra_compile_args,
         )
-        if not os.path.exists(self.build_temp):
-            os.makedirs(self.build_temp)
+    ]
+    return ext_modules
 
-        # CMakeLists.txt is in the same directory as this setup.py file
-        cmake_list_dir = os.path.abspath(os.path.dirname(__file__))
-        print("-" * 10, "Running CMake prepare", "-" * 40)
-        subprocess.check_call(
-            ["cmake", cmake_list_dir] + cmake_args, cwd=self.build_temp, env=env
-        )
-
-        print("-" * 10, "Building extensions", "-" * 40)
-        cmake_cmd = ["cmake", "--build", "."] + self.build_args
-        subprocess.check_call(cmake_cmd, cwd=self.build_temp)
-        # Move from build temp to final position
-        for ext in self.extensions:
-            self.move_output(ext)
-
-    def move_output(self, ext):
-        build_temp = Path(self.build_temp).resolve()
-        lib_name = "lib" + ext.name + ".so"
-        dest_path = build_temp.parents[0] / lib_name
-        source_path = build_temp / lib_name
-        dest_directory = dest_path.parents[0]
-        dest_directory.mkdir(parents=True, exist_ok=True)
-        self.copy_file(source_path, dest_path)
-
-
-ext_modules = [
-    CMakeExtension("ait_model"),
-]
 
 setup(
     name="fx2ait",
     version="0.2.dev1",
     description="FX2AIT: Convert PyTorch Models to AITemplate",
-    zip_safe=True,
+    zip_safe=False,
     install_requires=["torch"],  # We will need torch>=1.13
     packages=find_packages(),
-    ext_modules=ext_modules,
-    cmdclass=dict(build_ext=CMakeBuild),
+    ext_modules=get_extensions(),
+    cmdclass=dict(build_ext=BuildExtension.with_options(no_python_abi_suffix=True)),
 )


### PR DESCRIPTION
This PR rewrote the building and loading of `libait_model.so` so that it can be packaged with fx2ait and loaded only once. The code is mostly adopted from `torchvision._C`. After this PR, fx2ait no longer requires the user to put a "./build/libait_model.so" file in the current directory.

One limitation is that it does not support Windows and ROCM platforms.