### PR TITLE
Support dim != 1 for softmax w/o using permute

### DIFF
--- a/python/aitemplate/compiler/ops/softmax/softmax.py
+++ b/python/aitemplate/compiler/ops/softmax/softmax.py
@@ -37,7 +37,6 @@ from aitemplate.compiler.base import (
     Tensor,
 )
 from aitemplate.compiler.ops.softmax.cache_entry import NormQueryEntry, NormRecordEntry
-from aitemplate.compiler.ops.tensor.permute import permute
 
 from aitemplate.testing import detect_target
 
@@ -205,16 +204,12 @@ class softmax(Operator):
                 "flattening input tensor before normalization is not supported yet"
             )
         dim = wrap_dim(dim, x._rank())
-        tail_shapes = x.shape()[dim + 1 :]
-        # The backend only supports reduction over the last non-1 dimension, so if we want
-        # to reduce over other dimensions we have to permute the tensor first.
-        if not all(isinstance(s, IntImm) and s.value() == 1 for s in tail_shapes):
-            perm_shape = list(range(x._rank()))
-            perm_shape[dim] = x._rank() - 1
-            perm_shape[-1] = dim
-            x_perm = permute()(x, perm_shape)
-            x_perm_softmax = softmax()(x_perm, dim=-1)
-            return permute()(x_perm_softmax, perm_shape)
+
+        inner_dims = x.shape()[dim + 1 :]
+        if not all(isinstance(d, IntImm) for d in inner_dims):
+            raise NotImplementedError(
+                "inner dims must all be static; {dim=}, {x.shape()=}"
+            )
 
         self._attrs["inputs"] = [x]
         self._attrs["dim"] = dim


### PR DESCRIPTION
Summary:
This is a port of PyTorch's softmax implementation.

Notable differences:
* We use fast_exp & fast_max instead of std::max and std::exp
* We don't use higher-precision types for accumulator values (doesn't look like the dim=-1 softmax code does this either)

This is probably the reason why we are (very marginally) faster.

I have named this new softmax implementation "softmaxGeneral" since it is able to handle arbitrary reduction dimensions, even though we are only using it for the `dim > 1` case.

Differential Revision: D47732875

