### PR TITLE
Expose negative_slope for leaky_relu

### DIFF
--- a/python/aitemplate/compiler/ops/common/math.py
+++ b/python/aitemplate/compiler/ops/common/math.py
@@ -67,8 +67,8 @@ def sigmoid(tensor: Any) -> Tensor:
     return OP_REGISTRY.get("SIGMOID")(tensor)
 
 
-def leaky_relu(tensor: Any) -> Tensor:
-    return OP_REGISTRY.get("LRELU")(tensor)
+def leaky_relu(tensor: Any, negative_slope: Any) -> Tensor:
+    return OP_REGISTRY.get("LRELU")(tensor, negative_slope)
 
 
 def hardtanh(*args, **kwargs) -> Tensor:


### PR DESCRIPTION
`custom_math.cuh/h` supports `negative_slope` for `leaky_relu` however the option is not exposed in `ops/common/math.py`.

This PR simply exposes the `negative_slope` parameter.