### PR TITLE
Fix maximum recursion depth exceeded

### DIFF
--- a/python/aitemplate/compiler/stable_set.py
+++ b/python/aitemplate/compiler/stable_set.py
@@ -19,8 +19,11 @@ It also tries to preserve the original element order as much as possible, which 
 potentially make debugging (e.g. comparison with the original graph, comparison between
 AIT GPU trace and other GPU traces) easier.
 """
+import sys
 from collections import abc
 from typing import Any, Iterable
+
+sys.setrecursionlimit(10000)
 
 
 class StableSet(abc.MutableSet):


### PR DESCRIPTION
Fix for error encountered when compiling large graph. This PR simply increases the recursion limit in `compiler/stable_set.py`. 

```
  File "aitemplate\compiler\compiler.py", line 260, in compile_model
    graph = compiler.transform.optimize_graph(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aitemplate\compiler\transform\optimize_graph.py", line 146, in optimize_graph
    sorted_graph = func(sorted_graph, workdir)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aitemplate\compiler\transform\fuse_group_ops.py", line 762, in fuse_group_ops
    sorted_graph = fuse_group_layernorm_ops(sorted_graph)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aitemplate\compiler\transform\fuse_group_ops.py", line 732, in fuse_group_layernorm_ops
    sorted_graph = _fuse_group_ops_by_type(sorted_graph, op_type, workdir)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aitemplate\compiler\transform\fuse_group_ops.py", line 711, in _fuse_group_ops_by_type
    if not _group_ops_by_type(sorted_graph, op_type, workdir):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aitemplate\compiler\transform\fuse_group_ops.py", line 464, in _group_ops_by_type
    dependency_graph = _get_dependency_graph(sorted_graph, op_type)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aitemplate\compiler\transform\fuse_group_ops.py", line 367, in _get_dependency_graph
    _dfs(tensor, op_type, visited)
  File "aitemplate\compiler\transform\fuse_group_ops.py", line 304, in _dfs
    descendants.update(_dfs(output, op_type, visited))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aitemplate\compiler\transform\fuse_group_ops.py", line 304, in _dfs
    descendants.update(_dfs(output, op_type, visited))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aitemplate\compiler\transform\fuse_group_ops.py", line 304, in _dfs
    descendants.update(_dfs(output, op_type, visited))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  [Previous line repeated 979 more times]
  File "aitemplate\compiler\transform\fuse_group_ops.py", line 301, in _dfs
    for op in tensor.dst_ops():
  File "aitemplate\compiler\stable_set.py", line 70, in __iter__
    return list(self._d).__iter__()
           ^^^^^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded while calling a Python object
```