### PR TITLE
Add benchmark for softmax

### DIFF
--- a/tests/unittest/ops/test_softmax.py
+++ b/tests/unittest/ops/test_softmax.py
@@ -15,7 +15,12 @@
 """
 Unittests for LayerNorm Operator.
 """
+import json
+import math
+import tempfile
 import unittest
+from collections import namedtuple
+from statistics import mean
 
 import torch
 
@@ -23,13 +28,14 @@ from aitemplate.compiler import compile_model, ops
 from aitemplate.compiler.base import IntVar
 from aitemplate.frontend import Tensor
 from aitemplate.testing import detect_target
+from aitemplate.testing.profile import profile_callable
 from aitemplate.testing.test_utils import filter_test_cases_by_params, TestEnv
 from aitemplate.utils.torch_utils import string_to_torch_dtype
 from parameterized import parameterized
 
 
 class SoftmaxTestCase(unittest.TestCase):
-    def _test_softmax(
+    def _build_model(
         self,
         batch_sizes=(1, 1024),
         input_shapes=(6,),
@@ -42,7 +48,7 @@ class SoftmaxTestCase(unittest.TestCase):
             self.skipTest(f"Rocm doesn't support {dtype}")
         if target.name() == "cuda" and dtype == "bfloat16" and int(target._arch) < 80:
             self.skipTest(f"CUDA SM{target._arch} doesn't support {dtype}")
-        torch_dtype = string_to_torch_dtype(dtype)
+
         X = Tensor(
             shape=[IntVar(name="input_batch", values=list(batch_sizes)), *input_shapes],
             dtype=dtype,
@@ -51,9 +57,20 @@ class SoftmaxTestCase(unittest.TestCase):
         )
         Y = ops.softmax()(X, dim)
         Y._attrs["is_output"] = True
-        Y._attrs["name"] = "output"
+        Y._attrs["name"] = "Y"
 
-        module = compile_model(Y, target, "./tmp", testname)
+        return compile_model(Y, target, "./tmp", testname)
+
+    def _test_softmax(
+        self,
+        batch_sizes=(1, 1024),
+        input_shapes=(6,),
+        dim=-1,
+        dtype="float16",
+        testname="softmax",
+    ):
+        module = self._build_model(batch_sizes, input_shapes, dim, dtype, testname)
+        torch_dtype = string_to_torch_dtype(dtype)
 
         for batch_size in batch_sizes:
             x_pt = torch.randn(batch_size, *input_shapes, dtype=torch_dtype).cuda()
@@ -137,6 +154,83 @@ class SoftmaxTestCase(unittest.TestCase):
             dim=dim,
         )
 
+    def _test_benchmark_softmax(self):
+        dtype = "float16"
+        torch_dtype = string_to_torch_dtype(dtype)
+        BenchResult = namedtuple(
+            "BenchResult", ["dim", "batch_size", "permute_ms", "softmax_ms"]
+        )
+        results = []
+        shape = (260, 4)
+        batch_sizes = [2**p for p in range(0, 16)]
+        for reduction_dim in [-1, -2]:
+            module = self._build_model(
+                batch_sizes,
+                shape,
+                reduction_dim,
+                dtype,
+                f"bench_softmax_{abs(reduction_dim)}",
+            )
+
+            for batch_size in batch_sizes:
+                x_pt = torch.ones(batch_size, *shape, dtype=torch_dtype).cuda()
+                y_pt = torch.empty([batch_size, *shape], dtype=torch_dtype).cuda()
+                with tempfile.NamedTemporaryFile("r") as f:
+                    module.profile_with_tensors(
+                        inputs={"X": x_pt},
+                        outputs={"Y": y_pt},
+                        num_iters=1000,
+                        filename=f.name,
+                    )
+                    profiling_data = json.loads(f.read())
+
+                    permute_ms = 0
+                    softmax_ms = 0
+                    for func_name, record in profiling_data.items():
+                        if func_name.startswith("permute"):
+                            permute_ms += record["ms_per_iter"]
+                        elif func_name.startswith("softmax"):
+                            softmax_ms += record["ms_per_iter"]
+                    results.append(
+                        BenchResult(reduction_dim, batch_size, permute_ms, softmax_ms)
+                    )
+
+        for r in results:
+            items = r.batch_size * math.prod(shape)
+            runtime_ms = r.permute_ms + r.softmax_ms
+            print(
+                f"{r.dim=}, {items=}, {r.permute_ms=}, {r.softmax_ms=}, {runtime_ms=}"
+            )
+
+    def _test_benchmark_pytorch_softmax(self):
+        batch_sizes = [2**p for p in range(0, 16)]
+        shape = (260, 4)
+        dtype = "float16"
+        torch_dtype = string_to_torch_dtype(dtype)
+        BenchResult = namedtuple("BenchResult", ["dim", "batch_size", "runtime_ms"])
+        cache_flush_slab = torch.empty(
+            size=[40, 1024, 1024],  # A100 L2 cache size
+            dtype=torch.float16,
+        ).cuda()
+
+        results = []
+        for reduction_dim in [-1, -2]:
+            for batch_size in batch_sizes:
+                x_pt = torch.ones(batch_size, *shape, dtype=torch_dtype).cuda()
+                _, wall_times = profile_callable(
+                    lambda: torch.nn.functional.softmax(x_pt, dim=reduction_dim),
+                    cache_flush_slab,
+                    n_iter=1000,
+                )
+                results.append(
+                    BenchResult(reduction_dim, batch_size, mean(wall_times) / 1000.0)
+                )
+
+        for r in results:
+            items = r.batch_size * math.prod(shape)
+            print(f"{r.dim=}, {items=}, {r.runtime_ms=}")
+
 
 if __name__ == "__main__":
+    torch.manual_seed(0)
     unittest.main()


### PR DESCRIPTION
Summary: To compare the relative slowdown when we are reducing over the non-last dimension. Also to compare our relative performance to PyTorch's kernel.

Differential Revision: D47540354

