### PR TITLE
Fix and re-enable eliminate_permutations graph transformation

### DIFF
--- a/python/aitemplate/compiler/transform/optimize_graph.py
+++ b/python/aitemplate/compiler/transform/optimize_graph.py
@@ -51,6 +51,7 @@ from aitemplate.compiler.transform.transform_memory_ops import transform_memory_
 from aitemplate.compiler.transform.transform_odd_alignment import (
     transform_odd_alignment,
 )
+from aitemplate.compiler.transform.transform_permutations import eliminate_permutations
 from aitemplate.compiler.transform.transform_permute_to_reshape import (
     transform_permute_to_reshape,
 )
@@ -125,8 +126,7 @@ def optimize_graph(
         split_large_split_ops,
         transform_permute_to_reshape,
         transform_memory_ops,
-        # FIXME: temporarily disable this due to some accuracy issue
-        # eliminate_permutations,
+        eliminate_permutations,
     ]
 
     if not optimize:

--- a/python/aitemplate/compiler/transform/transform_permutations.py
+++ b/python/aitemplate/compiler/transform/transform_permutations.py
@@ -17,6 +17,7 @@ from typing import List
 import numpy as np
 
 from aitemplate.compiler.base import Operator, Tensor
+from aitemplate.compiler.tensor_accessor import TensorAccessor
 from aitemplate.compiler.transform import transform_utils
 
 
@@ -60,6 +61,32 @@ def remove_second_permutation_from_graph(
     transform_utils.remove_tensor_from_sorted_graph(output_tensor)
 
 
+def _reshaped_or_strided_input_or_output_accessor(op: Operator) -> bool:
+    def _reshaped_or_strided_tensor_accessor(accessor: TensorAccessor) -> bool:
+        if (
+            accessor.actual_shapes is not None
+            and accessor.actual_shapes != accessor.original_shapes
+        ):
+            return True
+
+        # Is it a strided accessor
+        if hasattr(accessor, "stride_dim") and accessor.stride_dim is not None:
+            return True
+
+        return False
+
+    input_accessors = op._attrs.get("input_accessors", None)
+    output_accessors = op._attrs.get("output_accessors", None)
+
+    return (
+        (input_accessors is not None)
+        and _reshaped_or_strided_tensor_accessor(input_accessors[0])
+    ) or (
+        (output_accessors is not None)
+        and _reshaped_or_strided_tensor_accessor(output_accessors[0])
+    )
+
+
 def eliminate_permutations(
     sorted_graph: List[Tensor], workdir: str = None
 ) -> List[Tensor]:
@@ -73,12 +100,7 @@ def eliminate_permutations(
                 continue
             if not cur_op._attrs["op"].startswith("permute"):
                 continue
-            input_accessors = cur_op._attrs.get("input_accessors", None)
-            if (
-                input_accessors is not None
-                and hasattr(input_accessors[0], "strided_dim")
-                and input_accessors[0].strided_dim is not None
-            ):
+            if _reshaped_or_strided_input_or_output_accessor(cur_op):
                 continue
             curr_op_output = cur_op._attrs["outputs"][0]
             dst_ops = curr_op_output._attrs["dst_ops"]
@@ -88,6 +110,8 @@ def eliminate_permutations(
             remove_list = []
             for next_op in dst_ops:
                 if not next_op._attrs["op"].startswith("permute"):
+                    continue
+                if _reshaped_or_strided_input_or_output_accessor(next_op):
                     continue
                 p1 = get_permutation(cur_op)
                 p2 = get_permutation(next_op)


### PR DESCRIPTION
Summary:
Fix eliminate_permutations graph transformation in AITemplate to retain successive cancelling permutations on strided input Tensor.

Re-enabled the transformation as well.

Differential Revision: D47371853

