### PR TITLE
Upsampling2d out shape / SD 8px increment. Fixes #867.

### DIFF
--- a/examples/05_stable_diffusion/scripts/compile.py
+++ b/examples/05_stable_diffusion/scripts/compile.py
@@ -55,8 +55,8 @@ def compile_diffusers(
     ).to("cuda")
 
     assert (
-        height % 64 == 0 and width % 64 == 0
-    ), "Height and Width must be multiples of 64, otherwise, the compilation process will fail."
+        height % 8 == 0 and width % 8 == 0
+    ), "Height and Width must be multiples of 8, otherwise, the compilation process will fail."
 
     ww = width // 8
     hh = height // 8

--- a/examples/05_stable_diffusion/scripts/compile_alt.py
+++ b/examples/05_stable_diffusion/scripts/compile_alt.py
@@ -82,10 +82,10 @@ def compile_diffusers(
         convert_conv_to_gemm = False
 
     assert (
-        width[0] % 64 == 0 and width[1] % 64 == 0
+        width[0] % 8 == 0 and width[1] % 8 == 0
     ), "Minimum Width and Maximum Width must be multiples of 64, otherwise, the compilation process will fail."
     assert (
-        height[0] % 64 == 0 and height[1] % 64 == 0
+        height[0] % 8 == 0 and height[1] % 8 == 0
     ), "Minimum Height and Maximum Height must be multiples of 64, otherwise, the compilation process will fail."
 
     pipe = StableDiffusionPipeline.from_pretrained(

--- a/examples/05_stable_diffusion/scripts/compile_controlnet.py
+++ b/examples/05_stable_diffusion/scripts/compile_controlnet.py
@@ -60,10 +60,10 @@ def compile_diffusers(
         convert_conv_to_gemm = False
 
     assert (
-        width % 64 == 0
+        width % 8 == 0
     ), "Width must be multiples of 64, otherwise, the compilation process will fail."
     assert (
-        height % 64 == 0
+        height % 8 == 0
     ), "Height must be multiples of 64, otherwise, the compilation process will fail."
 
     controlnet = ControlNetModel.from_pretrained(

--- a/examples/05_stable_diffusion/src/modeling/resnet.py
+++ b/examples/05_stable_diffusion/src/modeling/resnet.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 #
 from aitemplate.compiler import ops
-from aitemplate.frontend import nn
+from aitemplate.frontend import nn, Tensor
 
 
 def get_shape(x):
@@ -57,11 +57,17 @@ class Upsample2D(nn.Module):
         else:
             self.Conv2d_0 = conv
 
-    def forward(self, x):
+    def forward(self, x, upsample_size=None):
         if self.use_conv_transpose:
             return self.conv(x)
-
-        x = nn.Upsampling2d(scale_factor=2.0, mode="nearest")(x)
+        out = None
+        if upsample_size is not None:
+            out = ops.size()(x)
+            out[1] = upsample_size[1]
+            out[2] = upsample_size[2]
+            out = [x._attrs["int_var"] for x in out]
+            out = Tensor(out)
+        x = nn.Upsampling2d(scale_factor=2.0, mode="nearest")(x, out)
 
         # TODO(Suraj, Patrick) - clean up after weight dicts are correctly renamed
         if self.use_conv:

--- a/examples/05_stable_diffusion/src/modeling/unet_2d_condition.py
+++ b/examples/05_stable_diffusion/src/modeling/unet_2d_condition.py
@@ -14,6 +14,7 @@
 #
 from typing import Optional, Tuple, Union
 
+from aitemplate.compiler import ops
 from aitemplate.frontend import nn, Tensor
 
 from .embeddings import TimestepEmbedding, Timesteps
@@ -248,11 +249,15 @@ class UNet2DConditionModel(nn.Module):
             sample += mid_block_additional_residual
 
         # 5. up
-        for upsample_block in self.up_blocks:
+        upsample_size = None
+        for i, upsample_block in enumerate(self.up_blocks):
+            is_final_block = i == len(self.up_blocks) - 1
             res_samples = down_block_res_samples[-len(upsample_block.resnets) :]
             down_block_res_samples = down_block_res_samples[
                 : -len(upsample_block.resnets)
             ]
+            if not is_final_block:
+                upsample_size = ops.size()(down_block_res_samples[-1])
 
             if (
                 hasattr(upsample_block, "attentions")
@@ -263,10 +268,14 @@ class UNet2DConditionModel(nn.Module):
                     temb=emb,
                     res_hidden_states_tuple=res_samples,
                     encoder_hidden_states=encoder_hidden_states,
+                    upsample_size=upsample_size,
                 )
             else:
                 sample = upsample_block(
-                    hidden_states=sample, temb=emb, res_hidden_states_tuple=res_samples
+                    hidden_states=sample,
+                    temb=emb,
+                    res_hidden_states_tuple=res_samples,
+                    upsample_size=upsample_size,
                 )
 
         # 6. post-process

--- a/examples/05_stable_diffusion/src/modeling/unet_blocks.py
+++ b/examples/05_stable_diffusion/src/modeling/unet_blocks.py
@@ -543,6 +543,7 @@ class CrossAttnUpBlock2D(nn.Module):
         res_hidden_states_tuple,
         temb=None,
         encoder_hidden_states=None,
+        upsample_size=None,
     ):
         for resnet, attn in zip(self.resnets, self.attentions):
             # pop res hidden states
@@ -557,7 +558,7 @@ class CrossAttnUpBlock2D(nn.Module):
 
         if self.upsamplers is not None:
             for upsampler in self.upsamplers:
-                hidden_states = upsampler(hidden_states)
+                hidden_states = upsampler(hidden_states, upsample_size)
 
         return hidden_states
 
@@ -610,7 +611,9 @@ class UpBlock2D(nn.Module):
         else:
             self.upsamplers = None
 
-    def forward(self, hidden_states, res_hidden_states_tuple, temb=None):
+    def forward(
+        self, hidden_states, res_hidden_states_tuple, temb=None, upsample_size=None
+    ):
         for resnet in self.resnets:
             # pop res hidden states
             res_hidden_states = res_hidden_states_tuple[-1]
@@ -623,7 +626,7 @@ class UpBlock2D(nn.Module):
 
         if self.upsamplers is not None:
             for upsampler in self.upsamplers:
-                hidden_states = upsampler(hidden_states)
+                hidden_states = upsampler(hidden_states, upsample_size)
 
         return hidden_states
 

--- a/python/aitemplate/backend/cuda/upsample/upsampling2d.py
+++ b/python/aitemplate/backend/cuda/upsample/upsampling2d.py
@@ -49,13 +49,13 @@ def gen_function(
     half2_data_ref = backend_spec.half2_data_ref
 
     args = {
-        "indent":"    ",
-        "dtype":"int64_t ",
-        "div":"/",
-        "x_dim0":"*batch",
-        "x_dim1":"*in_h",
-        "x_dim2":"*in_w",
-        "x_dim3":"*in_ch",
+        "indent": "    ",
+        "dtype": "int64_t ",
+        "div": "/",
+        "x_dim0": "*batch",
+        "x_dim1": "*in_h",
+        "x_dim2": "*in_w",
+        "x_dim3": "*in_ch",
     }
     if func_attrs["out_shape"] is True:
         args["out_h"] = "*out_h"

--- a/python/aitemplate/backend/cuda/upsample/upsampling2d.py
+++ b/python/aitemplate/backend/cuda/upsample/upsampling2d.py
@@ -48,15 +48,22 @@ def gen_function(
     input_type = backend_spec.dtype_to_backend_type(x._attrs["dtype"])
     half2_data_ref = backend_spec.half2_data_ref
 
+    args = {
+        "indent":"    ",
+        "dtype":"int64_t ",
+        "div":"/",
+        "x_dim0":"*batch",
+        "x_dim1":"*in_h",
+        "x_dim2":"*in_w",
+        "x_dim3":"*in_ch",
+    }
+    if func_attrs["out_shape"] is True:
+        args["out_h"] = "*out_h"
+        args["out_w"] = "*out_w"
+    else:
+        args["scale_factor"] = func_attrs["scale_factor"]
     shape_eval_func = shape_eval_template.render(
-        indent="  ",
-        dtype="int64_t ",
-        x_dim0="*batch",
-        x_dim1="*in_h",
-        x_dim2="*in_w",
-        x_dim3="*in_ch",
-        scale_factor=func_attrs["scale_factor"],
-        div="/",
+        **args,
     )
     shape_save_func = shape_save_template.render(
         indent="  ",

--- a/python/aitemplate/compiler/ops/upsample/upsampling_common.py
+++ b/python/aitemplate/compiler/ops/upsample/upsampling_common.py
@@ -102,15 +102,17 @@ class upsampling2d_base(Operator):
         self.exec_cond_template = EXEC_COND_TEMPLATE
 
     def _infer_shape(self, x: List[int], out: List[int] = None):
-        self.shape_eval_template = SHAPE_FUNC_TEMPLATE if out is None else _SHAPE_FUNC_TEMPLATE
+        self.shape_eval_template = (
+            SHAPE_FUNC_TEMPLATE if out is None else _SHAPE_FUNC_TEMPLATE
+        )
         args = {
-            "indent":"",
-            "dtype":"",
-            "div":"//",
-            "x_dim0":x[0],
-            "x_dim1":x[1],
-            "x_dim2":x[2],
-            "x_dim3":x[3],
+            "indent": "",
+            "dtype": "",
+            "div": "//",
+            "x_dim0": x[0],
+            "x_dim1": x[1],
+            "x_dim2": x[2],
+            "x_dim3": x[3],
         }
         if out is None:
             args["scale_factor"] = self._attrs["scale_factor"]
@@ -118,9 +120,7 @@ class upsampling2d_base(Operator):
             args["out_h"] = out[1]
             args["out_w"] = out[2]
         self.shape_args = args
-        eval_func = self.shape_eval_template.render(
-            **args
-        )
+        eval_func = self.shape_eval_template.render(**args)
         output = {}
         exec(eval_func, output)  # noqa: P204
         return [
@@ -156,8 +156,16 @@ class upsampling2d_base(Operator):
 
         in_h = x._attrs["shape"][1]._attrs["symbolic_value"]
         in_w = x._attrs["shape"][2]._attrs["symbolic_value"]
-        out_h = in_h * int(self._attrs["scale_factor"]) if out is None else out._attrs["shape"][1]._attrs["symbolic_value"]
-        out_w = in_w * int(self._attrs["scale_factor"]) if out is None else out._attrs["shape"][2]._attrs["symbolic_value"]
+        out_h = (
+            in_h * int(self._attrs["scale_factor"])
+            if out is None
+            else out._attrs["shape"][1]._attrs["symbolic_value"]
+        )
+        out_w = (
+            in_w * int(self._attrs["scale_factor"])
+            if out is None
+            else out._attrs["shape"][2]._attrs["symbolic_value"]
+        )
 
         output_shape[1]._attrs["symbolic_value"] = out_h
         output_shape[2]._attrs["symbolic_value"] = out_w

--- a/python/aitemplate/frontend/nn/upsample.py
+++ b/python/aitemplate/frontend/nn/upsample.py
@@ -44,9 +44,11 @@ class Upsampling2d(Module):
         self.op = upsampling2d(scale_factor, mode)
 
     def forward(self, *args):
-        assert len(args) == 1
+        out = None
         x = args[0]
-        return self.op(x)
+        if len(args) == 2:
+            out = args[1]
+        return self.op(x, out)
 
 
 class Upsampling2dAdd(Module):


### PR DESCRIPTION
Allows out shape to be passed to Upsampling2d while maintaining compatibility with using a scale_factor. This enables SD to generate in 8px increment (#867).

Example:
69x69 552x552
![out2](https://github.com/facebookincubator/AITemplate/assets/106811348/c2a2d8bc-960e-45aa-8dd0-e3bfcb425ac0)

Also tested with ESRGAN example which uses Upsampling2d with scale factor, output is as expected.