### PR TITLE
extend output_checks to work with more types

### DIFF
--- a/python/aitemplate/backend/cuda/lib_template.py
+++ b/python/aitemplate/backend/cuda/lib_template.py
@@ -18,6 +18,7 @@ Common function templates for CUDA codegen.
 import jinja2
 
 from aitemplate.backend import registry
+from aitemplate.backend.backend_spec import CUDASpec
 
 # pylint: disable=C0301
 
@@ -36,3 +37,9 @@ def void_ptr_decl(name, dtype="float16", indent="  "):
     # FIXME: we keep dtype in void_ptr_decl's param list because rocm needs it.
     # We will remove it once we support general tensor type for rocm
     return PTR_TEMPLATE.render(name=name, dtype="void*", indent=indent)
+
+
+@registry.reg("cuda.lib.dtype_to_backend_type")
+def dtype_to_backend_type(dtype):
+    backend_spec = CUDASpec()
+    return backend_spec.dtype_to_backend_type(dtype)

--- a/python/aitemplate/backend/rocm/lib_template.py
+++ b/python/aitemplate/backend/rocm/lib_template.py
@@ -18,6 +18,7 @@ Common codegen functions for ROCM.
 import jinja2
 
 from aitemplate.backend import registry
+from aitemplate.backend.backend_spec import ROCMSpec
 
 # pylint: disable=W0613
 
@@ -44,3 +45,9 @@ def void_ptr_decl(name, dtype="float16", indent="  "):
     else:
         raise NotImplementedError
     return PTR_TEMPLATE.render(name=name, dtype=type_string, indent=indent)
+
+
+@registry.reg("rocm.lib.dtype_to_backend_type")
+def dtype_to_backend_type(dtype):
+    backend_spec = ROCMSpec()
+    return backend_spec.dtype_to_backend_type(dtype)

--- a/static/csrc/debug_utility.cpp
+++ b/static/csrc/debug_utility.cpp
@@ -45,16 +45,6 @@ __global__ void inf_and_nan_checker(const half* tensor, int64_t elem_cnt) {
   }
 }
 
-__global__ void outputs_checker(const half* tensor, int64_t elem_cnt) {
-  for (int64_t i = 0; i < elem_cnt; i++) {
-    float v = (float)(*(tensor + i));
-    if (i != 0) {
-      printf(", ");
-    }
-    printf("%f", v);
-  }
-  printf("\n");
-}
 } // namespace
 
 namespace ait {
@@ -68,13 +58,4 @@ void InvokeInfAndNanChecker(
   ait::StreamSynchronize(stream);
 }
 
-void InvokeOutputsChecker(
-    const half* tensor,
-    const char* tensor_name,
-    int64_t elem_cnt,
-    ait::StreamType stream) {
-  printf("Tensor (%s) output:\n", tensor_name);
-  outputs_checker<<<1, 1, 0, stream>>>(tensor, elem_cnt);
-  ait::StreamSynchronize(stream);
-}
 } // namespace ait

--- a/static/include/debug_utility.h
+++ b/static/include/debug_utility.h
@@ -15,6 +15,21 @@
 #pragma once
 #include "device_functions-generated.h"
 
+namespace {
+template <typename T>
+__global__ void outputs_checker(const T* tensor, int64_t elem_cnt) {
+  for (int64_t i = 0; i < elem_cnt; i++) {
+    float v = (float)(*(tensor + i));
+    if (i != 0) {
+      printf(", ");
+    }
+    printf("%f", v);
+  }
+  printf("\n");
+}
+
+} // namespace
+
 namespace ait {
 void InvokeInfAndNanChecker(
     const half* tensor,
@@ -22,9 +37,14 @@ void InvokeInfAndNanChecker(
     int64_t elem_cnt,
     ait::StreamType stream);
 
+template <typename T>
 void InvokeOutputsChecker(
-    const half* tensor,
+    const T* tensor,
     const char* tensor_name,
     int64_t elem_cnt,
-    ait::StreamType stream);
+    ait::StreamType stream) {
+  printf("Tensor (%s) output:\n", tensor_name);
+  outputs_checker<<<1, 1, 0, stream>>>(tensor, elem_cnt);
+  ait::StreamSynchronize(stream);
+}
 } // namespace ait


### PR DESCRIPTION
Previously, our InvokeOutputsChecker only worked with half. This PR extended it with general type support.