### PR TITLE
MSVC fixes

### DIFF
--- a/python/aitemplate/backend/codegen.py
+++ b/python/aitemplate/backend/codegen.py
@@ -49,7 +49,7 @@ from aitemplate.utils.environ import (
     multistream_mode,
 )
 from aitemplate.utils.graph_utils import split_simple_multistream_parallel_ops
-from aitemplate.utils.misc import is_debug
+from aitemplate.utils.misc import is_debug, is_windows
 
 # pylint: disable=C0103,W0613,C0301
 
@@ -1067,8 +1067,7 @@ class ModelContainerGenerator:
             set_up_constant_folding_inputs="\n".join(
                 self.set_up_constant_folding_inputs
             ),
-            # # todo: enable once this feature is fully available
-            # is_windows=is_windows(),
+            is_windows=is_windows(),
         )
         result[model_container_src_fname] = model_container_base_src
         return result

--- a/python/aitemplate/backend/cuda/builder_cmake.py
+++ b/python/aitemplate/backend/cuda/builder_cmake.py
@@ -228,7 +228,10 @@ class BuilderCMake:
 
         device_compiler_options = Target.current().get_device_compiler_options()
         if is_windows():
-            host_compiler_options = ["-Xcompiler=/Zc:__cplusplus", "-D_DISABLE_EXTENDED_ALIGNED_STORAGE"]
+            host_compiler_options = [
+                "-Xcompiler=/Zc:__cplusplus",
+                "-D_DISABLE_EXTENDED_ALIGNED_STORAGE",
+            ]
         else:
             host_compiler_options = [
                 f"-Xcompiler {opt}" if "=" in opt else f"-Xcompiler={opt}"

--- a/python/aitemplate/backend/cuda/builder_cmake.py
+++ b/python/aitemplate/backend/cuda/builder_cmake.py
@@ -262,7 +262,6 @@ class BuilderCMake:
         for source, profiler_binary in file_pairs:
             if type(source) is not list:
                 source = [source]
-            source = [f"../{s}" if ":" not in s else s for s in source]
             test_name = short_str(str(source[0]))
 
             build_dir = Path(source[0]).parent / test_name
@@ -270,7 +269,9 @@ class BuilderCMake:
 
             rendered = cmake_template.render(
                 CMAKE_PROJECT=test_name,
-                CMAKE_SOURCE_FILES=_files_as_str(source),
+                CMAKE_SOURCE_FILES=_files_as_str(
+                    [f"../{str(Path(s).name)}" if ":" not in s else s for s in source]
+                ),
                 # # todo: this can be done once we're able to track header files
                 # # properly
                 # CMAKE_HEADER_FILES=_files_as_str(

--- a/python/aitemplate/backend/cuda/builder_cmake.py
+++ b/python/aitemplate/backend/cuda/builder_cmake.py
@@ -228,7 +228,7 @@ class BuilderCMake:
 
         device_compiler_options = Target.current().get_device_compiler_options()
         if is_windows():
-            host_compiler_options = ["-Xcompiler=/Zc:__cplusplus"]
+            host_compiler_options = ["-Xcompiler=/Zc:__cplusplus", "-D_DISABLE_EXTENDED_ALIGNED_STORAGE"]
         else:
             host_compiler_options = [
                 f"-Xcompiler {opt}" if "=" in opt else f"-Xcompiler={opt}"

--- a/python/aitemplate/backend/cuda/builder_cmake.py
+++ b/python/aitemplate/backend/cuda/builder_cmake.py
@@ -257,14 +257,17 @@ class BuilderCMake:
 
         # go ahead
         for source, profiler_binary in file_pairs:
-            test_name = short_str(str(source))
+            if type(source) is not list:
+                source = [source]
+            source = [f"../{s}" if ":" not in s else s for s in source]
+            test_name = short_str(str(source[0]))
 
-            build_dir = Path(source).parent / test_name
+            build_dir = Path(source[0]).parent / test_name
             build_dir.mkdir(exist_ok=True)
 
             rendered = cmake_template.render(
                 CMAKE_PROJECT=test_name,
-                CMAKE_SOURCE_FILES=_files_as_str("../" + str(Path(source).name)),
+                CMAKE_SOURCE_FILES=_files_as_str(source),
                 # # todo: this can be done once we're able to track header files
                 # # properly
                 # CMAKE_HEADER_FILES=_files_as_str(

--- a/python/aitemplate/backend/cuda/conv2d/common.py
+++ b/python/aitemplate/backend/cuda/conv2d/common.py
@@ -857,6 +857,7 @@ def gen_function(
         program = EXEC_TEMPLATE.render(
             is_bias=is_bias,
             is_bias_add=is_bias_add,
+            is_windows=is_windows(),
             indent=" " * 4,
             instance_name=fname,
             dtype=dtype,

--- a/python/aitemplate/backend/cuda/conv2d/common.py
+++ b/python/aitemplate/backend/cuda/conv2d/common.py
@@ -28,6 +28,7 @@ from aitemplate.backend.cuda.gemm_universal.common import add_profiler, build_pr
 from aitemplate.backend.target import Target
 
 from aitemplate.utils import alignment
+from aitemplate.utils.misc import is_windows
 
 
 KERNEL_KEY_TEMPLATE = jinja2.Template(
@@ -67,7 +68,11 @@ EXEC_TEMPLATE = jinja2.Template(
 {{indent}}    static_cast<{{dtype}}*>(bias_ptr),                                            // void * ptr_Vector
 {{indent}}    nullptr,                                                                      // void * ptr_Tensor
 {{indent}}    0,                                                                            // typename LayoutC::Stride::Index ldr
+{% if is_windows %}
+{{indent}}    static_cast<int>(*out_ch),                                                    // typename LayoutC::Stride::Index ldt
+{% else %}
 {{indent}}    *out_ch,                                                                      // typename LayoutC::Stride::Index ldt
+{% endif %}
 {% else %}
 {{indent}}    {ElementComputeEpilogue(1), ElementComputeEpilogue(0)},                       // typename EpilogueOutputOp::Params const & output_op
 {% endif %}
@@ -639,6 +644,7 @@ def gen_profiler(
             is_profiler=True,
             is_bias=is_bias,
             is_bias_add=is_bias_add,
+            is_windows=is_windows(),
             instance_name=instance_name,
             dtype=dtype,
         )

--- a/python/aitemplate/backend/cuda/tensor/expand.py
+++ b/python/aitemplate/backend/cuda/tensor/expand.py
@@ -28,6 +28,7 @@ from aitemplate.backend.cuda.tensor import expand_static_shape  # noqa: F401
 
 from aitemplate.utils.misc import is_windows
 
+
 @registry.reg("cuda.expand.func_decl")
 def gen_function_decl(func_attrs: Dict[str, Any]) -> str:
     if func_attrs["optimize_fixed_dims"] and func_attrs["non_head_dims_are_fixed"]:

--- a/python/aitemplate/backend/main_templates.py
+++ b/python/aitemplate/backend/main_templates.py
@@ -322,12 +322,12 @@ MODEL_CONTAINER_TEMPLATE = jinja2.Template(
 #include "model_container.h"
 #include "owned_constants.h"
 
-namespace ait {
-namespace {
-
 {% if is_windows %}
 #include "windll.h"
 {% endif %}
+
+namespace ait {
+namespace {
 
 // Contains the metadata for each constant.
 constexpr std::array<ConstantInfo, {{ num_constants }}> owned_constants = {


### PR DESCRIPTION
This PR comprises 5 fixes related to CMake MSVC.

## [builder_cmake list of source fix](https://github.com/facebookincubator/AITemplate/commit/5021cc7e8bf56ac1f5131c88a280a2108948db2e)
Issue occurs when compiling profilers.
```
File "aitemplate\backend\cuda\builder_cmake.py", line 262, in make_profilers
  build_dir = Path(source).parent / test_name

File "aitemplate\backend\cuda\builder_cmake.py", line 271, in make_profilers
  CMAKE_SOURCE_FILES=_files_as_str("../" + str(Path(source).name)),

TypeError: expected str, bytes or os.PathLike object, not list
```
Also fixed for absolute path work_dir.

## [MSVC aligned_storage fix](https://github.com/facebookincubator/AITemplate/commit/8fc7ea2474c3463b6c6b7afabda42030ff160fb3)
```
error : static assertion failed with "You've instantiated std::aligned_storage<Len, Align> with an extended alignment (in other words, Align > alignof(max_align_t)). Before VS 2017 15.8, the member "type" would non-conformingly have an alignment of only alignof(max_align_t). VS 2017 15.8 was fixed to handle this correctly, but the fix inherently changes layout and breaks binary compatibility (*only* for uses of aligned_storage with extended alignments). To suppress this error, please define either (1) _ENABLE_EXTENDED_ALIGNED_STORAGE to confirm that you want a type with an extended alignment, or (2) _DISABLE_EXTENDED_ALIGNED_STORAGE to get the old non-conforming behavior."
```
Adds `-D_DISABLE_EXTENDED_ALIGNED_STORAGE` to compile options.

## [MSVC Conv2d common narrowing conversion](https://github.com/facebookincubator/AITemplate/commit/d7441d8d89ea91b210890f4874eda4baef92fd71)
`error C2398: Element '11': conversion from 'int64_t' to 'int' requires a narrowing conversion`
Error refers to 
https://github.com/facebookincubator/AITemplate/blob/048c9e7bf0c8e9a180aa9f61d192dd404a30f1a8/python/aitemplate/backend/cuda/conv2d/common.py#L70
`is_windows` passed to template so that fix is only applied on windows.

## [MSVC tensor/expand.py fix](https://github.com/facebookincubator/AITemplate/pull/841/commits/a9170084f57d7305cb1ac2ee95df57824c83a3e6)
Encountered when compiling CLIP which uses expand ops.
```
expand_4.cu(99): error : expression must have a constant value
  int64_t input_strides[input_rank];
                                   ^
expand_4.cu(99): note #2689-D: the value of parameter "input_rank" (declared at line 72) cannot be used as a constant
  int64_t input_strides[input_rank];
```

## [ModelContainerGenerator enable is_windows](https://github.com/facebookincubator/AITemplate/pull/841/commits/ce55067a4628f2ce5096b59754b57d900be9a3e1)/[main_templates.py fix windll.h include](https://github.com/facebookincubator/AITemplate/pull/841/commits/35485364abe5c6925c76b0bd1b0747adf91c2353)

Error before enabling `is_windows` for `ModelContainerGenerator`:
```
model_container_base.obj : error LNK2019: unresolved external symbol "unsigned char const * const _binary_constants_bin_start" (?_binary_constants_bin_start@@3QBEB) referenced in function "public: __cdecl ait::ModelContainerBase::ModelContainerBase(unsigned __int64,unsigned __int64,unsigned __int64,unsigned __int64,unsigned __int64,class AITemplateAllocator &)" (??0ModelContainerBase@ait@@QEAA@_K0000AEAVAITemplateAllocator@@@Z) [build\model.vcxproj]
         model_container_base.obj : error LNK2019: unresolved external symbol "unsigned char const * const _binary_constants_bin_end" (?_binary_constants_bin_end@@3QBEB) referenced in function "public: __cdecl ait::ModelContainerBase::ModelContainerBase(unsigned __int64,unsigned __int64,unsigned __int64,unsigned __int64,unsigned __int64,class AITemplateAllocator &)" (??0ModelContainerBase@ait@@QEAA@_K0000AEAVAITemplateAllocator@@@Z) [build\model.vcxproj]
         build\Release\model.dll : fatal error LNK1120: 2 unresolved externals [build\model.vcxproj]
```

After enabling `is_windows`:
```
error : identifier "GetConstantsBin" is undefined [build\objlib.vcxproj]
```
`windll.h` include was in the wrong place. It is moved outside of namespace.