### PR TITLE
Fix group_layernorm alignment and reshape fusion

### DIFF
--- a/python/aitemplate/backend/cuda/layernorm_sigmoid_mul/group_layernorm_sigmoid_mul.py
+++ b/python/aitemplate/backend/cuda/layernorm_sigmoid_mul/group_layernorm_sigmoid_mul.py
@@ -269,7 +269,11 @@ def group_layernorm_sigmoid_mul_gen_function_call(func_attrs, indent="  "):
 
     all_shape_funcs = []
     # all Ms are the same
-    input_0_shapes = inputs[0]._attrs["shape"]
+    if func_attrs.get("input_accessors", None):
+        input_accessor = func_attrs["input_accessors"][0]
+        input_0_shapes = input_accessor.original_shapes
+    else:
+        input_0_shapes = inputs[0]._attrs["shape"]
     norm_ndim = len(func_attrs["normalized_shape"][0])
     m_name = "M"
     m_shape_func = layernorm_common.generate_m_shape_func(


### PR DESCRIPTION
Summary:
The group_layernorm back-end implementation is not well-aligned with the input TensorAccessors which can cause CUDA illegal memory access under certain fusion scenarios (e.g., reshape fusion).

This diff addresses these issues.

Differential Revision: D47395663

