### PR TITLE
Add more uses cases for linalg norm conversion.

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -307,8 +307,20 @@ def acc_ops_linalg_norm(
     input_val = kwargs["input"]
     if not isinstance(input_val, AITTensor):
         raise RuntimeError(f"Unexpected input for {name}: {input_val}")
+    if (
+        isinstance(kwargs["dim"], int)
+        and "ord" in kwargs
+        and kwargs["ord"] != 2
+        and kwargs["ord"] is not None
+    ):
+        # If dim is an int, the vector norm will be computed.
+        # For vector norm, the default ord is 2 if not specified
+        # otherwise, AIT hasn't implement it
+        raise RuntimeError("AIT linalg_norm only supports ord=2 use case!")
 
-    if "ord" not in kwargs or kwargs["ord"] != 2:
+    if not isinstance(kwargs["dim"], int) and (
+        "ord" not in kwargs or kwargs["ord"] != 2
+    ):
         raise RuntimeError("AIT linalg_norm only supports ord=2 use case!")
 
     # Hard code ord_kind=2 for l2 norm

--- a/fx2ait/fx2ait/test/converters/test_ait_linalg_norm.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_linalg_norm.py
@@ -42,6 +42,24 @@ class TestLinalgConverter(AITTestCase):
                 dim=1,
                 keepdims=True,
             ),
+            param(
+                "vector_norm_dim_3",
+                input_shape=[1, 100, 40, 40],
+                dim=3,
+                keepdims=False,
+            ),
+            param(
+                "vector_norm_dim_2",
+                input_shape=[1, 100, 40, 40],
+                dim=2,
+                keepdims=False,
+            ),
+            param(
+                "vector_norm_dim_1",
+                input_shape=[1, 100, 40, 40],
+                dim=-1,
+                keepdims=True,
+            ),
         ]
     )
     def test_linalg_norm(


### PR DESCRIPTION
Summary:
Add more uses cases for linalg norm conversion.
For torch.linalg.norm, if dim is an int, the vector norm will be computed. For vector norm, the default ord is 2 if not specifed.
Therefore when ord=None and dim is integer, we can safely use AIT's vector norm

Differential Revision: D47859386

