### PR TITLE
Introduce a new option to optimize the compilation time

### DIFF
--- a/fx2ait/fx2ait/fx2ait.py
+++ b/fx2ait/fx2ait/fx2ait.py
@@ -70,6 +70,7 @@ class AITInterpreter(torch.fx.Interpreter):
         do_optimize_graph: bool = True,
         use_fast_math: bool = True,
         profile_timeout: int = 500,
+        optimize_for_compilation_time: bool = False,
     ):
         """
         Args:
@@ -89,6 +90,7 @@ class AITInterpreter(torch.fx.Interpreter):
             save_remote_cache: whether to save the updated cache
             use_fast_math: whether to use fast math in CUDA kernels
             profile_timeout: timeout in seconds for AIT profilers to complete
+            optimize_for_compilation_time: we use O1 and disable the ProfileImpl function to reduce compilation time.
         """
         super().__init__(module)
 
@@ -112,6 +114,7 @@ class AITInterpreter(torch.fx.Interpreter):
             _LOGGER.info(f"Set CACHE_DIR to {self.cache_dir}")
         self.use_fp16_acc = use_fp16_acc
         self.use_fast_math = use_fast_math
+        self.optimize_for_compilation_time = optimize_for_compilation_time
         self.hardware_target = self._create_target()
         self.input_specs = input_specs
         self.input_specs_iter = 0
@@ -138,6 +141,7 @@ class AITInterpreter(torch.fx.Interpreter):
             use_fp16_acc=self.use_fp16_acc,
             remote_cache_bytes=self.remote_cache_bytes,
             use_fast_math=self.use_fast_math,
+            optimize_for_compilation_time=self.optimize_for_compilation_time,
         )
 
     def _load_profile_cache(self) -> bytes:

--- a/fx2ait/fx2ait/lower/lower_settings.py
+++ b/fx2ait/fx2ait/lower/lower_settings.py
@@ -83,3 +83,5 @@ class LowerSettings:
     load_ait_dir: Optional[str] = None
     # jit.trace AITModule
     trace_ait_module: bool = True
+    # If True, optimize for compilation time (ie. compile w/ -O1 rather than -O3 and skip profiling codegen)
+    optimize_for_compilation_time: bool = False

--- a/python/aitemplate/backend/main_templates.py
+++ b/python/aitemplate/backend/main_templates.py
@@ -226,6 +226,9 @@ class {{model_name}} : public ModelBase<{{model_name}}> {
 {% endif %}
 
     void ProfileImpl(StreamType stream, size_t iters, const std::string& filename) {
+#ifdef OPTIMIZE_FOR_COMPILATION_TIME
+      throw std::runtime_error("Profile is disabled, please recompile without OPTIMIZE_FOR_COMPILE_TIME flag");
+#else
       std::ofstream ss(filename);
       if (!ss) {
         throw std::runtime_error(std::string("Could not open file ") + filename);
@@ -285,6 +288,7 @@ class {{model_name}} : public ModelBase<{{model_name}}> {
       DeviceToDeviceCopies(stream);
       std::cout << "AIT per op profiling finished." << std::endl;
       FreeDeviceMemory(L2CacheSlab);
+#endif
     }
 
     static std::unique_ptr<{{model_name}}> Create(


### PR DESCRIPTION
Summary: Adds new `optimize_for_compilation_time` setting to lowering settings, which skips the codegen for ProfileImpl and does the gcc compilation with `-O1` flag rather than `-O3`.

Reviewed By: chenyang78

Differential Revision: D47862220

