### PR TITLE
Remove repeated environment variable logging

### DIFF
--- a/python/aitemplate/compiler/transform/profile.py
+++ b/python/aitemplate/compiler/transform/profile.py
@@ -31,6 +31,7 @@ from aitemplate.compiler.ops.gemm_universal.gemm_common import (
     gemm,
     GemmProfilerPostprocessingDelegate,
 )
+from aitemplate.utils.environ import force_profiler_cache
 
 # pylint: disable=C0103,W0613,W0102
 
@@ -78,6 +79,7 @@ def profile(
         devices = [0]
     profiler_dir = os.path.join(workdir)
     start_t = datetime.now()
+    _LOGGER.info(f"Force profiler cache = {force_profiler_cache()}")
     generated_profilers = list(
         codegen.gen_profiler(sorted_graph, profiler_dir, dynamic_profiling_strategy)
     )

--- a/python/aitemplate/utils/environ.py
+++ b/python/aitemplate/utils/environ.py
@@ -66,7 +66,6 @@ def force_profiler_cache() -> bool:
         assert (
             os.environ.get("FORCE_PROFILE", None) != "1"
         ), "cannot specify both AIT_FORCE_PROFILER_CACHE and FORCE_PROFILE"
-    _LOGGER.info(f"{force_cache=}")
     return force_cache
 
 


### PR DESCRIPTION
Summary: AIT_FORCE_PROFILER_CACHE is an environment variable that should not change during AIT compilation. Log it only once instead of every profiling.

Differential Revision: D47535987

