### PR TITLE
SDXL

### DIFF
--- a/examples/05_stable_diffusion/scripts/compile_sdxl.py
+++ b/examples/05_stable_diffusion/scripts/compile_sdxl.py
@@ -1,0 +1,212 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import logging
+import sys
+
+import click
+import torch
+from aitemplate.testing import detect_target
+from aitemplate.utils.import_path import import_parent
+from diffusers import AutoencoderKL, StableDiffusionXLPipeline
+
+if __name__ == "__main__":
+    import_parent(filepath=__file__, level=1)
+
+from src.compile_lib.compile_clip_alt import compile_clip
+from src.compile_lib.compile_unet_alt import compile_timestep_embedder, compile_unet
+from src.compile_lib.compile_vae_alt import compile_vae
+
+
+@click.command()
+@click.option(
+    "--hf-hub-or-path",
+    default="stabilityai/stable-diffusion-xl-base-1.0",
+    help="the local or hf hub path e.g. stabilityai/stable-diffusion-xl-base-1.0",
+)
+@click.option(
+    "--width",
+    default=(64, 2048),
+    type=(int, int),
+    nargs=2,
+    help="Minimum and maximum width",
+)
+@click.option(
+    "--height",
+    default=(64, 2048),
+    type=(int, int),
+    nargs=2,
+    help="Minimum and maximum height",
+)
+@click.option(
+    "--batch-size",
+    default=(1, 1),
+    type=(int, int),
+    nargs=2,
+    help="Minimum and maximum batch size",
+)
+@click.option("--clip-chunks", default=10, help="Maximum number of clip chunks")
+@click.option(
+    "--include-constants",
+    default=True,
+    type=bool,
+    help="include constants (model weights) with compiled model",
+)
+@click.option("--use-fp16-acc", default=True, help="use fp16 accumulation")
+@click.option("--convert-conv-to-gemm", default=True, help="convert 1x1 conv to gemm")
+@click.option("--work-dir", default="./tmp", help="work directory")
+@click.option(
+    "--model-name-prefix", default="SDXL", help="Prefix for compiled module names"
+)
+@click.option(
+    "--fp32-vae",
+    default=False,
+    help="fp32 vae, if false, use https://huggingface.co/madebyollin/sdxl-vae-fp16-fix as replacement vae",
+)
+def compile_diffusers(
+    hf_hub_or_path,
+    width,
+    height,
+    batch_size,
+    clip_chunks,
+    include_constants,
+    use_fp16_acc=True,
+    convert_conv_to_gemm=True,
+    work_dir="./tmp",
+    model_name_prefix="SDXL",
+    fp32_vae=False,
+):
+    logging.getLogger().setLevel(logging.INFO)
+    torch.manual_seed(4896)
+
+    if detect_target().name() == "rocm":
+        convert_conv_to_gemm = False
+
+    pipe = StableDiffusionXLPipeline.from_pretrained(
+        hf_hub_or_path,
+        torch_dtype=torch.float16,
+    ).to("cuda")
+    if fp32_vae:
+        pipe.vae.to("cuda", dtype=torch.float32)
+    else:
+        vae = AutoencoderKL.from_pretrained(
+            "madebyollin/sdxl-vae-fp16-fix", torch_dtype=torch.float16
+        ).to("cuda")
+        pipe.vae = vae
+
+    # text_encoder
+    model_name = f"{model_name_prefix}_text_encoder"
+    compile_clip(
+        pipe.text_encoder,
+        batch_size=batch_size,
+        seqlen=pipe.text_encoder.config.max_position_embeddings,
+        use_fp16_acc=use_fp16_acc,
+        convert_conv_to_gemm=convert_conv_to_gemm,
+        output_hidden_states=True,
+        text_projection_dim=None,
+        depth=pipe.text_encoder.config.num_hidden_layers,
+        num_heads=pipe.text_encoder.config.num_attention_heads,
+        dim=pipe.text_encoder.config.hidden_size,
+        act_layer=pipe.text_encoder.config.hidden_act,
+        constants=include_constants,
+        model_name=model_name,
+        work_dir=work_dir,
+    )
+    # text_encoder 2
+    model_name = f"{model_name_prefix}_text_encoder_2"
+    compile_clip(
+        pipe.text_encoder_2,
+        batch_size=batch_size,
+        seqlen=pipe.text_encoder_2.config.max_position_embeddings,
+        use_fp16_acc=use_fp16_acc,
+        convert_conv_to_gemm=convert_conv_to_gemm,
+        output_hidden_states=True,
+        text_projection_dim=pipe.text_encoder_2.config.projection_dim,
+        depth=pipe.text_encoder_2.config.num_hidden_layers,
+        num_heads=pipe.text_encoder_2.config.num_attention_heads,
+        dim=pipe.text_encoder_2.config.hidden_size,
+        act_layer=pipe.text_encoder_2.config.hidden_act,
+        constants=include_constants,
+        model_name=model_name,
+        work_dir=work_dir,
+    )
+    model_name = f"{model_name_prefix}_unet"
+    # UNet
+    compile_unet(
+        pipe.unet,
+        batch_size=batch_size,
+        width=width,
+        height=height,
+        clip_chunks=clip_chunks,
+        use_fp16_acc=use_fp16_acc,
+        convert_conv_to_gemm=convert_conv_to_gemm,
+        hidden_dim=pipe.unet.config.cross_attention_dim,
+        attention_head_dim=pipe.unet.config.attention_head_dim,
+        use_linear_projection=pipe.unet.config.get("use_linear_projection", False),
+        block_out_channels=pipe.unet.config.block_out_channels,
+        down_block_types=pipe.unet.config.down_block_types,
+        up_block_types=pipe.unet.config.up_block_types,
+        in_channels=pipe.unet.config.in_channels,
+        out_channels=pipe.unet.config.out_channels,
+        class_embed_type=pipe.unet.config.class_embed_type,
+        num_class_embeds=pipe.unet.config.num_class_embeds,
+        only_cross_attention=pipe.unet.config.only_cross_attention,
+        sample_size=pipe.unet.config.sample_size,
+        dim=pipe.unet.config.block_out_channels[0],
+        time_embedding_dim=pipe.unet.config.time_embedding_dim,
+        conv_in_kernel=pipe.unet.config.conv_in_kernel,
+        projection_class_embeddings_input_dim=pipe.unet.config.projection_class_embeddings_input_dim,
+        addition_embed_type=pipe.unet.config.addition_embed_type,
+        addition_time_embed_dim=pipe.unet.config.addition_time_embed_dim,
+        transformer_layers_per_block=pipe.unet.config.transformer_layers_per_block,
+        constants=False
+        if sys.platform == "win32"
+        else include_constants,  # Too big, RC : fatal error RW1023: I/O error seeking in file
+        model_name=model_name,
+        work_dir=work_dir,
+    )
+    # `add_time_proj` Timesteps
+    model_name = f"{model_name_prefix}_addition_time_embed"
+    compile_timestep_embedder(
+        pipe.unet.config.addition_time_embed_dim,
+        work_dir=work_dir,
+        model_name=model_name,
+    )
+    model_name = f"{model_name_prefix}_vae"
+    # VAE
+    compile_vae(
+        pipe.vae,
+        batch_size=batch_size,
+        width=width,
+        height=height,
+        use_fp16_acc=use_fp16_acc,
+        convert_conv_to_gemm=convert_conv_to_gemm,
+        constants=include_constants,
+        block_out_channels=pipe.vae.config.block_out_channels,
+        layers_per_block=pipe.vae.config.layers_per_block,
+        act_fn=pipe.vae.config.act_fn,
+        latent_channels=pipe.vae.config.latent_channels,
+        in_channels=pipe.vae.config.in_channels,
+        out_channels=pipe.vae.config.out_channels,
+        down_block_types=pipe.vae.config.down_block_types,
+        up_block_types=pipe.vae.config.up_block_types,
+        sample_size=pipe.vae.config.sample_size,
+        model_name=model_name,
+        work_dir=work_dir,
+        dtype="float32" if fp32_vae else "float16",
+    )
+
+
+if __name__ == "__main__":
+    compile_diffusers()

--- a/examples/05_stable_diffusion/scripts/compile_sdxl.py
+++ b/examples/05_stable_diffusion/scripts/compile_sdxl.py
@@ -170,7 +170,6 @@ def compile_diffusers(
         conv_in_kernel=pipe.unet.config.conv_in_kernel,
         projection_class_embeddings_input_dim=pipe.unet.config.projection_class_embeddings_input_dim,
         addition_embed_type=pipe.unet.config.addition_embed_type,
-        addition_time_embed_dim=pipe.unet.config.addition_time_embed_dim,
         transformer_layers_per_block=pipe.unet.config.transformer_layers_per_block,
         constants=False
         if sys.platform == "win32"

--- a/examples/05_stable_diffusion/scripts/compile_sdxl.py
+++ b/examples/05_stable_diffusion/scripts/compile_sdxl.py
@@ -15,6 +15,8 @@
 import logging
 import sys
 
+sys.setrecursionlimit(10000)
+
 import click
 import torch
 from aitemplate.testing import detect_target

--- a/examples/05_stable_diffusion/scripts/demo_xl.py
+++ b/examples/05_stable_diffusion/scripts/demo_xl.py
@@ -16,9 +16,8 @@
 import click
 import torch
 
-from aitemplate.testing.benchmark_pt import benchmark_torch_function
 from aitemplate.utils.import_path import import_parent
-from diffusers import StableDiffusionXLPipeline, AutoencoderKL
+from diffusers import AutoencoderKL, StableDiffusionXLPipeline
 
 if __name__ == "__main__":
     import_parent(filepath=__file__, level=1)
@@ -70,7 +69,21 @@ from src.pipeline_stable_diffusion_xl_ait import StableDiffusionXLAITPipeline
 @click.option(
     "--benchmark", type=bool, default=False, help="run stable diffusion e2e benchmark"
 )
-def run(hf_hub_or_path, apply_weights, unet_module, text_encoder_module, text_encoder_2_module, time_embed_module, vae_module, width, height, batch, prompt, negative_prompt, benchmark):
+def run(
+    hf_hub_or_path,
+    apply_weights,
+    unet_module,
+    text_encoder_module,
+    text_encoder_2_module,
+    time_embed_module,
+    vae_module,
+    width,
+    height,
+    batch,
+    prompt,
+    negative_prompt,
+    benchmark,
+):
     diffusers_pipe = StableDiffusionXLPipeline.from_pretrained(
         hf_hub_or_path,
         use_safetensors=True,

--- a/examples/05_stable_diffusion/scripts/demo_xl.py
+++ b/examples/05_stable_diffusion/scripts/demo_xl.py
@@ -1,0 +1,112 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import click
+import torch
+
+from aitemplate.testing.benchmark_pt import benchmark_torch_function
+from aitemplate.utils.import_path import import_parent
+from diffusers import StableDiffusionXLPipeline, AutoencoderKL
+
+if __name__ == "__main__":
+    import_parent(filepath=__file__, level=1)
+
+from src.pipeline_stable_diffusion_xl_ait import StableDiffusionXLAITPipeline
+
+
+@click.command()
+@click.option(
+    "--hf-hub-or-path",
+    default="stabilityai/stable-diffusion-xl-base-1.0",
+    help="huggingface hub name or path to local model",
+)
+@click.option(
+    "--apply-weights",
+    default=True,
+    help="apply weights to module, required for Windows",
+)
+@click.option(
+    "--unet-module",
+    help="path to unet module",
+    required=True,
+)
+@click.option(
+    "--text-encoder-module",
+    help="path to text encoder module",
+    required=True,
+)
+@click.option(
+    "--text-encoder-2-module",
+    help="path to text encoder 2 module",
+    required=True,
+)
+@click.option(
+    "--time-embed-module",
+    help="path to time embed module",
+    required=True,
+)
+@click.option(
+    "--vae-module",
+    help="path to vae module",
+    required=True,
+)
+@click.option("--width", default=1024, help="Width of generated image")
+@click.option("--height", default=1024, help="Height of generated image")
+@click.option("--batch", default=1, help="Batch size of generated image")
+@click.option("--prompt", default="A vision of paradise, Unreal Engine", help="prompt")
+@click.option("--negative_prompt", default="", help="prompt")
+@click.option(
+    "--benchmark", type=bool, default=False, help="run stable diffusion e2e benchmark"
+)
+def run(hf_hub_or_path, apply_weights, unet_module, text_encoder_module, text_encoder_2_module, time_embed_module, vae_module, width, height, batch, prompt, negative_prompt, benchmark):
+    diffusers_pipe = StableDiffusionXLPipeline.from_pretrained(
+        hf_hub_or_path,
+        use_safetensors=True,
+        torch_dtype=torch.float16,
+    )
+    vae = AutoencoderKL.from_pretrained(
+        "madebyollin/sdxl-vae-fp16-fix",
+        use_safetensors=True,
+        torch_dtype=torch.float16,
+    )
+    pipe = StableDiffusionXLAITPipeline(
+        vae,
+        diffusers_pipe.text_encoder,
+        diffusers_pipe.text_encoder_2,
+        diffusers_pipe.tokenizer,
+        diffusers_pipe.tokenizer_2,
+        diffusers_pipe.unet,
+        diffusers_pipe.scheduler,
+        text_encoder_module,
+        text_encoder_2_module,
+        unet_module,
+        vae_module,
+        time_embed_module,
+        apply_weights_to_modules=apply_weights,
+    )
+
+    prompt = [prompt] * batch
+    images = pipe(
+        prompt=prompt,
+        prompt_2=prompt,
+        height=height,
+        width=width,
+    ).images
+    for i, image in enumerate(images):
+        image.save(f"example_ait_{i}.png")
+
+
+if __name__ == "__main__":
+    run()

--- a/examples/05_stable_diffusion/src/compile_lib/compile_clip_alt.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_clip_alt.py
@@ -12,19 +12,21 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import sys
 
 from aitemplate.compiler import compile_model
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
 
 from ..modeling.clip import CLIPTextTransformer as ait_CLIPTextTransformer
-from .util import mark_output
+from .util import torch_dtype_from_str
 
 
-def map_clip_params(pt_mod, batch_size=1, seqlen=77, depth=12):
-    params_ait = {}
+def map_clip(pt_mod, device="cuda", dtype="float16"):
     pt_params = dict(pt_mod.named_parameters())
+    params_ait = {}
     for key, arr in pt_params.items():
+        arr = arr.to(device, dtype=torch_dtype_from_str(dtype))
         name = key.replace("text_model.", "")
         ait_name = name.replace(".", "_")
         if name.endswith("out_proj.weight"):
@@ -38,7 +40,6 @@ def map_clip_params(pt_mod, batch_size=1, seqlen=77, depth=12):
         elif "v_proj" in name:
             ait_name = ait_name.replace("v_proj", "proj_v")
         params_ait[ait_name] = arr
-
     return params_ait
 
 
@@ -49,10 +50,14 @@ def compile_clip(
     dim=768,
     num_heads=12,
     depth=12,
-    use_fp16_acc=False,
-    convert_conv_to_gemm=False,
+    output_hidden_states=False,
+    text_projection_dim=None,
+    use_fp16_acc=True,
+    convert_conv_to_gemm=True,
     act_layer="gelu",
     constants=True,
+    model_name="CLIPTextModel",
+    work_dir="./tmp",
 ):
     mask_seq = 0
     causal = True
@@ -66,25 +71,41 @@ def compile_clip(
         causal=causal,
         mask_seq=mask_seq,
         act_layer=act_layer,
+        output_hidden_states=output_hidden_states,
+        text_projection_dim=text_projection_dim,
     )
     ait_mod.name_parameter_tensor()
 
     pt_mod = pt_mod.eval()
-    params_ait = map_clip_params(pt_mod, batch_size, seqlen, depth)
-    batch_size = IntVar(values=list(batch_size), name="batch_size")
+    params_ait = map_clip(pt_mod)
+
+    static_shape = batch_size[0] == batch_size[1]
+    if static_shape:
+        batch_size = batch_size[0]
+    else:
+        batch_size = IntVar(values=list(batch_size), name="batch_size")
 
     input_ids_ait = Tensor(
-        [batch_size, seqlen], name="input0", dtype="int64", is_input=True
+        [batch_size, seqlen], name="input_ids", dtype="int64", is_input=True
     )
     position_ids_ait = Tensor(
-        [batch_size, seqlen], name="input1", dtype="int64", is_input=True
+        [batch_size, seqlen], name="position_ids", dtype="int64", is_input=True
     )
+
     Y = ait_mod(input_ids=input_ids_ait, position_ids=position_ids_ait)
-    mark_output(Y)
+    for out in Y:
+        shape = [d._attrs["values"] for d in out._attrs["shape"]]
+        print(f'AIT {out._attrs["name"]} shape: {shape}')
 
     target = detect_target(
         use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm
     )
+    dll_name = model_name + ".dll" if sys.platform == "win32" else model_name + ".so"
     compile_model(
-        Y, target, "./tmp", "CLIPTextModel", constants=params_ait if constants else None
+        Y,
+        target,
+        work_dir,
+        model_name,
+        constants=params_ait if constants else None,
+        dll_name=dll_name,
     )

--- a/examples/05_stable_diffusion/src/compile_lib/compile_unet_alt.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_unet_alt.py
@@ -135,7 +135,7 @@ def compile_unet(
     projection_class_embeddings_input_dim=None,
     addition_embed_type=None,
     addition_time_embed_dim=None,
-    transformer_layers_per_block=1,
+    transformer_layers_per_block=[1, 1, 1, 1],
     dtype="float16",
 ):
     xl = False

--- a/examples/05_stable_diffusion/src/compile_lib/compile_unet_alt.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_unet_alt.py
@@ -12,24 +12,36 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import sys
+
 import torch
 from aitemplate.compiler import compile_model
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
 
-from ..modeling.controlnet_unet_2d_condition import (
-    ControlNetUNet2DConditionModel as ait_ControlNetUNet2DConditionModel,
-)
+from ..modeling.embeddings import Timesteps
 from ..modeling.unet_2d_condition import (
     UNet2DConditionModel as ait_UNet2DConditionModel,
 )
-from .util import mark_output
+from .util import torch_dtype_from_str
 
 
-def map_unet_params(pt_mod, dim):
-    pt_params = dict(pt_mod.named_parameters())
+def map_unet(
+    pt_mod, in_channels=None, conv_in_key=None, dim=320, device="cuda", dtype="float16"
+):
+    if in_channels is not None and conv_in_key is None:
+        raise ValueError(
+            "conv_in_key must be specified if in_channels is not None for padding"
+        )
+    if not isinstance(pt_mod, dict):
+        pt_params = dict(pt_mod.named_parameters())
+    else:
+        pt_params = pt_mod
     params_ait = {}
     for key, arr in pt_params.items():
+        if key.startswith("model.diffusion_model."):
+            key = key.replace("model.diffusion_model.", "")
+        arr = arr.to(device, dtype=torch_dtype_from_str(dtype))
         if len(arr.shape) == 4:
             arr = arr.permute((0, 2, 3, 1)).contiguous()
         elif key.endswith("ff.net.0.proj.weight"):
@@ -44,10 +56,41 @@ def map_unet_params(pt_mod, dim):
             continue
         params_ait[key.replace(".", "_")] = arr
 
-    params_ait["arange"] = (
-        torch.arange(start=0, end=dim // 2, dtype=torch.float32).cuda().half()
+    if conv_in_key is not None:
+        if in_channels % 4 != 0:
+            pad_by = 4 - (in_channels % 4)
+            params_ait[conv_in_key] = torch.functional.F.pad(
+                params_ait[conv_in_key], (0, pad_by)
+            )
+
+    params_ait["arange"] = torch.arange(start=0, end=dim // 2, dtype=torch.float32).to(
+        device, dtype=torch_dtype_from_str(dtype)
     )
     return params_ait
+
+
+def compile_timestep_embedder(
+    dim=256,
+    flip_sin_to_cos=True,
+    downscale_freq_shift=0,
+    work_dir="./tmp",
+    model_name="Timesteps",
+):
+    timesteps = Timesteps(
+        dim, flip_sin_to_cos=flip_sin_to_cos, downscale_freq_shift=downscale_freq_shift
+    )
+
+    timestep = Tensor([1], name="timestep", is_input=True)
+
+    Y = timesteps(timestep)
+    Y._attrs["is_output"] = True
+    Y._attrs["name"] = "time_embed"
+    shape = [d._attrs["values"] for d in Y._attrs["shape"]]
+    print(f'AIT {Y._attrs["name"]} shape: {shape}')
+    constants = {"arange": torch.arange(start=0, end=dim // 2, dtype=torch.float16)}
+
+    target = detect_target(use_fp16_acc=True, convert_conv_to_gemm=True)
+    compile_model(Y, target, work_dir, model_name, constants=constants)
 
 
 def compile_unet(
@@ -56,161 +99,280 @@ def compile_unet(
     height=(64, 2048),
     width=(64, 2048),
     clip_chunks=1,
+    work_dir="./tmp",
     dim=320,
     hidden_dim=1024,
     use_fp16_acc=False,
     convert_conv_to_gemm=False,
-    controlnet=True,
+    controlnet=False,
     attention_head_dim=[5, 10, 20, 20],  # noqa: B006
     model_name="UNet2DConditionModel",
     use_linear_projection=False,
     constants=True,
+    block_out_channels=(320, 640, 1280, 1280),
+    down_block_types=(
+        "CrossAttnDownBlock2D",
+        "CrossAttnDownBlock2D",
+        "CrossAttnDownBlock2D",
+        "DownBlock2D",
+    ),
+    up_block_types=(
+        "UpBlock2D",
+        "CrossAttnUpBlock2D",
+        "CrossAttnUpBlock2D",
+        "CrossAttnUpBlock2D",
+    ),
+    in_channels=4,
+    out_channels=4,
+    sample_size=64,
+    class_embed_type=None,
+    num_class_embeds=None,
+    only_cross_attention=[True, True, True, False],
+    down_factor=8,
+    time_embedding_dim=None,
+    conv_in_kernel: int = 3,
+    projection_class_embeddings_input_dim=None,
+    addition_embed_type=None,
+    addition_time_embed_dim=None,
+    transformer_layers_per_block=1,
+    dtype="float16",
 ):
-    if controlnet:
-        ait_mod = ait_ControlNetUNet2DConditionModel(
-            sample_size=64,
-            cross_attention_dim=hidden_dim,
-            attention_head_dim=attention_head_dim,
-            use_linear_projection=use_linear_projection,
+    xl = False
+    if projection_class_embeddings_input_dim is not None:
+        xl = True
+    if isinstance(only_cross_attention, bool):
+        only_cross_attention = [only_cross_attention] * len(block_out_channels)
+    if isinstance(transformer_layers_per_block, int):
+        transformer_layers_per_block = [transformer_layers_per_block] * len(
+            down_block_types
         )
-    else:
-        ait_mod = ait_UNet2DConditionModel(
-            sample_size=64,
-            cross_attention_dim=hidden_dim,
-            attention_head_dim=attention_head_dim,
-            use_linear_projection=use_linear_projection,
-        )
+    if isinstance(attention_head_dim, int):
+        attention_head_dim = (attention_head_dim,) * len(down_block_types)
+
+    ait_mod = ait_UNet2DConditionModel(
+        sample_size=sample_size,
+        cross_attention_dim=hidden_dim,
+        attention_head_dim=attention_head_dim,
+        use_linear_projection=use_linear_projection,
+        up_block_types=up_block_types,
+        down_block_types=down_block_types,
+        block_out_channels=block_out_channels,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        class_embed_type=class_embed_type,
+        num_class_embeds=num_class_embeds,
+        only_cross_attention=only_cross_attention,
+        time_embedding_dim=time_embedding_dim,
+        conv_in_kernel=conv_in_kernel,
+        projection_class_embeddings_input_dim=projection_class_embeddings_input_dim,
+        addition_embed_type=addition_embed_type,
+        addition_time_embed_dim=addition_time_embed_dim,
+        transformer_layers_per_block=transformer_layers_per_block,
+        dtype=dtype,
+    )
     ait_mod.name_parameter_tensor()
 
     # set AIT parameters
     pt_mod = pt_mod.eval()
-    params_ait = map_unet_params(pt_mod, dim)
-    if controlnet:
-        # static sizes only for now
-        batch_size = batch_size[0] * 2  # double batch size for unet
-        height = height[0] // 8
-        width = width[0] // 8
+    params_ait = map_unet(
+        pt_mod,
+        dim=dim,
+        in_channels=in_channels,
+        conv_in_key="conv_in_weight",
+        dtype=dtype,
+    )
+
+    static_shape = width[0] == width[1] and height[0] == height[1]
+
+    if static_shape:
+        height = height[0] // down_factor
+        width = width[0] // down_factor
         height_d = height
         width_d = width
+        height_1_d = height
+        width_1_d = width
+        height_2 = height // 2
+        width_2 = width // 2
+        height_4 = height // 4
+        width_4 = width // 4
+        height_8 = height // 8
+        width_8 = width // 8
+        height_2_d = height_2
+        width_2_d = width_2
+        height_4_d = height_4
+        width_4_d = width_4
+        height_8_d = height_8
+        width_8_d = width_8
     else:
-        batch_size = (batch_size[0], batch_size[1] * 2)  # double batch size for unet
-        batch_size = IntVar(values=list(batch_size), name="batch_size")
-        height = height[0] // 8, height[1] // 8
-        width = width[0] // 8, width[1] // 8
-        height_d = IntVar(values=list(height), name="height")
-        width_d = IntVar(values=list(width), name="width")
-    clip_chunks = 77, 77 * clip_chunks
-    embedding_size = IntVar(values=list(clip_chunks), name="embedding_size")
+        height = [x // down_factor for x in height]
+        width = [x // down_factor for x in width]
+        height_d = IntVar(values=list(height), name="height_d")
+        width_d = IntVar(values=list(width), name="width_d")
+        height_1_d = IntVar(values=list(height), name="height_1_d")
+        width_1_d = IntVar(values=list(width), name="width_1_d")
+        height_2 = [x // 2 for x in height]
+        width_2 = [x // 2 for x in width]
+        height_4 = [x // 4 for x in height]
+        width_4 = [x // 4 for x in width]
+        height_8 = [x // 8 for x in height]
+        width_8 = [x // 8 for x in width]
+        height_2_d = IntVar(values=list(height_2), name="height_2_d")
+        width_2_d = IntVar(values=list(width_2), name="width_2_d")
+        height_4_d = IntVar(values=list(height_4), name="height_4_d")
+        width_4_d = IntVar(values=list(width_4), name="width_4_d")
+        height_8_d = IntVar(values=list(height_8), name="height_8_d")
+        width_8_d = IntVar(values=list(width_8), name="width_8_d")
+
+    batch_size = batch_size[0], batch_size[1] * 2  # double batch size for unet
+    batch_size = IntVar(values=list(batch_size), name="batch_size")
+
+    if static_shape:
+        embedding_size = 77
+    else:
+        clip_chunks = 77, 77 * clip_chunks
+        embedding_size = IntVar(values=list(clip_chunks), name="embedding_size")
 
     latent_model_input_ait = Tensor(
-        [batch_size, height_d, width_d, 4], name="input0", is_input=True
+        [batch_size, height_d, width_d, in_channels],
+        name="latent_model_input",
+        is_input=True,
+        dtype=dtype,
     )
-    timesteps_ait = Tensor([batch_size], name="input1", is_input=True)
+    timesteps_ait = Tensor([batch_size], name="timesteps", is_input=True, dtype=dtype)
     text_embeddings_pt_ait = Tensor(
-        [batch_size, embedding_size, hidden_dim], name="input2", is_input=True
+        [batch_size, embedding_size, hidden_dim],
+        name="encoder_hidden_states",
+        is_input=True,
+        dtype=dtype,
     )
+
+    class_labels = None
+    # TODO: better way to handle this, enables class_labels for x4-upscaler
+    if in_channels == 7:
+        class_labels = Tensor(
+            [batch_size], name="class_labels", dtype="int64", is_input=True
+        )
+
+    add_embeds = None
+    if xl:
+        add_embeds = Tensor(
+            [batch_size, projection_class_embeddings_input_dim],
+            name="add_embeds",
+            is_input=True,
+            dtype=dtype,
+        )
+
+    down_block_residual_0 = None
+    down_block_residual_1 = None
+    down_block_residual_2 = None
+    down_block_residual_3 = None
+    down_block_residual_4 = None
+    down_block_residual_5 = None
+    down_block_residual_6 = None
+    down_block_residual_7 = None
+    down_block_residual_8 = None
+    down_block_residual_9 = None
+    down_block_residual_10 = None
+    down_block_residual_11 = None
+    mid_block_residual = None
     if controlnet:
         down_block_residual_0 = Tensor(
-            [batch_size, height, width, 320],
+            [batch_size, height_1_d, width_1_d, block_out_channels[0]],
             name="down_block_residual_0",
             is_input=True,
         )
         down_block_residual_1 = Tensor(
-            [batch_size, height, width, 320],
+            [batch_size, height_1_d, width_1_d, block_out_channels[0]],
             name="down_block_residual_1",
             is_input=True,
         )
         down_block_residual_2 = Tensor(
-            [batch_size, height, width, 320],
+            [batch_size, height_1_d, width_1_d, block_out_channels[0]],
             name="down_block_residual_2",
             is_input=True,
         )
         down_block_residual_3 = Tensor(
-            [batch_size, height // 2, width // 2, 320],
+            [batch_size, height_2_d, width_2_d, block_out_channels[0]],
             name="down_block_residual_3",
             is_input=True,
         )
         down_block_residual_4 = Tensor(
-            [batch_size, height // 2, width // 2, 640],
+            [batch_size, height_2_d, width_2_d, block_out_channels[1]],
             name="down_block_residual_4",
             is_input=True,
         )
         down_block_residual_5 = Tensor(
-            [batch_size, height // 2, width // 2, 640],
+            [batch_size, height_2_d, width_2_d, block_out_channels[1]],
             name="down_block_residual_5",
             is_input=True,
         )
         down_block_residual_6 = Tensor(
-            [batch_size, height // 4, width // 4, 640],
+            [batch_size, height_4_d, width_4_d, block_out_channels[1]],
             name="down_block_residual_6",
             is_input=True,
         )
         down_block_residual_7 = Tensor(
-            [batch_size, height // 4, width // 4, 1280],
+            [batch_size, height_4_d, width_4_d, block_out_channels[2]],
             name="down_block_residual_7",
             is_input=True,
         )
         down_block_residual_8 = Tensor(
-            [batch_size, height // 4, width // 4, 1280],
+            [batch_size, height_4_d, width_4_d, block_out_channels[2]],
             name="down_block_residual_8",
             is_input=True,
         )
         down_block_residual_9 = Tensor(
-            [batch_size, height // 8, width // 8, 1280],
+            [batch_size, height_8_d, width_8_d, block_out_channels[2]],
             name="down_block_residual_9",
             is_input=True,
         )
         down_block_residual_10 = Tensor(
-            [batch_size, height // 8, width // 8, 1280],
+            [batch_size, height_8_d, width_8_d, block_out_channels[3]],
             name="down_block_residual_10",
             is_input=True,
         )
         down_block_residual_11 = Tensor(
-            [batch_size, height // 8, width // 8, 1280],
+            [batch_size, height_8_d, width_8_d, block_out_channels[3]],
             name="down_block_residual_11",
             is_input=True,
         )
         mid_block_residual = Tensor(
-            [batch_size, height // 8, width // 8, 1280],
+            [batch_size, height_8_d, width_8_d, block_out_channels[3]],
             name="mid_block_residual",
             is_input=True,
         )
-    else:
-        mid_block_additional_residual = None
-        down_block_additional_residuals = None
 
-    if controlnet:
-        Y = ait_mod(
-            latent_model_input_ait,
-            timesteps_ait,
-            text_embeddings_pt_ait,
-            down_block_residual_0,
-            down_block_residual_1,
-            down_block_residual_2,
-            down_block_residual_3,
-            down_block_residual_4,
-            down_block_residual_5,
-            down_block_residual_6,
-            down_block_residual_7,
-            down_block_residual_8,
-            down_block_residual_9,
-            down_block_residual_10,
-            down_block_residual_11,
-            mid_block_residual,
-        )
-    else:
-        Y = ait_mod(
-            latent_model_input_ait,
-            timesteps_ait,
-            text_embeddings_pt_ait,
-            mid_block_additional_residual,
-            down_block_additional_residuals,
-        )
-    mark_output(Y)
-
+    Y = ait_mod(
+        sample=latent_model_input_ait,
+        timesteps=timesteps_ait,
+        encoder_hidden_states=text_embeddings_pt_ait,
+        down_block_residual_0=down_block_residual_0,
+        down_block_residual_1=down_block_residual_1,
+        down_block_residual_2=down_block_residual_2,
+        down_block_residual_3=down_block_residual_3,
+        down_block_residual_4=down_block_residual_4,
+        down_block_residual_5=down_block_residual_5,
+        down_block_residual_6=down_block_residual_6,
+        down_block_residual_7=down_block_residual_7,
+        down_block_residual_8=down_block_residual_8,
+        down_block_residual_9=down_block_residual_9,
+        down_block_residual_10=down_block_residual_10,
+        down_block_residual_11=down_block_residual_11,
+        mid_block_residual=mid_block_residual,
+        class_labels=class_labels,
+        add_embeds=add_embeds,
+    )
+    shape = [d._attrs["values"] for d in Y._attrs["shape"]]
+    print(f'AIT {Y._attrs["name"]} shape: {shape}')
     target = detect_target(
         use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm
     )
+    dll_name = model_name + ".dll" if sys.platform == "win32" else model_name + ".so"
     compile_model(
-        Y, target, "./tmp", model_name, constants=params_ait if constants else None
+        Y,
+        target,
+        work_dir,
+        model_name,
+        constants=params_ait if constants else None,
+        dll_name=dll_name,
     )

--- a/examples/05_stable_diffusion/src/compile_lib/compile_unet_alt.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_unet_alt.py
@@ -90,7 +90,8 @@ def compile_timestep_embedder(
     constants = {"arange": torch.arange(start=0, end=dim // 2, dtype=torch.float16)}
 
     target = detect_target(use_fp16_acc=True, convert_conv_to_gemm=True)
-    compile_model(Y, target, work_dir, model_name, constants=constants)
+    dll_name = model_name + ".dll" if sys.platform == "win32" else model_name + ".so"
+    compile_model(Y, target, work_dir, model_name, constants=constants, dll_name=dll_name)
 
 
 def compile_unet(

--- a/examples/05_stable_diffusion/src/compile_lib/compile_unet_alt.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_unet_alt.py
@@ -134,7 +134,6 @@ def compile_unet(
     conv_in_kernel: int = 3,
     projection_class_embeddings_input_dim=None,
     addition_embed_type=None,
-    addition_time_embed_dim=None,
     transformer_layers_per_block=[1, 1, 1, 1],
     dtype="float16",
 ):
@@ -167,7 +166,6 @@ def compile_unet(
         conv_in_kernel=conv_in_kernel,
         projection_class_embeddings_input_dim=projection_class_embeddings_input_dim,
         addition_embed_type=addition_embed_type,
-        addition_time_embed_dim=addition_time_embed_dim,
         transformer_layers_per_block=transformer_layers_per_block,
         dtype=dtype,
     )

--- a/examples/05_stable_diffusion/src/compile_lib/compile_vae_alt.py
+++ b/examples/05_stable_diffusion/src/compile_lib/compile_vae_alt.py
@@ -13,29 +13,32 @@
 #  limitations under the License.
 #
 
+import sys
+
 import torch
 from aitemplate.compiler import compile_model
 from aitemplate.frontend import IntVar, Tensor
 from aitemplate.testing import detect_target
 
 from ..modeling.vae import AutoencoderKL as ait_AutoencoderKL
-from .util import mark_output
 
 
 def torch_dtype_from_str(dtype: str):
     return torch.__dict__.get(dtype, None)
 
 
-def map_vae(pt_module, device="cuda", dtype="float16"):
+def map_vae(pt_module, device="cuda", dtype="float16", encoder=False):
     if not isinstance(pt_module, dict):
         pt_params = dict(pt_module.named_parameters())
     else:
         pt_params = pt_module
     params_ait = {}
+    quant_key = "post_quant" if encoder else "quant"
+    vae_key = "decoder" if encoder else "encoder"
     for key, arr in pt_params.items():
-        if key.startswith("encoder"):
+        if key.startswith(vae_key):
             continue
-        if key.startswith("quant"):
+        if key.startswith(quant_key):
             continue
         arr = arr.to(device, dtype=torch_dtype_from_str(dtype))
         key = key.replace(".", "_")
@@ -112,6 +115,10 @@ def map_vae(pt_module, device="cuda", dtype="float16"):
             params_ait[key] = arr
         else:
             params_ait[key] = arr
+    if encoder:
+        params_ait["encoder_conv_in_weight"] = torch.functional.F.pad(
+            params_ait["encoder_conv_in_weight"], (0, 1, 0, 0, 0, 0, 0, 0)
+        )
 
     return params_ait
 
@@ -121,36 +128,39 @@ def compile_vae(
     batch_size=(1, 8),
     height=(64, 2048),
     width=(64, 2048),
-    use_fp16_acc=False,
-    convert_conv_to_gemm=False,
-    name="AutoencoderKL",
+    use_fp16_acc=True,
+    convert_conv_to_gemm=True,
+    model_name="AutoencoderKL",
     constants=True,
+    block_out_channels=[128, 256, 512, 512],
+    layers_per_block=2,
+    act_fn="silu",
+    latent_channels=4,
+    sample_size=512,
+    in_channels=3,
+    out_channels=3,
+    down_block_types=[
+        "DownEncoderBlock2D",
+        "DownEncoderBlock2D",
+        "DownEncoderBlock2D",
+        "DownEncoderBlock2D",
+    ],
+    up_block_types=[
+        "UpDecoderBlock2D",
+        "UpDecoderBlock2D",
+        "UpDecoderBlock2D",
+        "UpDecoderBlock2D",
+    ],
+    input_size=(64, 64),
+    down_factor=8,
+    dtype="float16",
+    work_dir="./tmp",
+    vae_encode=False,
 ):
-    in_channels = 3
-    out_channels = 3
-    down_block_types = [
-        "DownEncoderBlock2D",
-        "DownEncoderBlock2D",
-        "DownEncoderBlock2D",
-        "DownEncoderBlock2D",
-    ]
-    up_block_types = [
-        "UpDecoderBlock2D",
-        "UpDecoderBlock2D",
-        "UpDecoderBlock2D",
-        "UpDecoderBlock2D",
-    ]
-    block_out_channels = [128, 256, 512, 512]
-    layers_per_block = 2
-    act_fn = "silu"
-    latent_channels = 4
-    sample_size = 512
-
-    # values not important, we only need this for mapping keys
     ait_vae = ait_AutoencoderKL(
-        1,
-        64,
-        64,
+        batch_size[0],
+        input_size[0],
+        input_size[1],
         in_channels=in_channels,
         out_channels=out_channels,
         down_block_types=down_block_types,
@@ -160,32 +170,59 @@ def compile_vae(
         act_fn=act_fn,
         latent_channels=latent_channels,
         sample_size=sample_size,
+        dtype=dtype,
     )
-    batch_size = IntVar(values=list(batch_size), name="batch_size")
-    height = height[0] // 8, height[1] // 8
-    width = width[0] // 8, width[1] // 8
-    height_d = IntVar(values=list(height), name="height")
-    width_d = IntVar(values=list(width), name="width")
+
+    static_batch = batch_size[0] == batch_size[1]
+    static_shape = height[0] == height[1] and width[0] == width[1]
+    if not vae_encode:
+        height = height[0] // down_factor, height[1] // down_factor
+        width = width[0] // down_factor, width[1] // down_factor
+
+    if static_batch:
+        batch_size = batch_size[0]
+    else:
+        batch_size = IntVar(values=list(batch_size), name="batch_size")
+    if static_shape:
+        height_d = height[0]
+        width_d = width[0]
+    else:
+        height_d = IntVar(values=list(height), name="height")
+        width_d = IntVar(values=list(width), name="width")
 
     ait_input = Tensor(
-        shape=[batch_size, height_d, width_d, latent_channels],
-        name="vae_input",
+        shape=[batch_size, height_d, width_d, 3 if vae_encode else latent_channels],
+        name="pixels" if vae_encode else "latent",
         is_input=True,
+        dtype=dtype,
     )
+    sample = None
+    if vae_encode:
+        sample = Tensor(
+            shape=[batch_size, height_d, width_d, latent_channels],
+            name="random_sample",
+            is_input=True,
+            dtype=dtype,
+        )
     ait_vae.name_parameter_tensor()
 
     pt_mod = pt_mod.eval()
-    params_ait = map_vae(pt_mod)
-
-    Y = ait_vae.decode(ait_input)
-    mark_output(Y)
+    params_ait = map_vae(pt_mod, dtype=dtype, encoder=vae_encode)
+    if vae_encode:
+        Y = ait_vae.encode(ait_input, sample)
+    else:
+        Y = ait_vae.decode(ait_input)
+    shape = [d._attrs["values"] for d in Y._attrs["shape"]]
+    print(f'AIT {Y._attrs["name"]} shape: {shape}')
     target = detect_target(
         use_fp16_acc=use_fp16_acc, convert_conv_to_gemm=convert_conv_to_gemm
     )
+    dll_name = model_name + ".dll" if sys.platform == "win32" else model_name + ".so"
     compile_model(
         Y,
         target,
-        "./tmp",
-        name,
+        work_dir,
+        model_name,
         constants=params_ait if constants else None,
+        dll_name=dll_name,
     )

--- a/examples/05_stable_diffusion/src/compile_lib/util.py
+++ b/examples/05_stable_diffusion/src/compile_lib/util.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import torch
+
+
 def mark_output(y):
     if type(y) is not tuple:
         y = (y,)
@@ -20,3 +23,7 @@ def mark_output(y):
         y[i]._attrs["name"] = "output_%d" % (i)
         y_shape = [d._attrs["values"] for d in y[i]._attrs["shape"]]
         print("AIT output_{} shape: {}".format(i, y_shape))
+
+
+def torch_dtype_from_str(dtype: str):
+    return torch.__dict__.get(dtype, None)

--- a/examples/05_stable_diffusion/src/inference_ait.py
+++ b/examples/05_stable_diffusion/src/inference_ait.py
@@ -1,0 +1,192 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+"""
+Helpers for inference using dict[str, torch.Tensor] as inputs and outputs.
+input names are manually specified, the same as set in compilation scripts.
+output names are taken from the model itself.
+usage:
+outputs = clip_inference(...)
+#Diffusers/Transformers
+pooled_prompt_embeds = outputs[0]
+prompt_embeds = prompt_embeds.hidden_states[-2]
+#AIT
+pooled_prompt_embeds = outputs["text_embeds"] # or "pooled_output" is without projection, "text_embeds" is with projection i.e. for bigG
+prompt_embeds = outputs["hidden_state_31"]
+usage:
+latent = unet_inference(...)['latent_output']
+usage:
+pixels = vae_decode_inference(...)['pixels']
+usage:
+latent = vae_encode_inference(...)['latent']
+"""
+from typing import Dict, List
+
+import torch
+from aitemplate.compiler import Model
+
+
+def inference(
+    module: Model,
+    inputs: Dict[str, torch.Tensor],
+    outputs: Dict[str, torch.Tensor],
+    benchmark: bool = False,
+    benchmark_count: int = 50,
+    benchmark_repeat: int = 4,
+    permute: bool = False,
+):
+    module.run_with_tensors(inputs, outputs, graph_mode=False)
+    if permute:
+        for name, output in outputs.items():
+            if len(output.shape) == 4:
+                outputs[name] = output.permute((0, 3, 1, 2))
+    if benchmark:
+        t, _, _ = module.benchmark_with_tensors(
+            inputs=inputs,
+            outputs=outputs,
+            count=benchmark_count,
+            repeat=benchmark_repeat,
+        )
+        print(f"latency: {t} ms, it/s: {1000 / t}")
+
+    return outputs
+
+
+def get_outputs(module: Model, dims, device: str = "cuda", dtype: str = "float16"):
+    outputs = {}
+    map = module.get_output_name_to_index_map()
+    for name, idx in map.items():
+        shape = module.get_output_maximum_shape(idx)
+        for idx, dim in enumerate(dims):
+            shape[idx] = dim
+        output = torch.empty(shape).to(device)
+        if dtype == "float16":
+            output = output.half()
+        outputs[name] = output
+    return outputs
+
+
+def clip_inference(
+    module: Model,
+    input_ids: torch.Tensor,
+    seqlen: int = 77,
+    device: str = "cuda",
+    dtype: str = "float16",
+    benchmark: bool = False,
+):
+    batch = input_ids.shape[0]
+    input_ids = input_ids.to(device)
+    position_ids = torch.arange(seqlen).expand((batch, -1)).to(device)
+    inputs = {
+        "input_ids": input_ids,
+        "position_ids": position_ids,
+    }
+    dims = [batch]
+    outputs = get_outputs(module, dims, device, dtype)
+    return inference(module, inputs, outputs, benchmark=benchmark)
+
+
+def unet_inference(
+    module: Model,
+    latent_model_input: torch.Tensor,
+    timesteps: torch.Tensor,
+    encoder_hidden_states: torch.Tensor,
+    class_labels: torch.Tensor = None,
+    down_block_residuals: List[torch.Tensor] = None,
+    mid_block_residual: torch.Tensor = None,
+    add_embeds: torch.Tensor = None,
+    device: str = "cuda",
+    dtype: str = "float16",
+    benchmark: bool = False,
+):
+    batch = latent_model_input.shape[0]
+    height, width = latent_model_input.shape[2], latent_model_input.shape[3]
+    timesteps = timesteps.expand(batch)
+    inputs = {
+        "latent_model_input": latent_model_input.permute((0, 2, 3, 1))
+        .contiguous()
+        .to(device),
+        "timesteps": timesteps.to(device),
+        "encoder_hidden_states": encoder_hidden_states.to(device),
+    }
+    if class_labels is not None:
+        inputs["class_labels"] = class_labels.contiguous().to(device)
+    if down_block_residuals is not None and mid_block_residual is not None:
+        for i, y in enumerate(down_block_residuals):
+            inputs[f"down_block_residual_{i}"] = (
+                y.permute((0, 2, 3, 1)).contiguous().to(device)
+            )
+        inputs["mid_block_residual"] = (
+            mid_block_residual.permute((0, 2, 3, 1)).contiguous().to(device)
+        )
+    if add_embeds is not None:
+        inputs["add_embeds"] = add_embeds.to(device)
+    if dtype == "float16":
+        for k, v in inputs.items():
+            if k == "class_labels":
+                continue
+            inputs[k] = v.half()
+    dims = [batch, height, width]
+    outputs = get_outputs(module, dims, device, dtype)
+    return inference(module, inputs, outputs, benchmark=benchmark, permute=True)
+
+
+def vae_decode_inference(
+    module: Model,
+    latent: torch.Tensor,
+    device: str = "cuda",
+    dtype: str = "float16",
+    benchmark: bool = False,
+    factor: int = 8,
+):
+    batch = latent.shape[0]
+    height, width = latent.shape[2:]
+    height *= factor
+    width *= factor
+    latent = latent.permute((0, 2, 3, 1)).contiguous().to(device)
+    if dtype == "float16":
+        latent = latent.half()
+    inputs = {
+        "latent": latent,
+    }
+    dims = [batch, height, width]
+    outputs = get_outputs(module, dims, device, dtype)
+    return inference(module, inputs, outputs, benchmark=benchmark, permute=True)
+
+
+def vae_encode_inference(
+    module: Model,
+    pixels: torch.Tensor,
+    device: str = "cuda",
+    dtype: str = "float16",
+    benchmark: bool = False,
+    factor: int = 8,
+    latent_channels: int = 4,
+):
+    batch = pixels.shape[0]
+    height, width = pixels.shape[2:]
+    height *= factor
+    width *= factor
+    pixels = pixels.permute((0, 2, 3, 1)).contiguous().to(device)
+    sample = torch.randn(batch, height, width, latent_channels).to(device)
+    if dtype == "float16":
+        pixels = pixels.half()
+        sample = sample.half()
+    inputs = {
+        "pixels": pixels,
+        "random_sample": sample,
+    }
+    dims = [batch, height, width]
+    outputs = get_outputs(module, dims, device, dtype)
+    return inference(module, inputs, outputs, benchmark=benchmark, permute=True)

--- a/examples/05_stable_diffusion/src/inference_ait.py
+++ b/examples/05_stable_diffusion/src/inference_ait.py
@@ -80,6 +80,7 @@ def get_outputs(module: Model, dims, device: str = "cuda", dtype: str = "float16
         outputs[name] = output
     return outputs
 
+
 def timestep_inference(
     module: Model,
     timestep: torch.Tensor,
@@ -89,15 +90,14 @@ def timestep_inference(
     to_cpu: bool = False,
 ):
     timestep = torch.tensor([timestep]).to(device)
-    inputs = {
-        "timestep": timestep.to(device)
-    }
+    inputs = {"timestep": timestep.to(device)}
     if dtype == "float16":
         for k, v in inputs.items():
             inputs[k] = v.half()
     dims = [1]
     outputs = get_outputs(module, dims, device, dtype)
     return inference(module, inputs, outputs, benchmark=benchmark, to_cpu=to_cpu)
+
 
 def clip_inference(
     module: Model,
@@ -163,7 +163,9 @@ def unet_inference(
             inputs[k] = v.half()
     dims = [batch, height, width]
     outputs = get_outputs(module, dims, device, dtype)
-    return inference(module, inputs, outputs, benchmark=benchmark, permute=True, to_cpu=to_cpu)
+    return inference(
+        module, inputs, outputs, benchmark=benchmark, permute=True, to_cpu=to_cpu
+    )
 
 
 def vae_decode_inference(
@@ -187,7 +189,9 @@ def vae_decode_inference(
     }
     dims = [batch, height, width]
     outputs = get_outputs(module, dims, device, dtype)
-    return inference(module, inputs, outputs, benchmark=benchmark, permute=True, to_cpu=to_cpu)
+    return inference(
+        module, inputs, outputs, benchmark=benchmark, permute=True, to_cpu=to_cpu
+    )
 
 
 def vae_encode_inference(
@@ -215,4 +219,6 @@ def vae_encode_inference(
     }
     dims = [batch, height, width]
     outputs = get_outputs(module, dims, device, dtype)
-    return inference(module, inputs, outputs, benchmark=benchmark, permute=True, to_cpu=to_cpu)
+    return inference(
+        module, inputs, outputs, benchmark=benchmark, permute=True, to_cpu=to_cpu
+    )

--- a/examples/05_stable_diffusion/src/modeling/attention.py
+++ b/examples/05_stable_diffusion/src/modeling/attention.py
@@ -50,6 +50,7 @@ class AttentionBlock(nn.Module):
         num_groups: int = 32,
         rescale_output_factor: float = 1.0,
         eps: float = 1e-5,
+        dtype="float16",
     ):
         super().__init__()
         self.batch_size = batch_size
@@ -58,13 +59,14 @@ class AttentionBlock(nn.Module):
             channels // num_head_channels if num_head_channels is not None else 1
         )
         self.num_head_size = num_head_channels
-        self.group_norm = nn.GroupNorm(num_groups, channels, eps)
+        self.group_norm = nn.GroupNorm(num_groups, channels, eps, dtype=dtype)
         self.attention = nn.CrossAttention(
             channels,
             height * width,
             height * width,
             self.num_heads,
             qkv_bias=True,
+            dtype=dtype,
         )
         self.rescale_output_factor = rescale_output_factor
 

--- a/examples/05_stable_diffusion/src/modeling/controlnet_unet_2d_condition.py
+++ b/examples/05_stable_diffusion/src/modeling/controlnet_unet_2d_condition.py
@@ -18,7 +18,7 @@ from aitemplate.compiler import ops
 from aitemplate.frontend import nn
 
 from .embeddings import TimestepEmbedding, Timesteps
-from .unet_blocks import get_down_block, get_up_block, UNetMidBlock2DCrossAttn
+from .unet_blocks import get_down_block, UNetMidBlock2DCrossAttn
 
 
 class ControlNetConditioningEmbedding(nn.Module):
@@ -192,6 +192,9 @@ class ControlNetModel(nn.Module):
             upcast_attention=upcast_attention,
         )
 
+    def get_shape(self, sample):
+        return [i._attrs["int_var"]._attrs["values"][0] for i in ops.size()(sample)]
+
     def forward(
         self,
         sample,
@@ -207,7 +210,7 @@ class ControlNetModel(nn.Module):
         sample = self.conv_in(sample)
 
         controlnet_cond = self.controlnet_cond_embedding(controlnet_cond)
-
+        controlnet_cond._attrs["shape"] = sample._attrs["shape"]
         sample = sample + controlnet_cond
         # 3. down
         down_block_res_samples = (sample,)  # up to but excluding last element
@@ -249,7 +252,6 @@ class ControlNetModel(nn.Module):
         ]
         mid_block_res_sample = mid_block_res_sample * conditioning_scale
 
-        # return (down_block_res_samples, mid_block_res_sample)
         return (
             down_block_res_samples[0],
             down_block_res_samples[1],
@@ -265,285 +267,3 @@ class ControlNetModel(nn.Module):
             down_block_res_samples[11],
             mid_block_res_sample,
         )
-
-
-class ControlNetUNet2DConditionModel(nn.Module):
-    r"""
-    UNet2DConditionModel is a conditional 2D UNet model that takes in a noisy sample, conditional state, and a timestep
-    and returns sample shaped output.
-
-    This model inherits from [`ModelMixin`]. Check the superclass documentation for the generic methods the library
-    implements for all the model (such as downloading or saving, etc.)
-
-    Parameters:
-        sample_size (`int`, *optional*): The size of the input sample.
-        in_channels (`int`, *optional*, defaults to 4): The number of channels in the input sample.
-        out_channels (`int`, *optional*, defaults to 4): The number of channels in the output.
-        center_input_sample (`bool`, *optional*, defaults to `False`): Whether to center the input sample.
-        flip_sin_to_cos (`bool`, *optional*, defaults to `False`):
-            Whether to flip the sin to cos in the time embedding.
-        freq_shift (`int`, *optional*, defaults to 0): The frequency shift to apply to the time embedding.
-        down_block_types (`Tuple[str]`, *optional*, defaults to `("CrossAttnDownBlock2D", "CrossAttnDownBlock2D", "CrossAttnDownBlock2D", "DownBlock2D")`):
-            The tuple of downsample blocks to use.
-        up_block_types (`Tuple[str]`, *optional*, defaults to `("UpBlock2D", "CrossAttnUpBlock2D", "CrossAttnUpBlock2D", "CrossAttnUpBlock2D",)`):
-            The tuple of upsample blocks to use.
-        block_out_channels (`Tuple[int]`, *optional*, defaults to `(320, 640, 1280, 1280)`):
-            The tuple of output channels for each block.
-        layers_per_block (`int`, *optional*, defaults to 2): The number of layers per block.
-        downsample_padding (`int`, *optional*, defaults to 1): The padding to use for the downsampling convolution.
-        mid_block_scale_factor (`float`, *optional*, defaults to 1.0): The scale factor to use for the mid block.
-        act_fn (`str`, *optional*, defaults to `"silu"`): The activation function to use.
-        norm_num_groups (`int`, *optional*, defaults to 32): The number of groups to use for the normalization.
-        norm_eps (`float`, *optional*, defaults to 1e-5): The epsilon to use for the normalization.
-        cross_attention_dim (`int`, *optional*, defaults to 1280): The dimension of the cross attention features.
-        attention_head_dim (`int`, *optional*, defaults to 8): The dimension of the attention heads.
-        use_linear_projection (`bool`, *optional*, defaults to False): Use linear projection instead of 1x1 convolution.
-    """
-
-    def __init__(
-        self,
-        sample_size: Optional[int] = None,
-        in_channels: int = 4,
-        out_channels: int = 4,
-        center_input_sample: bool = False,
-        flip_sin_to_cos: bool = True,
-        freq_shift: int = 0,
-        down_block_types: Tuple[str] = (
-            "CrossAttnDownBlock2D",
-            "CrossAttnDownBlock2D",
-            "CrossAttnDownBlock2D",
-            "DownBlock2D",
-        ),
-        up_block_types: Tuple[str] = (
-            "UpBlock2D",
-            "CrossAttnUpBlock2D",
-            "CrossAttnUpBlock2D",
-            "CrossAttnUpBlock2D",
-        ),
-        block_out_channels: Tuple[int] = (320, 640, 1280, 1280),
-        layers_per_block: int = 2,
-        downsample_padding: int = 1,
-        mid_block_scale_factor: float = 1,
-        act_fn: str = "silu",
-        norm_num_groups: int = 32,
-        norm_eps: float = 1e-5,
-        cross_attention_dim: int = 1280,
-        attention_head_dim: Union[int, Tuple[int]] = 8,
-        use_linear_projection: bool = False,
-    ):
-        super().__init__()
-        self.center_input_sample = center_input_sample
-        self.sample_size = sample_size
-        time_embed_dim = block_out_channels[0] * 4
-
-        # input
-        self.conv_in = nn.Conv2dBias(in_channels, block_out_channels[0], 3, 1, 1)
-        # time
-        self.time_proj = Timesteps(block_out_channels[0], flip_sin_to_cos, freq_shift)
-        timestep_input_dim = block_out_channels[0]
-
-        self.time_embedding = TimestepEmbedding(timestep_input_dim, time_embed_dim)
-
-        self.down_blocks = nn.ModuleList([])
-        self.up_blocks = nn.ModuleList([])
-
-        if isinstance(attention_head_dim, int):
-            attention_head_dim = (attention_head_dim,) * len(down_block_types)
-
-        # down
-        output_channel = block_out_channels[0]
-        for i, down_block_type in enumerate(down_block_types):
-            input_channel = output_channel
-            output_channel = block_out_channels[i]
-            is_final_block = i == len(block_out_channels) - 1
-
-            down_block = get_down_block(
-                down_block_type,
-                num_layers=layers_per_block,
-                in_channels=input_channel,
-                out_channels=output_channel,
-                temb_channels=time_embed_dim,
-                add_downsample=not is_final_block,
-                resnet_eps=norm_eps,
-                resnet_act_fn=act_fn,
-                attn_num_head_channels=attention_head_dim[i],
-                cross_attention_dim=cross_attention_dim,
-                downsample_padding=downsample_padding,
-                use_linear_projection=use_linear_projection,
-            )
-            self.down_blocks.append(down_block)
-
-        # mid
-        self.mid_block = UNetMidBlock2DCrossAttn(
-            in_channels=block_out_channels[-1],
-            temb_channels=time_embed_dim,
-            resnet_eps=norm_eps,
-            resnet_act_fn=act_fn,
-            output_scale_factor=mid_block_scale_factor,
-            resnet_time_scale_shift="default",
-            cross_attention_dim=cross_attention_dim,
-            attn_num_head_channels=attention_head_dim[-1],
-            resnet_groups=norm_num_groups,
-            use_linear_projection=use_linear_projection,
-        )
-
-        # up
-        reversed_block_out_channels = list(reversed(block_out_channels))
-        reversed_attention_head_dim = list(reversed(attention_head_dim))
-        output_channel = reversed_block_out_channels[0]
-        for i, up_block_type in enumerate(up_block_types):
-            prev_output_channel = output_channel
-            output_channel = reversed_block_out_channels[i]
-            input_channel = reversed_block_out_channels[
-                min(i + 1, len(block_out_channels) - 1)
-            ]
-
-            is_final_block = i == len(block_out_channels) - 1
-
-            up_block = get_up_block(
-                up_block_type,
-                num_layers=layers_per_block + 1,
-                in_channels=input_channel,
-                out_channels=output_channel,
-                prev_output_channel=prev_output_channel,
-                temb_channels=time_embed_dim,
-                add_upsample=not is_final_block,
-                resnet_eps=norm_eps,
-                resnet_act_fn=act_fn,
-                attn_num_head_channels=reversed_attention_head_dim[i],
-                cross_attention_dim=cross_attention_dim,
-                use_linear_projection=use_linear_projection,
-            )
-            self.up_blocks.append(up_block)
-            prev_output_channel = output_channel
-
-        # out
-        self.conv_norm_out = nn.GroupNorm(
-            num_channels=block_out_channels[0],
-            num_groups=norm_num_groups,
-            eps=norm_eps,
-            use_swish=True,
-        )
-
-        self.conv_out = nn.Conv2dBias(block_out_channels[0], out_channels, 3, 1, 1)
-
-    def forward(
-        self,
-        sample,
-        timesteps,
-        encoder_hidden_states,
-        down_block_residual_0,
-        down_block_residual_1,
-        down_block_residual_2,
-        down_block_residual_3,
-        down_block_residual_4,
-        down_block_residual_5,
-        down_block_residual_6,
-        down_block_residual_7,
-        down_block_residual_8,
-        down_block_residual_9,
-        down_block_residual_10,
-        down_block_residual_11,
-        mid_block_residual,
-        return_dict: bool = True,
-    ):
-        """r
-        Args:
-            sample (`torch.FloatTensor`): (batch, channel, height, width) noisy inputs tensor
-            timestep (`torch.FloatTensor` or `float` or `int): (batch) timesteps
-            encoder_hidden_states (`torch.FloatTensor`): (batch, channel, height, width) encoder hidden states
-            return_dict (`bool`, *optional*, defaults to `True`):
-                Whether or not to return a [`models.unet_2d_condition.UNet2DConditionOutput`] instead of a plain tuple.
-
-        Returns:
-            [`~models.unet_2d_condition.UNet2DConditionOutput`] or `tuple`:
-            [`~models.unet_2d_condition.UNet2DConditionOutput`] if `return_dict` is True, otherwise a `tuple`. When
-            returning a tuple, the first element is the sample tensor.
-        """
-        down_block_additional_residuals = (
-            down_block_residual_0,
-            down_block_residual_1,
-            down_block_residual_2,
-            down_block_residual_3,
-            down_block_residual_4,
-            down_block_residual_5,
-            down_block_residual_6,
-            down_block_residual_7,
-            down_block_residual_8,
-            down_block_residual_9,
-            down_block_residual_10,
-            down_block_residual_11,
-        )
-        mid_block_additional_residual = mid_block_residual
-        # 1. time
-        t_emb = self.time_proj(timesteps)
-        emb = self.time_embedding(t_emb)
-
-        # 2. pre-process
-        sample = self.conv_in(sample)
-
-        # 3. down
-        down_block_res_samples = (sample,)
-        for downsample_block in self.down_blocks:
-            if (
-                hasattr(downsample_block, "attentions")
-                and downsample_block.attentions is not None
-            ):
-                sample, res_samples = downsample_block(
-                    hidden_states=sample,
-                    temb=emb,
-                    encoder_hidden_states=encoder_hidden_states,
-                )
-            else:
-                sample, res_samples = downsample_block(hidden_states=sample, temb=emb)
-
-            down_block_res_samples += res_samples
-            # return sample
-
-        if down_block_additional_residuals is not None:
-            new_down_block_res_samples = ()
-
-            for down_block_res_sample, down_block_additional_residual in zip(
-                down_block_res_samples, down_block_additional_residuals
-            ):
-                down_block_res_sample += down_block_additional_residual
-                new_down_block_res_samples += (down_block_res_sample,)
-
-            down_block_res_samples = new_down_block_res_samples
-
-        # 4. mid
-        sample = self.mid_block(
-            sample, emb, encoder_hidden_states=encoder_hidden_states
-        )
-
-        if mid_block_additional_residual is not None:
-            sample += mid_block_additional_residual
-
-        # 5. up
-        for upsample_block in self.up_blocks:
-            res_samples = down_block_res_samples[-len(upsample_block.resnets) :]
-            down_block_res_samples = down_block_res_samples[
-                : -len(upsample_block.resnets)
-            ]
-
-            if (
-                hasattr(upsample_block, "attentions")
-                and upsample_block.attentions is not None
-            ):
-                sample = upsample_block(
-                    hidden_states=sample,
-                    temb=emb,
-                    res_hidden_states_tuple=res_samples,
-                    encoder_hidden_states=encoder_hidden_states,
-                )
-            else:
-                sample = upsample_block(
-                    hidden_states=sample, temb=emb, res_hidden_states_tuple=res_samples
-                )
-
-        # 6. post-process
-        # make sure hidden states is in float32
-        # when running in half-precision
-        sample = self.conv_norm_out(sample)
-        sample = self.conv_out(sample)
-        return sample

--- a/examples/05_stable_diffusion/src/modeling/resnet.py
+++ b/examples/05_stable_diffusion/src/modeling/resnet.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 #
 from aitemplate.compiler import ops
-from aitemplate.frontend import nn
+from aitemplate.frontend import nn, Tensor
 
 
 def get_shape(x):
@@ -37,6 +37,7 @@ class Upsample2D(nn.Module):
         use_conv_transpose=False,
         out_channels=None,
         name="conv",
+        dtype="float16",
     ):
         super().__init__()
         self.channels = channels
@@ -47,9 +48,11 @@ class Upsample2D(nn.Module):
 
         conv = None
         if use_conv_transpose:
-            conv = nn.ConvTranspose2dBias(channels, self.out_channels, 4, 2, 1)
+            conv = nn.ConvTranspose2dBias(
+                channels, self.out_channels, 4, 2, 1, dtype=dtype
+            )
         elif use_conv:
-            conv = nn.Conv2dBias(self.channels, self.out_channels, 3, 1, 1)
+            conv = nn.Conv2dBias(self.channels, self.out_channels, 3, 1, 1, dtype=dtype)
 
         # TODO(Suraj, Patrick) - clean up after weight dicts are correctly renamed
         if name == "conv":
@@ -57,11 +60,17 @@ class Upsample2D(nn.Module):
         else:
             self.Conv2d_0 = conv
 
-    def forward(self, x):
+    def forward(self, x, upsample_size=None):
         if self.use_conv_transpose:
             return self.conv(x)
-
-        x = nn.Upsampling2d(scale_factor=2.0, mode="nearest")(x)
+        out = None
+        if upsample_size is not None:
+            out = ops.size()(x)
+            out[1] = upsample_size[1]
+            out[2] = upsample_size[2]
+            out = [x._attrs["int_var"] for x in out]
+            out = Tensor(out)
+        x = nn.Upsampling2d(scale_factor=2.0, mode="nearest")(x, out)
 
         # TODO(Suraj, Patrick) - clean up after weight dicts are correctly renamed
         if self.use_conv:
@@ -83,7 +92,13 @@ class Downsample2D(nn.Module):
     """
 
     def __init__(
-        self, channels, use_conv=False, out_channels=None, padding=1, name="conv"
+        self,
+        channels,
+        use_conv=False,
+        out_channels=None,
+        padding=1,
+        name="conv",
+        dtype="float16",
     ):
         super().__init__()
         self.channels = channels
@@ -92,10 +107,16 @@ class Downsample2D(nn.Module):
         self.padding = padding
         stride = 2
         self.name = name
+        self.dtype = dtype
 
         if use_conv:
             conv = nn.Conv2dBias(
-                self.channels, self.out_channels, 3, stride=stride, padding=padding
+                self.channels,
+                self.out_channels,
+                3,
+                stride=stride,
+                dtype=dtype,
+                padding=padding,
             )
         else:
             assert self.channels == self.out_channels
@@ -110,9 +131,21 @@ class Downsample2D(nn.Module):
         else:
             self.conv = conv
 
-    def forward(self, x):
-        x = self.conv(x)
-        return x
+    def forward(self, hidden_states):
+        if self.use_conv and self.padding == 0:
+            padding = ops.full()([0, 1, 0, 0], 0.0, dtype=self.dtype)
+            padding._attrs["shape"][0] = hidden_states._attrs["shape"][0]
+            padding._attrs["shape"][2] = hidden_states._attrs["shape"][2]
+            padding._attrs["shape"][3] = hidden_states._attrs["shape"][3]
+            hidden_states = ops.concatenate()([hidden_states, padding], dim=1)
+            padding = ops.full()([0, 0, 1, 0], 0.0, dtype=self.dtype)
+            padding._attrs["shape"][0] = hidden_states._attrs["shape"][0]
+            padding._attrs["shape"][1] = hidden_states._attrs["shape"][1]
+            padding._attrs["shape"][3] = hidden_states._attrs["shape"][3]
+            hidden_states = ops.concatenate()([hidden_states, padding], dim=2)
+
+        hidden_states = self.conv(hidden_states)
+        return hidden_states
 
 
 class ResnetBlock2D(nn.Module):
@@ -135,6 +168,7 @@ class ResnetBlock2D(nn.Module):
         use_nin_shortcut=None,
         up=False,
         down=False,
+        dtype="float16"
     ):
         super().__init__()
         self.pre_norm = pre_norm
@@ -157,14 +191,15 @@ class ResnetBlock2D(nn.Module):
             eps=eps,
             affine=True,
             use_swish=True,
+            dtype=dtype,
         )
 
         self.conv1 = nn.Conv2dBias(
-            in_channels, out_channels, kernel_size=3, stride=1, padding=1
+            in_channels, out_channels, kernel_size=3, stride=1, padding=1, dtype=dtype
         )
 
         if temb_channels is not None:
-            self.time_emb_proj = nn.Linear(temb_channels, out_channels)
+            self.time_emb_proj = nn.Linear(temb_channels, out_channels, dtype=dtype)
         else:
             self.time_emb_proj = None
 
@@ -174,10 +209,11 @@ class ResnetBlock2D(nn.Module):
             eps=eps,
             affine=True,
             use_swish=True,
+            dtype=dtype,
         )
-        self.dropout = nn.Dropout(dropout)
+        self.dropout = nn.Dropout(dropout, dtype=dtype)
         self.conv2 = nn.Conv2dBias(
-            out_channels, out_channels, kernel_size=3, stride=1, padding=1
+            out_channels, out_channels, kernel_size=3, stride=1, padding=1, dtype=dtype
         )
 
         self.upsample = self.downsample = None
@@ -190,7 +226,7 @@ class ResnetBlock2D(nn.Module):
 
         if self.use_nin_shortcut:
             self.conv_shortcut = nn.Conv2dBias(
-                in_channels, out_channels, 1, 1, 0
+                in_channels, out_channels, 1, 1, 0, dtype=dtype
             )  # kernel_size=1, stride=1, padding=0) # conv_bias_add
         else:
             self.conv_shortcut = None

--- a/examples/05_stable_diffusion/src/modeling/resnet.py
+++ b/examples/05_stable_diffusion/src/modeling/resnet.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 #
 from aitemplate.compiler import ops
-from aitemplate.frontend import nn, Tensor
+from aitemplate.frontend import nn
 
 
 def get_shape(x):
@@ -60,17 +60,10 @@ class Upsample2D(nn.Module):
         else:
             self.Conv2d_0 = conv
 
-    def forward(self, x, upsample_size=None):
+    def forward(self, x):
         if self.use_conv_transpose:
             return self.conv(x)
-        out = None
-        if upsample_size is not None:
-            out = ops.size()(x)
-            out[1] = upsample_size[1]
-            out[2] = upsample_size[2]
-            out = [x._attrs["int_var"] for x in out]
-            out = Tensor(out)
-        x = nn.Upsampling2d(scale_factor=2.0, mode="nearest")(x, out)
+        x = nn.Upsampling2d(scale_factor=2.0, mode="nearest")(x)
 
         # TODO(Suraj, Patrick) - clean up after weight dicts are correctly renamed
         if self.use_conv:

--- a/examples/05_stable_diffusion/src/modeling/unet_2d_condition.py
+++ b/examples/05_stable_diffusion/src/modeling/unet_2d_condition.py
@@ -93,7 +93,6 @@ class UNet2DConditionModel(nn.Module):
         time_embedding_dim=None,
         projection_class_embeddings_input_dim=None,
         addition_embed_type=None,
-        addition_time_embed_dim=None,
         transformer_layers_per_block=[1, 1, 1, 1],
     ):
         super().__init__()
@@ -146,7 +145,6 @@ class UNet2DConditionModel(nn.Module):
             self.class_embedding = None
 
         if addition_embed_type == "text_time":
-            # self.add_time_proj = Timesteps(addition_time_embed_dim, flip_sin_to_cos, freq_shift, dtype=dtype, arange_name="add_arange")
             self.add_embedding = TimestepEmbedding(
                 projection_class_embeddings_input_dim, time_embed_dim, dtype=dtype
             )

--- a/examples/05_stable_diffusion/src/modeling/unet_2d_condition.py
+++ b/examples/05_stable_diffusion/src/modeling/unet_2d_condition.py
@@ -366,16 +366,12 @@ class UNet2DConditionModel(nn.Module):
         if mid_block_additional_residual is not None:
             mid_block_additional_residual._attrs["shape"] = sample._attrs["shape"]
             sample += mid_block_additional_residual
-        upsample_size = None
         # 5. up
         for i, upsample_block in enumerate(self.up_blocks):
-            is_final_block = i == len(self.up_blocks) - 1
             res_samples = down_block_res_samples[-len(upsample_block.resnets) :]
             down_block_res_samples = down_block_res_samples[
                 : -len(upsample_block.resnets)
             ]
-            if not is_final_block:
-                upsample_size = ops.size()(down_block_res_samples[-1])
 
             if (
                 hasattr(upsample_block, "attentions")
@@ -386,14 +382,12 @@ class UNet2DConditionModel(nn.Module):
                     temb=emb,
                     res_hidden_states_tuple=res_samples,
                     encoder_hidden_states=encoder_hidden_states,
-                    upsample_size=upsample_size,
                 )
             else:
                 sample = upsample_block(
                     hidden_states=sample,
                     temb=emb,
                     res_hidden_states_tuple=res_samples,
-                    upsample_size=upsample_size,
                 )
 
         # 6. post-process

--- a/examples/05_stable_diffusion/src/modeling/unet_2d_condition.py
+++ b/examples/05_stable_diffusion/src/modeling/unet_2d_condition.py
@@ -94,7 +94,7 @@ class UNet2DConditionModel(nn.Module):
         projection_class_embeddings_input_dim=None,
         addition_embed_type=None,
         addition_time_embed_dim=None,
-        transformer_layers_per_block=1,
+        transformer_layers_per_block=[1, 1, 1, 1],
     ):
         super().__init__()
         self.center_input_sample = center_input_sample

--- a/examples/05_stable_diffusion/src/modeling/unet_blocks.py
+++ b/examples/05_stable_diffusion/src/modeling/unet_blocks.py
@@ -592,7 +592,6 @@ class CrossAttnUpBlock2D(nn.Module):
         res_hidden_states_tuple,
         temb=None,
         encoder_hidden_states=None,
-        upsample_size=None,
     ):
         for resnet, attn in zip(self.resnets, self.attentions):
             # pop res hidden states
@@ -607,7 +606,7 @@ class CrossAttnUpBlock2D(nn.Module):
 
         if self.upsamplers is not None:
             for upsampler in self.upsamplers:
-                hidden_states = upsampler(hidden_states, upsample_size)
+                hidden_states = upsampler(hidden_states)
 
         return hidden_states
 
@@ -670,7 +669,7 @@ class UpBlock2D(nn.Module):
             self.upsamplers = None
 
     def forward(
-        self, hidden_states, res_hidden_states_tuple, temb=None, upsample_size=None
+        self, hidden_states, res_hidden_states_tuple, temb=None
     ):
         for resnet in self.resnets:
             # pop res hidden states
@@ -684,7 +683,7 @@ class UpBlock2D(nn.Module):
 
         if self.upsamplers is not None:
             for upsampler in self.upsamplers:
-                hidden_states = upsampler(hidden_states, upsample_size)
+                hidden_states = upsampler(hidden_states)
 
         return hidden_states
 

--- a/examples/05_stable_diffusion/src/modeling/vae.py
+++ b/examples/05_stable_diffusion/src/modeling/vae.py
@@ -17,9 +17,11 @@ Translated from https://github.com/huggingface/diffusers/blob/main/src/diffusers
 
 from typing import Tuple
 
+from aitemplate.compiler import ops
+
 from aitemplate.frontend import nn, Tensor
 
-from .unet_blocks import get_up_block, UNetMidBlock2D
+from .unet_blocks import get_down_block, get_up_block, UNetMidBlock2D
 
 
 class Decoder(nn.Module):
@@ -34,12 +36,18 @@ class Decoder(nn.Module):
         block_out_channels=(64,),
         layers_per_block=2,
         act_fn="silu",
+        dtype="float16",
     ):
         super().__init__()
         self.layers_per_block = layers_per_block
 
         self.conv_in = nn.Conv2dBias(
-            in_channels, block_out_channels[-1], kernel_size=3, stride=1, padding=1
+            in_channels,
+            block_out_channels[-1],
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            dtype=dtype,
         )
 
         # mid
@@ -55,6 +63,7 @@ class Decoder(nn.Module):
             attn_num_head_channels=None,
             resnet_groups=32,
             temb_channels=None,
+            dtype=dtype,
         )
 
         # up
@@ -78,6 +87,7 @@ class Decoder(nn.Module):
                 resnet_eps=1e-6,
                 resnet_act_fn=act_fn,
                 attn_num_head_channels=None,
+                dtype=dtype,
             )
             self.up_blocks.append(up_block)
             prev_output_channel = output_channel
@@ -89,9 +99,15 @@ class Decoder(nn.Module):
             num_groups=num_groups_out,
             eps=1e-6,
             use_swish=True,
+            dtype=dtype,
         )
         self.conv_out = nn.Conv2dBias(
-            block_out_channels[0], out_channels, kernel_size=3, padding=1, stride=1
+            block_out_channels[0],
+            out_channels,
+            kernel_size=3,
+            padding=1,
+            stride=1,
+            dtype=dtype,
         )
 
     def forward(self, z) -> Tensor:
@@ -111,6 +127,114 @@ class Decoder(nn.Module):
         return sample
 
 
+class Encoder(nn.Module):
+    def __init__(
+        self,
+        batch_size,
+        height,
+        width,
+        in_channels=3,
+        out_channels=3,
+        down_block_types=("DownEncoderBlock2D",),
+        block_out_channels=(64,),
+        layers_per_block=2,
+        norm_num_groups=32,
+        act_fn="silu",
+        double_z=True,
+        dtype="float16",
+    ):
+        super().__init__()
+        self.layers_per_block = layers_per_block
+
+        self.conv_in = nn.Conv2dBiasFewChannels(
+            in_channels,
+            block_out_channels[0],
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            dtype=dtype,
+        )
+
+        self.mid_block = None
+        self.down_blocks = nn.ModuleList([])
+
+        # down
+        output_channel = block_out_channels[0]
+        for i, down_block_type in enumerate(down_block_types):
+            input_channel = output_channel
+            output_channel = block_out_channels[i]
+            is_final_block = i == len(block_out_channels) - 1
+
+            down_block = get_down_block(
+                down_block_type,
+                num_layers=self.layers_per_block,
+                in_channels=input_channel,
+                out_channels=output_channel,
+                add_downsample=not is_final_block,
+                resnet_eps=1e-6,
+                downsample_padding=0,
+                resnet_act_fn=act_fn,
+                resnet_groups=norm_num_groups,
+                attn_num_head_channels=None,
+                temb_channels=None,
+                dtype=dtype,
+            )
+            self.down_blocks.append(down_block)
+
+        # mid
+        self.mid_block = UNetMidBlock2D(
+            batch_size,
+            height,
+            width,
+            in_channels=block_out_channels[-1],
+            resnet_eps=1e-6,
+            resnet_act_fn=act_fn,
+            output_scale_factor=1,
+            resnet_time_scale_shift="default",
+            attn_num_head_channels=None,
+            resnet_groups=norm_num_groups,
+            temb_channels=None,
+            dtype=dtype,
+        )
+
+        # out
+        self.conv_norm_out = nn.GroupNorm(
+            num_channels=block_out_channels[-1],
+            num_groups=norm_num_groups,
+            eps=1e-6,
+            dtype=dtype,
+        )
+        self.conv_act = ops.silu
+
+        conv_out_channels = 2 * out_channels if double_z else out_channels
+        self.conv_out = nn.Conv2dBias(
+            block_out_channels[-1],
+            conv_out_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            dtype=dtype,
+        )
+
+    def forward(self, x):
+        sample = x
+
+        sample = self.conv_in(sample)
+
+        for down_block in self.down_blocks:
+            sample = down_block(sample)
+
+        # middle
+        sample = self.mid_block(sample)
+
+        # post-process
+        sample = self.conv_norm_out(sample)
+        sample = self.conv_act(sample)
+        sample = self.conv_out(sample)
+
+        return sample
+
+
 class AutoencoderKL(nn.Module):
     def __init__(
         self,
@@ -125,7 +249,9 @@ class AutoencoderKL(nn.Module):
         layers_per_block: int = 1,
         act_fn: str = "silu",
         latent_channels: int = 4,
+        norm_num_groups: int = 32,
         sample_size: int = 32,
+        dtype="float16",
     ):
         super().__init__()
         self.decoder = Decoder(
@@ -138,15 +264,67 @@ class AutoencoderKL(nn.Module):
             block_out_channels=block_out_channels,
             layers_per_block=layers_per_block,
             act_fn=act_fn,
+            dtype=dtype,
         )
         self.post_quant_conv = nn.Conv2dBias(
-            latent_channels, latent_channels, kernel_size=1, stride=1, padding=0
+            latent_channels,
+            latent_channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            dtype=dtype,
+        )
+
+        self.encoder = Encoder(
+            batch_size,
+            height,
+            width,
+            in_channels=in_channels,
+            out_channels=latent_channels,
+            down_block_types=down_block_types,
+            block_out_channels=block_out_channels,
+            layers_per_block=layers_per_block,
+            act_fn=act_fn,
+            norm_num_groups=norm_num_groups,
+            double_z=True,
+            dtype=dtype,
+        )
+        self.quant_conv = nn.Conv2dBias(
+            2 * latent_channels,
+            2 * latent_channels,
+            kernel_size=1,
+            stride=1,
+            padding=0,
+            dtype=dtype,
         )
 
     def decode(self, z: Tensor, return_dict: bool = True):
         z = self.post_quant_conv(z)
         dec = self.decoder(z)
+        dec._attrs["is_output"] = True
+        dec._attrs["name"] = "pixels"
         return dec
 
-    def forward(self):
-        raise NotImplementedError("Only decode() is implemented for AutoencoderKL!")
+    def encode(
+        self,
+        x: Tensor,
+        sample: Tensor = None,
+        return_dict: bool = True,
+        deterministic: bool = False,
+    ):
+        h = self.encoder(x)
+        moments = self.quant_conv(h)
+        if sample is None:
+            return moments
+        mean, logvar = ops.chunk()(moments, 2, dim=3)
+        logvar = ops.clamp()(logvar, -30.0, 20.0)
+        std = ops.exp(0.5 * logvar)
+        # var = ops.exp(logvar)
+        # if deterministic:
+        #     var = std = Tensor(mean.shape(), value=0.0, dtype=mean._attrs["dtype"])
+        sample._attrs["shape"] = mean._attrs["shape"]
+        std._attrs["shape"] = mean._attrs["shape"]
+        z = mean + std * sample
+        z._attrs["is_output"] = True
+        z._attrs["name"] = "latent"
+        return z

--- a/examples/05_stable_diffusion/src/pipeline_stable_diffusion_xl_ait.py
+++ b/examples/05_stable_diffusion/src/pipeline_stable_diffusion_xl_ait.py
@@ -1,0 +1,792 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import inspect
+import os
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import torch
+from transformers import CLIPTextModel, CLIPTextModelWithProjection, CLIPTokenizer
+
+from .inference_ait import (
+    clip_inference,
+    unet_inference,
+    vae_decode_inference,
+    timestep_inference,
+)
+
+from aitemplate.compiler import Model
+from .compile_lib.compile_clip_alt import map_clip
+from .compile_lib.compile_unet_alt import map_unet
+from .compile_lib.compile_vae_alt import map_vae
+
+from diffusers.image_processor import VaeImageProcessor
+from diffusers.loaders import FromSingleFileMixin, LoraLoaderMixin
+from diffusers.models import AutoencoderKL, UNet2DConditionModel
+from diffusers.schedulers import KarrasDiffusionSchedulers
+from diffusers.utils import (
+    is_invisible_watermark_available,
+    logging,
+    randn_tensor,
+)
+from diffusers.pipelines.pipeline_utils import DiffusionPipeline
+from diffusers.pipelines.stable_diffusion_xl import StableDiffusionXLPipelineOutput
+
+
+if is_invisible_watermark_available():
+    from diffusers.pipelines.stable_diffusion_xl.watermark import StableDiffusionXLWatermarker
+
+
+logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
+
+# Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.rescale_noise_cfg
+def rescale_noise_cfg(noise_cfg, noise_pred_text, guidance_rescale=0.0):
+    """
+    Rescale `noise_cfg` according to `guidance_rescale`. Based on findings of [Common Diffusion Noise Schedules and
+    Sample Steps are Flawed](https://arxiv.org/pdf/2305.08891.pdf). See Section 3.4
+    """
+    std_text = noise_pred_text.std(dim=list(range(1, noise_pred_text.ndim)), keepdim=True)
+    std_cfg = noise_cfg.std(dim=list(range(1, noise_cfg.ndim)), keepdim=True)
+    # rescale the results from guidance (fixes overexposure)
+    noise_pred_rescaled = noise_cfg * (std_text / std_cfg)
+    # mix with the original results from guidance by factor guidance_rescale to avoid "plain looking" images
+    noise_cfg = guidance_rescale * noise_pred_rescaled + (1 - guidance_rescale) * noise_cfg
+    return noise_cfg
+
+
+class StableDiffusionXLAITPipeline(DiffusionPipeline, FromSingleFileMixin, LoraLoaderMixin):
+    r"""
+    Pipeline for text-to-image generation using Stable Diffusion XL.
+
+    This model inherits from [`DiffusionPipeline`]. Check the superclass documentation for the generic methods the
+    library implements for all the pipelines (such as downloading or saving, running on a particular device, etc.)
+
+    In addition the pipeline inherits the following loading methods:
+        - *LoRA*: [`StableDiffusionXLPipeline.load_lora_weights`]
+        - *Ckpt*: [`loaders.FromSingleFileMixin.from_single_file`]
+
+    as well as the following saving methods:
+        - *LoRA*: [`loaders.StableDiffusionXLPipeline.save_lora_weights`]
+
+    Args:
+        vae ([`AutoencoderKL`]):
+            Variational Auto-Encoder (VAE) Model to encode and decode images to and from latent representations.
+        text_encoder ([`CLIPTextModel`]):
+            Frozen text-encoder. Stable Diffusion XL uses the text portion of
+            [CLIP](https://huggingface.co/docs/transformers/model_doc/clip#transformers.CLIPTextModel), specifically
+            the [clip-vit-large-patch14](https://huggingface.co/openai/clip-vit-large-patch14) variant.
+        text_encoder_2 ([` CLIPTextModelWithProjection`]):
+            Second frozen text-encoder. Stable Diffusion XL uses the text and pool portion of
+            [CLIP](https://huggingface.co/docs/transformers/model_doc/clip#transformers.CLIPTextModelWithProjection),
+            specifically the
+            [laion/CLIP-ViT-bigG-14-laion2B-39B-b160k](https://huggingface.co/laion/CLIP-ViT-bigG-14-laion2B-39B-b160k)
+            variant.
+        tokenizer (`CLIPTokenizer`):
+            Tokenizer of class
+            [CLIPTokenizer](https://huggingface.co/docs/transformers/v4.21.0/en/model_doc/clip#transformers.CLIPTokenizer).
+        tokenizer_2 (`CLIPTokenizer`):
+            Second Tokenizer of class
+            [CLIPTokenizer](https://huggingface.co/docs/transformers/v4.21.0/en/model_doc/clip#transformers.CLIPTokenizer).
+        unet ([`UNet2DConditionModel`]): Conditional U-Net architecture to denoise the encoded image latents.
+        scheduler ([`SchedulerMixin`]):
+            A scheduler to be used in combination with `unet` to denoise the encoded image latents. Can be one of
+            [`DDIMScheduler`], [`LMSDiscreteScheduler`], or [`PNDMScheduler`].
+    """
+
+    def __init__(
+        self,
+        vae: AutoencoderKL,
+        text_encoder: CLIPTextModel,
+        text_encoder_2: CLIPTextModelWithProjection,
+        tokenizer: CLIPTokenizer,
+        tokenizer_2: CLIPTokenizer,
+        unet: UNet2DConditionModel,
+        scheduler: KarrasDiffusionSchedulers,
+        text_encoder_module_path: str,
+        text_encoder_2_module_path: str,
+        unet_module_path: str,
+        vae_module_path: str,
+        timestep_module_path: str,
+        apply_weights_to_modules: bool = True,
+        force_zeros_for_empty_prompt: bool = True,
+        add_watermarker: Optional[bool] = None,
+        
+    ):
+        super().__init__()
+
+        self.register_modules(
+            vae=vae,
+            text_encoder=text_encoder,
+            text_encoder_2=text_encoder_2,
+            tokenizer=tokenizer,
+            tokenizer_2=tokenizer_2,
+            unet=unet,
+            scheduler=scheduler,
+        )
+        self.register_to_config(force_zeros_for_empty_prompt=force_zeros_for_empty_prompt)
+        self.vae_scale_factor = 2 ** (len(self.vae.config.block_out_channels) - 1)
+        self.image_processor = VaeImageProcessor(vae_scale_factor=self.vae_scale_factor)
+        self.default_sample_size = self.unet.config.sample_size
+
+        add_watermarker = add_watermarker if add_watermarker is not None else is_invisible_watermark_available()
+
+        if add_watermarker:
+            self.watermark = StableDiffusionXLWatermarker()
+        else:
+            self.watermark = None
+        self.text_encoder_module_path = text_encoder_module_path
+        self.text_encoder_2_module_path = text_encoder_2_module_path
+        self.unet_module_path = unet_module_path
+        self.vae_module_path = vae_module_path
+        self.text_encoder_exe = None
+        self.text_encoder_2_exe = None
+        self.unet_exe = None
+        self.vae_exe = None
+        self.timestep_exe = Model(timestep_module_path)
+
+    def apply_vae(self):
+        self.vae_exe = Model(self.vae_module_path)
+        self.vae_exe.set_many_constants_with_tensors(
+            map_vae(self.vae)
+        )
+
+    def apply_clip(self):
+        self.text_encoder_exe = Model(self.text_encoder_module_path)
+        self.text_encoder_exe.nlayers = [x for x in range(0, self.text_encoder.config.num_hidden_layers)]
+        self.text_encoder_2_exe = Model(self.text_encoder_2_module_path)
+        self.text_encoder_2_exe.nlayers = [x for x in range(0, self.text_encoder_2.config.num_hidden_layers)]
+        self.text_encoder_exe.set_many_constants_with_tensors(
+            map_clip(self.text_encoder)
+        )
+        self.text_encoder_2_exe.set_many_constants_with_tensors(
+            map_clip(self.text_encoder_2)
+        )
+    
+    def apply_unet(self):
+        self.unet_exe = Model(self.unet_module_path)
+        self.unet_exe.set_many_constants_with_tensors(
+            map_unet(self.unet)
+        )
+
+    def unload_clip(self):
+        self.text_encoder_exe = None
+        self.text_encoder_2_exe = None
+        torch.cuda.empty_cache()
+    
+    def unload_unet(self):
+        self.unet_exe = None
+        torch.cuda.empty_cache()
+    
+    def unload_vae(self):
+        self.vae_exe = None
+        torch.cuda.empty_cache()
+
+    def encode_prompt(
+        self,
+        prompt: str,
+        prompt_2: Optional[str] = None,
+        num_images_per_prompt: int = 1,
+        do_classifier_free_guidance: bool = True,
+        negative_prompt: Optional[str] = None,
+        negative_prompt_2: Optional[str] = None,
+    ):
+        r"""
+        Encodes the prompt into text encoder hidden states.
+
+        Args:
+            prompt (`str` or `List[str]`, *optional*):
+                prompt to be encoded
+            prompt_2 (`str` or `List[str]`, *optional*):
+                The prompt or prompts to be sent to the `tokenizer_2` and `text_encoder_2`. If not defined, `prompt` is
+                used in both text-encoders
+            device: (`torch.device`):
+                torch device
+            num_images_per_prompt (`int`):
+                number of images that should be generated per prompt
+            do_classifier_free_guidance (`bool`):
+                whether to use classifier free guidance or not
+            negative_prompt (`str` or `List[str]`, *optional*):
+                The prompt or prompts not to guide the image generation. If not defined, one has to pass
+                `negative_prompt_embeds` instead. Ignored when not using guidance (i.e., ignored if `guidance_scale` is
+                less than `1`).
+            negative_prompt_2 (`str` or `List[str]`, *optional*):
+                The prompt or prompts not to guide the image generation to be sent to `tokenizer_2` and
+                `text_encoder_2`. If not defined, `negative_prompt` is used in both text-encoders
+            prompt_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated text embeddings. Can be used to easily tweak text inputs, *e.g.* prompt weighting. If not
+                provided, text embeddings will be generated from `prompt` input argument.
+            negative_prompt_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated negative text embeddings. Can be used to easily tweak text inputs, *e.g.* prompt
+                weighting. If not provided, negative_prompt_embeds will be generated from `negative_prompt` input
+                argument.
+            pooled_prompt_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated pooled text embeddings. Can be used to easily tweak text inputs, *e.g.* prompt weighting.
+                If not provided, pooled text embeddings will be generated from `prompt` input argument.
+            negative_pooled_prompt_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated negative pooled text embeddings. Can be used to easily tweak text inputs, *e.g.* prompt
+                weighting. If not provided, pooled negative_prompt_embeds will be generated from `negative_prompt`
+                input argument.
+            lora_scale (`float`, *optional*):
+                A lora scale that will be applied to all LoRA layers of the text encoder if LoRA layers are loaded.
+        """
+        if prompt is not None and isinstance(prompt, str):
+            batch_size = 1
+        elif prompt is not None and isinstance(prompt, list):
+            batch_size = len(prompt)
+
+        # Define tokenizers and text encoders
+        tokenizers = [self.tokenizer, self.tokenizer_2] if self.tokenizer is not None else [self.tokenizer_2]
+        text_encoders = (
+            [self.text_encoder_exe, self.text_encoder_2_exe] if self.text_encoder_exe is not None else [self.text_encoder_2_exe]
+        )
+
+        prompt_2 = prompt_2 or prompt
+        # textual inversion: procecss multi-vector tokens if necessary
+        prompt_embeds_list = []
+        prompts = [prompt, prompt_2]
+        for prompt, tokenizer, text_encoder in zip(prompts, tokenizers, text_encoders):
+            text_inputs = tokenizer(
+                prompt,
+                padding="max_length",
+                max_length=tokenizer.model_max_length,
+                truncation=True,
+                return_tensors="pt",
+            )
+
+            text_input_ids = text_inputs.input_ids
+            untruncated_ids = tokenizer(prompt, padding="longest", return_tensors="pt").input_ids
+
+            # prompt_embeds = text_encoder(
+            #     text_input_ids.to(device),
+            #     output_hidden_states=True,
+            # )
+            prompt_embeds = clip_inference(text_encoder, text_input_ids, to_cpu=True)
+            # We are only ALWAYS interested in the pooled output of the final text encoder
+            if 'text_embeds' in prompt_embeds.keys():
+                pooled_prompt_embeds = prompt_embeds['text_embeds']
+            else:
+                pooled_prompt_embeds = prompt_embeds['pooled_output']
+            # pooled_prompt_embeds = prompt_embeds[0]
+            # prompt_embeds = prompt_embeds.hidden_states[-2] # -2 because it includes last hidden state, AIT does not so uses -1
+            prompt_embeds = prompt_embeds[f'hidden_state_{text_encoder.nlayers[-1]}']
+
+            prompt_embeds_list.append(prompt_embeds)
+
+        prompt_embeds = torch.concat(prompt_embeds_list, dim=-1)
+
+        # get unconditional embeddings for classifier free guidance
+        zero_out_negative_prompt = negative_prompt is None and self.config.force_zeros_for_empty_prompt
+        if do_classifier_free_guidance and zero_out_negative_prompt:
+            negative_prompt_embeds = torch.zeros_like(prompt_embeds)
+            negative_pooled_prompt_embeds = torch.zeros_like(pooled_prompt_embeds)
+        elif do_classifier_free_guidance:
+            negative_prompt = negative_prompt or ""
+            negative_prompt_2 = negative_prompt_2 or negative_prompt
+
+            uncond_tokens: List[str]
+            if prompt is not None and type(prompt) is not type(negative_prompt):
+                raise TypeError(
+                    f"`negative_prompt` should be the same type to `prompt`, but got {type(negative_prompt)} !="
+                    f" {type(prompt)}."
+                )
+            elif isinstance(negative_prompt, str):
+                uncond_tokens = [negative_prompt, negative_prompt_2]
+            elif batch_size != len(negative_prompt):
+                raise ValueError(
+                    f"`negative_prompt`: {negative_prompt} has batch size {len(negative_prompt)}, but `prompt`:"
+                    f" {prompt} has batch size {batch_size}. Please make sure that passed `negative_prompt` matches"
+                    " the batch size of `prompt`."
+                )
+            else:
+                uncond_tokens = [negative_prompt, negative_prompt_2]
+
+            negative_prompt_embeds_list = []
+            for negative_prompt, tokenizer, text_encoder in zip(uncond_tokens, tokenizers, text_encoders):
+                max_length = prompt_embeds.shape[1]
+                uncond_input = tokenizer(
+                    negative_prompt,
+                    padding="max_length",
+                    max_length=max_length,
+                    truncation=True,
+                    return_tensors="pt",
+                )
+
+                # negative_prompt_embeds = text_encoder(
+                #     uncond_input.input_ids.to(device),
+                #     output_hidden_states=True,
+                # )
+                negative_prompt_embeds = clip_inference(text_encoder, text_input_ids, to_cpu=True)
+                # We are only ALWAYS interested in the pooled output of the final text encoder
+                if 'text_embeds' in negative_prompt_embeds.keys():
+                    negative_pooled_prompt_embeds = negative_prompt_embeds['text_embeds']
+                else:
+                    negative_pooled_prompt_embeds = negative_prompt_embeds['pooled_output']
+                # negative_pooled_prompt_embeds = negative_prompt_embeds[0]
+                # negative_prompt_embeds = negative_prompt_embeds.hidden_states[-2] # -2 because it includes last hidden state, AIT does not so uses -1
+                prompt_embeds = negative_prompt_embeds[f'hidden_state_{text_encoder.nlayers[-1]}']
+
+                negative_prompt_embeds_list.append(negative_prompt_embeds)
+
+            negative_prompt_embeds = torch.concat(negative_prompt_embeds_list, dim=-1)
+
+        prompt_embeds = prompt_embeds
+        bs_embed, seq_len, _ = prompt_embeds.shape
+        # duplicate text embeddings for each generation per prompt, using mps friendly method
+        prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+        prompt_embeds = prompt_embeds.view(bs_embed * num_images_per_prompt, seq_len, -1)
+
+        if do_classifier_free_guidance:
+            # duplicate unconditional embeddings for each generation per prompt, using mps friendly method
+            seq_len = negative_prompt_embeds.shape[1]
+            negative_prompt_embeds = negative_prompt_embeds.to(dtype=self.text_encoder_2.dtype)
+            negative_prompt_embeds = negative_prompt_embeds.repeat(1, num_images_per_prompt, 1)
+            negative_prompt_embeds = negative_prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, -1)
+
+        pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, num_images_per_prompt).view(
+            bs_embed * num_images_per_prompt, -1
+        )
+        if do_classifier_free_guidance:
+            negative_pooled_prompt_embeds = negative_pooled_prompt_embeds.repeat(1, num_images_per_prompt).view(
+                bs_embed * num_images_per_prompt, -1
+            )
+
+        return prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds
+
+    # Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.StableDiffusionPipeline.prepare_extra_step_kwargs
+    def prepare_extra_step_kwargs(self, generator, eta):
+        # prepare extra kwargs for the scheduler step, since not all schedulers have the same signature
+        # eta (η) is only used with the DDIMScheduler, it will be ignored for other schedulers.
+        # eta corresponds to η in DDIM paper: https://arxiv.org/abs/2010.02502
+        # and should be between [0, 1]
+
+        accepts_eta = "eta" in set(inspect.signature(self.scheduler.step).parameters.keys())
+        extra_step_kwargs = {}
+        if accepts_eta:
+            extra_step_kwargs["eta"] = eta
+
+        # check if the scheduler accepts generator
+        accepts_generator = "generator" in set(inspect.signature(self.scheduler.step).parameters.keys())
+        if accepts_generator:
+            extra_step_kwargs["generator"] = generator
+        return extra_step_kwargs
+
+    def check_inputs(
+        self,
+        prompt,
+        prompt_2,
+        height,
+        width,
+        callback_steps,
+        negative_prompt=None,
+        negative_prompt_2=None,
+        prompt_embeds=None,
+        negative_prompt_embeds=None,
+        pooled_prompt_embeds=None,
+        negative_pooled_prompt_embeds=None,
+    ):
+        if height % 8 != 0 or width % 8 != 0:
+            raise ValueError(f"`height` and `width` have to be divisible by 8 but are {height} and {width}.")
+
+        if (callback_steps is None) or (
+            callback_steps is not None and (not isinstance(callback_steps, int) or callback_steps <= 0)
+        ):
+            raise ValueError(
+                f"`callback_steps` has to be a positive integer but is {callback_steps} of type"
+                f" {type(callback_steps)}."
+            )
+
+        if prompt is not None and prompt_embeds is not None:
+            raise ValueError(
+                f"Cannot forward both `prompt`: {prompt} and `prompt_embeds`: {prompt_embeds}. Please make sure to"
+                " only forward one of the two."
+            )
+        elif prompt_2 is not None and prompt_embeds is not None:
+            raise ValueError(
+                f"Cannot forward both `prompt_2`: {prompt_2} and `prompt_embeds`: {prompt_embeds}. Please make sure to"
+                " only forward one of the two."
+            )
+        elif prompt is None and prompt_embeds is None:
+            raise ValueError(
+                "Provide either `prompt` or `prompt_embeds`. Cannot leave both `prompt` and `prompt_embeds` undefined."
+            )
+        elif prompt is not None and (not isinstance(prompt, str) and not isinstance(prompt, list)):
+            raise ValueError(f"`prompt` has to be of type `str` or `list` but is {type(prompt)}")
+        elif prompt_2 is not None and (not isinstance(prompt_2, str) and not isinstance(prompt_2, list)):
+            raise ValueError(f"`prompt_2` has to be of type `str` or `list` but is {type(prompt_2)}")
+
+        if negative_prompt is not None and negative_prompt_embeds is not None:
+            raise ValueError(
+                f"Cannot forward both `negative_prompt`: {negative_prompt} and `negative_prompt_embeds`:"
+                f" {negative_prompt_embeds}. Please make sure to only forward one of the two."
+            )
+        elif negative_prompt_2 is not None and negative_prompt_embeds is not None:
+            raise ValueError(
+                f"Cannot forward both `negative_prompt_2`: {negative_prompt_2} and `negative_prompt_embeds`:"
+                f" {negative_prompt_embeds}. Please make sure to only forward one of the two."
+            )
+
+        if prompt_embeds is not None and negative_prompt_embeds is not None:
+            if prompt_embeds.shape != negative_prompt_embeds.shape:
+                raise ValueError(
+                    "`prompt_embeds` and `negative_prompt_embeds` must have the same shape when passed directly, but"
+                    f" got: `prompt_embeds` {prompt_embeds.shape} != `negative_prompt_embeds`"
+                    f" {negative_prompt_embeds.shape}."
+                )
+
+        if prompt_embeds is not None and pooled_prompt_embeds is None:
+            raise ValueError(
+                "If `prompt_embeds` are provided, `pooled_prompt_embeds` also have to be passed. Make sure to generate `pooled_prompt_embeds` from the same text encoder that was used to generate `prompt_embeds`."
+            )
+
+        if negative_prompt_embeds is not None and negative_pooled_prompt_embeds is None:
+            raise ValueError(
+                "If `negative_prompt_embeds` are provided, `negative_pooled_prompt_embeds` also have to be passed. Make sure to generate `negative_pooled_prompt_embeds` from the same text encoder that was used to generate `negative_prompt_embeds`."
+            )
+
+    # Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.StableDiffusionPipeline.prepare_latents
+    def prepare_latents(self, batch_size, num_channels_latents, height, width, dtype, generator, latents=None):
+        shape = (batch_size, num_channels_latents, height // self.vae_scale_factor, width // self.vae_scale_factor)
+        if isinstance(generator, list) and len(generator) != batch_size:
+            raise ValueError(
+                f"You have passed a list of generators of length {len(generator)}, but requested an effective batch"
+                f" size of {batch_size}. Make sure the batch size matches the length of the generators."
+            )
+
+        if latents is None:
+            latents = randn_tensor(shape, generator=generator, dtype=dtype)
+        else:
+            latents = latents
+
+        # scale the initial noise by the standard deviation required by the scheduler
+        latents = latents * self.scheduler.init_noise_sigma
+        return latents
+
+    def _get_add_time_ids(self, original_size, crops_coords_top_left, target_size, dtype):
+        add_time_ids = list(original_size + crops_coords_top_left + target_size)
+
+        passed_add_embed_dim = (
+            self.unet.config.addition_time_embed_dim * len(add_time_ids) + self.text_encoder_2.config.projection_dim
+        )
+        expected_add_embed_dim = self.unet.add_embedding.linear_1.in_features
+
+        if expected_add_embed_dim != passed_add_embed_dim:
+            raise ValueError(
+                f"Model expects an added time embedding vector of length {expected_add_embed_dim}, but a vector of {passed_add_embed_dim} was created. The model has an incorrect config. Please check `unet.config.time_embedding_type` and `text_encoder_2.config.projection_dim`."
+            )
+
+        add_time_embeds = []
+        for time_id in add_time_ids:
+            time_embed = timestep_inference(self.timestep_exe, time_id, to_cpu=True)['time_embed']
+            add_time_embeds.append(time_embed)
+
+        add_time_embeds = torch.cat(add_time_embeds, dim=-1).to(dtype=dtype)
+        return add_time_embeds
+
+    @torch.no_grad()
+    def __call__(
+        self,
+        prompt: Union[str, List[str]] = None,
+        prompt_2: Optional[Union[str, List[str]]] = None,
+        height: Optional[int] = None,
+        width: Optional[int] = None,
+        num_inference_steps: int = 50,
+        denoising_end: Optional[float] = None,
+        guidance_scale: float = 5.0,
+        negative_prompt: Optional[Union[str, List[str]]] = None,
+        negative_prompt_2: Optional[Union[str, List[str]]] = None,
+        num_images_per_prompt: Optional[int] = 1,
+        eta: float = 0.0,
+        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
+        latents: Optional[torch.FloatTensor] = None,
+        output_type: Optional[str] = "pil",
+        return_dict: bool = True,
+        callback: Optional[Callable[[int, int, torch.FloatTensor], None]] = None,
+        callback_steps: int = 1,
+        cross_attention_kwargs: Optional[Dict[str, Any]] = None,
+        guidance_rescale: float = 0.0,
+        original_size: Optional[Tuple[int, int]] = None,
+        crops_coords_top_left: Tuple[int, int] = (0, 0),
+        target_size: Optional[Tuple[int, int]] = None,
+    ):
+        r"""
+        Function invoked when calling the pipeline for generation.
+
+        Args:
+            prompt (`str` or `List[str]`, *optional*):
+                The prompt or prompts to guide the image generation. If not defined, one has to pass `prompt_embeds`.
+                instead.
+            prompt_2 (`str` or `List[str]`, *optional*):
+                The prompt or prompts to be sent to the `tokenizer_2` and `text_encoder_2`. If not defined, `prompt` is
+                used in both text-encoders
+            height (`int`, *optional*, defaults to self.unet.config.sample_size * self.vae_scale_factor):
+                The height in pixels of the generated image.
+            width (`int`, *optional*, defaults to self.unet.config.sample_size * self.vae_scale_factor):
+                The width in pixels of the generated image.
+            num_inference_steps (`int`, *optional*, defaults to 50):
+                The number of denoising steps. More denoising steps usually lead to a higher quality image at the
+                expense of slower inference.
+            denoising_end (`float`, *optional*):
+                When specified, determines the fraction (between 0.0 and 1.0) of the total denoising process to be
+                completed before it is intentionally prematurely terminated. As a result, the returned sample will
+                still retain a substantial amount of noise as determined by the discrete timesteps selected by the
+                scheduler. The denoising_end parameter should ideally be utilized when this pipeline forms a part of a
+                "Mixture of Denoisers" multi-pipeline setup, as elaborated in [**Refining the Image
+                Output**](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_xl#refining-the-image-output)
+            guidance_scale (`float`, *optional*, defaults to 5.0):
+                Guidance scale as defined in [Classifier-Free Diffusion Guidance](https://arxiv.org/abs/2207.12598).
+                `guidance_scale` is defined as `w` of equation 2. of [Imagen
+                Paper](https://arxiv.org/pdf/2205.11487.pdf). Guidance scale is enabled by setting `guidance_scale >
+                1`. Higher guidance scale encourages to generate images that are closely linked to the text `prompt`,
+                usually at the expense of lower image quality.
+            negative_prompt (`str` or `List[str]`, *optional*):
+                The prompt or prompts not to guide the image generation. If not defined, one has to pass
+                `negative_prompt_embeds` instead. Ignored when not using guidance (i.e., ignored if `guidance_scale` is
+                less than `1`).
+            negative_prompt_2 (`str` or `List[str]`, *optional*):
+                The prompt or prompts not to guide the image generation to be sent to `tokenizer_2` and
+                `text_encoder_2`. If not defined, `negative_prompt` is used in both text-encoders
+            num_images_per_prompt (`int`, *optional*, defaults to 1):
+                The number of images to generate per prompt.
+            eta (`float`, *optional*, defaults to 0.0):
+                Corresponds to parameter eta (η) in the DDIM paper: https://arxiv.org/abs/2010.02502. Only applies to
+                [`schedulers.DDIMScheduler`], will be ignored for others.
+            generator (`torch.Generator` or `List[torch.Generator]`, *optional*):
+                One or a list of [torch generator(s)](https://pytorch.org/docs/stable/generated/torch.Generator.html)
+                to make generation deterministic.
+            latents (`torch.FloatTensor`, *optional*):
+                Pre-generated noisy latents, sampled from a Gaussian distribution, to be used as inputs for image
+                generation. Can be used to tweak the same generation with different prompts. If not provided, a latents
+                tensor will ge generated by sampling using the supplied random `generator`.
+            prompt_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated text embeddings. Can be used to easily tweak text inputs, *e.g.* prompt weighting. If not
+                provided, text embeddings will be generated from `prompt` input argument.
+            negative_prompt_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated negative text embeddings. Can be used to easily tweak text inputs, *e.g.* prompt
+                weighting. If not provided, negative_prompt_embeds will be generated from `negative_prompt` input
+                argument.
+            pooled_prompt_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated pooled text embeddings. Can be used to easily tweak text inputs, *e.g.* prompt weighting.
+                If not provided, pooled text embeddings will be generated from `prompt` input argument.
+            negative_pooled_prompt_embeds (`torch.FloatTensor`, *optional*):
+                Pre-generated negative pooled text embeddings. Can be used to easily tweak text inputs, *e.g.* prompt
+                weighting. If not provided, pooled negative_prompt_embeds will be generated from `negative_prompt`
+                input argument.
+            output_type (`str`, *optional*, defaults to `"pil"`):
+                The output format of the generate image. Choose between
+                [PIL](https://pillow.readthedocs.io/en/stable/): `PIL.Image.Image` or `np.array`.
+            return_dict (`bool`, *optional*, defaults to `True`):
+                Whether or not to return a [`~pipelines.stable_diffusion_xl.StableDiffusionXLPipelineOutput`] instead
+                of a plain tuple.
+            callback (`Callable`, *optional*):
+                A function that will be called every `callback_steps` steps during inference. The function will be
+                called with the following arguments: `callback(step: int, timestep: int, latents: torch.FloatTensor)`.
+            callback_steps (`int`, *optional*, defaults to 1):
+                The frequency at which the `callback` function will be called. If not specified, the callback will be
+                called at every step.
+            cross_attention_kwargs (`dict`, *optional*):
+                A kwargs dictionary that if specified is passed along to the `AttentionProcessor` as defined under
+                `self.processor` in
+                [diffusers.models.attention_processor](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
+            guidance_rescale (`float`, *optional*, defaults to 0.7):
+                Guidance rescale factor proposed by [Common Diffusion Noise Schedules and Sample Steps are
+                Flawed](https://arxiv.org/pdf/2305.08891.pdf) `guidance_scale` is defined as `φ` in equation 16. of
+                [Common Diffusion Noise Schedules and Sample Steps are Flawed](https://arxiv.org/pdf/2305.08891.pdf).
+                Guidance rescale factor should fix overexposure when using zero terminal SNR.
+            original_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+                If `original_size` is not the same as `target_size` the image will appear to be down- or upsampled.
+                `original_size` defaults to `(width, height)` if not specified. Part of SDXL's micro-conditioning as
+                explained in section 2.2 of
+                [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952).
+            crops_coords_top_left (`Tuple[int]`, *optional*, defaults to (0, 0)):
+                `crops_coords_top_left` can be used to generate an image that appears to be "cropped" from the position
+                `crops_coords_top_left` downwards. Favorable, well-centered images are usually achieved by setting
+                `crops_coords_top_left` to (0, 0). Part of SDXL's micro-conditioning as explained in section 2.2 of
+                [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952).
+            target_size (`Tuple[int]`, *optional*, defaults to (1024, 1024)):
+                For most cases, `target_size` should be set to the desired height and width of the generated image. If
+                not specified it will default to `(width, height)`. Part of SDXL's micro-conditioning as explained in
+                section 2.2 of [https://huggingface.co/papers/2307.01952](https://huggingface.co/papers/2307.01952).
+
+        Examples:
+
+        Returns:
+            [`~pipelines.stable_diffusion_xl.StableDiffusionXLPipelineOutput`] or `tuple`:
+            [`~pipelines.stable_diffusion_xl.StableDiffusionXLPipelineOutput`] if `return_dict` is True, otherwise a
+            `tuple`. When returning a tuple, the first element is a list with the generated images.
+        """
+        # 0. Default height and width to unet
+        height = height or self.default_sample_size * self.vae_scale_factor
+        width = width or self.default_sample_size * self.vae_scale_factor
+
+        original_size = original_size or (height, width)
+        target_size = target_size or (height, width)
+
+        # 1. Check inputs. Raise error if not correct
+        self.check_inputs(
+            prompt,
+            prompt_2,
+            height,
+            width,
+            callback_steps,
+            negative_prompt,
+            negative_prompt_2,
+        )
+
+        # 2. Define call parameters
+        if prompt is not None and isinstance(prompt, str):
+            batch_size = 1
+        elif prompt is not None and isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            batch_size = prompt_embeds.shape[0]
+
+        self.apply_clip()
+
+        # here `guidance_scale` is defined analog to the guidance weight `w` of equation (2)
+        # of the Imagen paper: https://arxiv.org/pdf/2205.11487.pdf . `guidance_scale = 1`
+        # corresponds to doing no classifier free guidance.
+        do_classifier_free_guidance = guidance_scale > 1.0
+
+        (
+            prompt_embeds,
+            negative_prompt_embeds,
+            pooled_prompt_embeds,
+            negative_pooled_prompt_embeds,
+        ) = self.encode_prompt(
+            prompt=prompt,
+            prompt_2=prompt_2,
+            num_images_per_prompt=num_images_per_prompt,
+            do_classifier_free_guidance=do_classifier_free_guidance,
+            negative_prompt=negative_prompt,
+            negative_prompt_2=negative_prompt_2,
+        )
+
+        self.unload_clip()
+
+        # 4. Prepare timesteps
+        self.scheduler.set_timesteps(num_inference_steps)
+
+        timesteps = self.scheduler.timesteps
+
+        # 5. Prepare latent variables
+        num_channels_latents = self.unet.config.in_channels
+        latents = self.prepare_latents(
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            prompt_embeds.dtype,
+            generator,
+            latents,
+        )
+
+        # 6. Prepare extra step kwargs. TODO: Logic should ideally just be moved out of the pipeline
+        extra_step_kwargs = self.prepare_extra_step_kwargs(generator, eta)
+
+        # 7. Prepare added time ids & embeddings
+        add_text_embeds = pooled_prompt_embeds
+        add_time_ids = self._get_add_time_ids(
+            original_size, crops_coords_top_left, target_size, dtype=prompt_embeds.dtype
+        )
+
+        if do_classifier_free_guidance:
+            prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+            add_text_embeds = torch.cat([negative_pooled_prompt_embeds, add_text_embeds], dim=0)
+            add_time_ids = torch.cat([add_time_ids, add_time_ids], dim=0)
+
+        prompt_embeds = prompt_embeds
+        add_text_embeds = add_text_embeds
+        add_time_ids = add_time_ids.repeat(batch_size * num_images_per_prompt, 1)
+        add_embeds = torch.cat([add_text_embeds, add_time_ids], dim=-1)
+        # 8. Denoising loop
+        num_warmup_steps = max(len(timesteps) - num_inference_steps * self.scheduler.order, 0)
+
+        # 7.1 Apply denoising_end
+        if denoising_end is not None and type(denoising_end) == float and denoising_end > 0 and denoising_end < 1:
+            discrete_timestep_cutoff = int(
+                round(
+                    self.scheduler.config.num_train_timesteps
+                    - (denoising_end * self.scheduler.config.num_train_timesteps)
+                )
+            )
+            num_inference_steps = len(list(filter(lambda ts: ts >= discrete_timestep_cutoff, timesteps)))
+            timesteps = timesteps[:num_inference_steps]
+
+        self.apply_unet()
+
+        with self.progress_bar(total=num_inference_steps) as progress_bar:
+            for i, t in enumerate(timesteps):
+                # expand the latents if we are doing classifier free guidance
+                latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
+
+                latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
+
+                # predict the noise residual
+                # added_cond_kwargs = {"text_embeds": add_text_embeds, "time_ids": add_time_ids}
+                # noise_pred = self.unet(
+                #     latent_model_input,
+                #     t,
+                #     encoder_hidden_states=prompt_embeds,
+                #     cross_attention_kwargs=cross_attention_kwargs,
+                #     added_cond_kwargs=added_cond_kwargs,
+                #     return_dict=False,
+                # )[0]
+                noise_pred = unet_inference(
+                    self.unet_exe,
+                    latent_model_input,
+                    t,
+                    prompt_embeds,
+                    add_embeds=add_embeds,
+                    to_cpu=True,
+                )['latent_output']
+
+                # perform guidance
+                if do_classifier_free_guidance:
+                    noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                    noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
+
+                if do_classifier_free_guidance and guidance_rescale > 0.0:
+                    # Based on 3.4. in https://arxiv.org/pdf/2305.08891.pdf
+                    noise_pred = rescale_noise_cfg(noise_pred, noise_pred_text, guidance_rescale=guidance_rescale)
+
+                # compute the previous noisy sample x_t -> x_t-1
+                latents = self.scheduler.step(noise_pred, t, latents, **extra_step_kwargs, return_dict=False)[0]
+
+                # call the callback, if provided
+                if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
+                    progress_bar.update()
+                    if callback is not None and i % callback_steps == 0:
+                        callback(i, t, latents)
+
+        self.unload_unet()
+
+        self.apply_vae()
+
+        if not output_type == "latent":
+            image = vae_decode_inference(self.vae_exe, latents / self.vae.config.scaling_factor, to_cpu=True)['pixels']
+            self.unload_vae()
+        else:
+            image = latents
+            return StableDiffusionXLPipelineOutput(images=image)
+
+        # apply watermark if available
+        if self.watermark is not None:
+            image = self.watermark.apply_watermark(image)
+
+        image = self.image_processor.postprocess(image, output_type=output_type)
+
+        if not return_dict:
+            return (image,)
+
+        return StableDiffusionXLPipelineOutput(images=image)

--- a/python/aitemplate/backend/cuda/tensor/argmax.py
+++ b/python/aitemplate/backend/cuda/tensor/argmax.py
@@ -32,7 +32,9 @@ header_files = """
 #include <cub/cub.cuh>
 
 using bfloat16 = nv_bfloat16;
-
+// if this #if statement does not evaluate to True, it is already
+// defined in cub's util_type.cuh and would be a redefinition
+#if (__CUDACC_VER_MAJOR__ < 11 && CUDA_VERSION < 11000) || _NVHPC_CUDA
 namespace cub {
     template <>
     struct FpLimits<bfloat16>
@@ -54,7 +56,7 @@ namespace cub {
     template<> struct Traits<bfloat16>
       : NumericTraits<bfloat16> {};
 }
-
+#endif
 """
 
 

--- a/python/aitemplate/compiler/stable_set.py
+++ b/python/aitemplate/compiler/stable_set.py
@@ -19,8 +19,11 @@ It also tries to preserve the original element order as much as possible, which 
 potentially make debugging (e.g. comparison with the original graph, comparison between
 AIT GPU trace and other GPU traces) easier.
 """
+import sys
 from collections import abc
 from typing import Any, Iterable
+
+sys.setrecursionlimit(10000)
 
 
 class StableSet(abc.MutableSet):

--- a/python/aitemplate/compiler/stable_set.py
+++ b/python/aitemplate/compiler/stable_set.py
@@ -19,11 +19,8 @@ It also tries to preserve the original element order as much as possible, which 
 potentially make debugging (e.g. comparison with the original graph, comparison between
 AIT GPU trace and other GPU traces) easier.
 """
-import sys
 from collections import abc
 from typing import Any, Iterable
-
-sys.setrecursionlimit(10000)
 
 
 class StableSet(abc.MutableSet):


### PR DESCRIPTION
SDXL

Related issue: #851 

## Status

- [x] Compilation
- [x] Pipeline
- [ ] Documentation

## Compilation

`scripts/compile_sdxl.py`
* text_encoder
* text_encoder_2
* unet
* addition_time_embed
* vae

```
INFO:aitemplate.backend.build_cache_base:Build cache disabled
INFO <aitemplate.testing.detect_target> Set target to CUDA
The config attributes {'add_watermarker': None} were passed to StableDiffusionXLPipeline, but are not expected and will be ignored. Please verify your model_index.json configuration file.
Keyword arguments {'add_watermarker': None} are not expected by StableDiffusionXLPipeline and will be ignored.
The config attributes {'force_upcast': True} were passed to AutoencoderKL, but are not expected and will be ignored. Please verify your config.json configuration file.
The config attributes {'force_upcast': False} were passed to AutoencoderKL, but are not expected and will be ignored. Please verify your config.json configuration file.
AIT last_hidden_state shape: [[1], [77], [768]]
AIT pooled_output shape: [[1], [768]]
AIT hidden_state_0 shape: [[1], [77], [768]]
AIT hidden_state_1 shape: [[1], [77], [768]]
AIT hidden_state_2 shape: [[1], [77], [768]]
AIT hidden_state_3 shape: [[1], [77], [768]]
AIT hidden_state_4 shape: [[1], [77], [768]]
AIT hidden_state_5 shape: [[1], [77], [768]]
AIT hidden_state_6 shape: [[1], [77], [768]]
AIT hidden_state_7 shape: [[1], [77], [768]]
AIT hidden_state_8 shape: [[1], [77], [768]]
AIT hidden_state_9 shape: [[1], [77], [768]]
AIT hidden_state_10 shape: [[1], [77], [768]]
AIT hidden_state_11 shape: [[1], [77], [768]]
INFO <aitemplate.compiler.compiler> Start to compile AIT model. test_dir='A:\\SDXL_text_encoder'
INFO <aitemplate.backend.target> Loading profile cache from: C:\Users\user\.aitemplate\cuda.db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_gemm_3' exists in the db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_conv_3' exists in the db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_conv3d_3' exists in the db
INFO <aitemplate.compiler.compiler> optimized graph elapsed time: 0:00:00.551695
INFO <aitemplate.compiler.transform.refine_graph> reduced unique ops from 167 to 28
INFO <aitemplate.compiler.transform.profile> Force profiler cache = False
INFO <aitemplate.compiler.ops.gemm_universal.gemm_common> Load profiling result for gemm_rcr_bias_12 from cache: ('cutlass_tensorop_h16816gemm_64x64_64x5_tn_align_8_8', 0, 1)
...
INFO <aitemplate.compiler.transform.memory_planning> Workspace shared_size=0 unique_size=0
INFO <aitemplate.compiler.transform.memory_planning> max_blob=76008960 constant_offset=76008960
INFO <aitemplate.backend.codegen> generated 2 function srcs
INFO <aitemplate.compiler.compiler> folded constants elapsed time: 0:00:00.010961
INFO <aitemplate.compiler.transform.memory_planning> Workspace shared_size=236544 unique_size=0
INFO <aitemplate.compiler.transform.memory_planning> max_blob=2483840 constant_offset=246120960
INFO <aitemplate.backend.codegen> generated 26 function srcs
INFO <aitemplate.backend.codegen> generated 8 library srcs
INFO <aitemplate.backend.cuda.builder_cmake> Executing "cmake.EXE" -B "A:/SDXL_text_encoder/build" -S "A:/SDXL_text_encoder"
INFO <aitemplate.backend.cuda.builder_cmake> Executing msbuild "A:/SDXL_text_encoder/build/SDXL_text_encoder.sln" -m /property:Configuration=Release
2023-08-07 15:05:25,371 INFO <aitemplate.compiler.compiler> compiled the final .so file elapsed time: 0:01:19.093088
AIT last_hidden_state shape: [[1], [77], [1280]]
AIT pooled_output shape: [[1], [1280]]
AIT text_embeds shape: [[1], [1280]]
AIT hidden_state_0 shape: [[1], [77], [1280]]
AIT hidden_state_1 shape: [[1], [77], [1280]]
AIT hidden_state_2 shape: [[1], [77], [1280]]
AIT hidden_state_3 shape: [[1], [77], [1280]]
AIT hidden_state_4 shape: [[1], [77], [1280]]
AIT hidden_state_5 shape: [[1], [77], [1280]]
AIT hidden_state_6 shape: [[1], [77], [1280]]
AIT hidden_state_7 shape: [[1], [77], [1280]]
AIT hidden_state_8 shape: [[1], [77], [1280]]
AIT hidden_state_9 shape: [[1], [77], [1280]]
AIT hidden_state_10 shape: [[1], [77], [1280]]
AIT hidden_state_11 shape: [[1], [77], [1280]]
AIT hidden_state_12 shape: [[1], [77], [1280]]
AIT hidden_state_13 shape: [[1], [77], [1280]]
AIT hidden_state_14 shape: [[1], [77], [1280]]
AIT hidden_state_15 shape: [[1], [77], [1280]]
AIT hidden_state_16 shape: [[1], [77], [1280]]
AIT hidden_state_17 shape: [[1], [77], [1280]]
AIT hidden_state_18 shape: [[1], [77], [1280]]
AIT hidden_state_19 shape: [[1], [77], [1280]]
AIT hidden_state_20 shape: [[1], [77], [1280]]
AIT hidden_state_21 shape: [[1], [77], [1280]]
AIT hidden_state_22 shape: [[1], [77], [1280]]
AIT hidden_state_23 shape: [[1], [77], [1280]]
AIT hidden_state_24 shape: [[1], [77], [1280]]
AIT hidden_state_25 shape: [[1], [77], [1280]]
AIT hidden_state_26 shape: [[1], [77], [1280]]
AIT hidden_state_27 shape: [[1], [77], [1280]]
AIT hidden_state_28 shape: [[1], [77], [1280]]
AIT hidden_state_29 shape: [[1], [77], [1280]]
AIT hidden_state_30 shape: [[1], [77], [1280]]
AIT hidden_state_31 shape: [[1], [77], [1280]]
INFO <aitemplate.compiler.compiler> Start to compile AIT model. test_dir='A:\\SDXL_text_encoder_2'
INFO <aitemplate.backend.target> Loading profile cache from: C:\Users\user\.aitemplate\cuda.db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_gemm_3' exists in the db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_conv_3' exists in the db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_conv3d_3' exists in the db
INFO <aitemplate.compiler.compiler> optimized graph elapsed time: 0:00:00.766962
INFO <aitemplate.compiler.transform.refine_graph> reduced unique ops from 396 to 17
INFO <aitemplate.compiler.transform.profile> Force profiler cache = False
INFO <aitemplate.compiler.ops.gemm_universal.gemm_common> generating profiler_filename='gemm_rcr_bias_9e46850d5286ecc7e078b5b7f76afbcac62967b4_3'
...
INFO <aitemplate.compiler.transform.memory_planning> Workspace shared_size=0 unique_size=0
INFO <aitemplate.compiler.transform.memory_planning> max_blob=126681600 constant_offset=126681600
INFO <aitemplate.backend.codegen> generated 2 function srcs
INFO <aitemplate.compiler.compiler> folded constants elapsed time: 0:00:00.015991
INFO <aitemplate.compiler.transform.memory_planning> Workspace shared_size=394240 unique_size=0
INFO <aitemplate.compiler.transform.memory_planning> max_blob=7490688 constant_offset=1389319680
INFO <aitemplate.backend.codegen> generated 15 function srcs
INFO <aitemplate.backend.codegen> generated 8 library srcs
INFO <aitemplate.backend.cuda.builder_cmake> Executing "cmake.EXE" -B "A:/SDXL_text_encoder_2/build" -S "A:/SDXL_text_encoder_2"
INFO <aitemplate.compiler.compiler> compiled the final .so file elapsed time: 0:01:59.937896
AIT latent_output shape: [[1, 2], [8, 256], [8, 256], [4]]
INFO <aitemplate.compiler.compiler> Start to compile AIT model. test_dir='A:\\SDXL_unet'
INFO <aitemplate.backend.target> Loading profile cache from: C:\Users\user\.aitemplate\cuda.db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_gemm_3' exists in the db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_conv_3' exists in the db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_conv3d_3' exists in the db
INFO <aitemplate.compiler.compiler> optimized graph elapsed time: 0:00:12.960270
INFO <aitemplate.compiler.transform.refine_graph> reduced unique ops from 2460 to 336
INFO <aitemplate.compiler.transform.profile> Force profiler cache = False
INFO <aitemplate.compiler.ops.gemm_universal.gemm_common> generating profiler_filename='gemm_rcr_9e46850d5286ecc7e078b5b7f76afbcac62967b4_3'
...
INFO <aitemplate.compiler.transform.profile> ran 51 profilers elapsed time: 0:02:16.783349
INFO <aitemplate.compiler.transform.memory_planning> Workspace shared_size=0 unique_size=0
INFO <aitemplate.compiler.transform.memory_planning> max_blob=320 constant_offset=320
INFO <aitemplate.backend.codegen> generated 1 function srcs
INFO <aitemplate.compiler.compiler> folded constants elapsed time: 0:00:00.065957
INFO <aitemplate.compiler.transform.memory_planning> Workspace shared_size=83886080 unique_size=0
INFO <aitemplate.compiler.transform.memory_planning> max_blob=1276678400 constant_offset=320
INFO <aitemplate.backend.codegen> generated 335 function srcs
INFO <aitemplate.backend.codegen> generated 8 library srcs
INFO <aitemplate.backend.cuda.builder_cmake> Executing "cmake.EXE" -B "A:/SDXL_unet/build" -S "A:/SDXL_unet"
INFO <aitemplate.backend.cuda.builder_cmake> Executing msbuild "A:/SDXL_unet/build/SDXL_unet.sln" -m /property:Configuration=Release
INFO <aitemplate.compiler.compiler> compiled the final .so file elapsed time: 0:09:37.074907
AIT time_embed shape: [[1], [256]]
INFO <aitemplate.compiler.compiler> Start to compile AIT model. test_dir='A:\\SDXL_addition_time_embed'
INFO <aitemplate.backend.target> Loading profile cache from: C:\Users\user\.aitemplate\cuda.db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_gemm_3' exists in the db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_conv_3' exists in the db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_conv3d_3' exists in the db
INFO <aitemplate.compiler.compiler> optimized graph elapsed time: 0:00:00.011620
INFO <aitemplate.compiler.transform.refine_graph> reduced unique ops from 2 to 2
INFO <aitemplate.compiler.transform.profile> Force profiler cache = False
INFO <aitemplate.compiler.transform.profile> generated 0 profilers elapsed time: 0:00:00.000961
INFO <aitemplate.compiler.transform.profile> compiled profilers elapsed time: 0:00:00
INFO <aitemplate.backend.profiler_runner> Initialized profiler runner with devices: [0]
INFO <aitemplate.compiler.transform.profile> ran 0 profilers elapsed time: 0:00:00.001057
INFO <aitemplate.compiler.transform.memory_planning> Workspace shared_size=0 unique_size=0
INFO <aitemplate.compiler.transform.memory_planning> max_blob=256 constant_offset=256
INFO <aitemplate.backend.codegen> generated 1 function srcs
INFO <aitemplate.compiler.compiler> folded constants elapsed time: 0:00:00.005357
INFO <aitemplate.compiler.transform.memory_planning> Workspace shared_size=0 unique_size=0
INFO <aitemplate.compiler.transform.memory_planning> max_blob=576 constant_offset=256
INFO <aitemplate.backend.codegen> generated 1 function srcs
INFO <aitemplate.backend.codegen> generated 8 library srcs
INFO <aitemplate.backend.cuda.builder_cmake> Executing "cmake.EXE" -B "A:/SDXL_addition_time_embed/build" -S "A:/SDXL_addition_time_embed"
INFO <aitemplate.backend.cuda.builder_cmake> Executing msbuild "A:/SDXL_addition_time_embed/build/SDXL_addition_time_embed.sln" -m /property:Configuration=Release
INFO <aitemplate.compiler.compiler> compiled the final .so file elapsed time: 0:00:49.568846
AIT pixels shape: [[1], [64, 2048], [64, 2048], [3]]
INFO <aitemplate.compiler.compiler> Start to compile AIT model. test_dir='A:\\SDXL_vae'
INFO <aitemplate.backend.target> Loading profile cache from: C:\Users\user\.aitemplate\cuda.db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_gemm_3' exists in the db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_conv_3' exists in the db
INFO <aitemplate.backend.profiler_cache> table_name='cuda_conv3d_3' exists in the db
INFO <aitemplate.compiler.compiler> optimized graph elapsed time: 0:00:00.177116
INFO <aitemplate.compiler.transform.refine_graph> reduced unique ops from 83 to 38
INFO <aitemplate.compiler.transform.profile> Force profiler cache = False
INFO <aitemplate.compiler.ops.gemm_universal.gemm_common> generating profiler_filename='gemm_rcr_bias_a4cc685557842bbc9ccfcb9d53d8d86a1e9f0356_3'
INFO <aitemplate.compiler.transform.profile> ran 20 profilers elapsed time: 0:03:23.172469
INFO <aitemplate.compiler.transform.constant_folding> No constants to fold, skipping constant folding.
INFO <aitemplate.compiler.compiler> folded constants elapsed time: 0:00:00.006229
INFO <aitemplate.compiler.transform.memory_planning> Workspace shared_size=134217728 unique_size=0
INFO <aitemplate.compiler.transform.memory_planning> max_blob=5368709120 constant_offset=98980544
INFO <aitemplate.backend.codegen> generated 38 function srcs
INFO <aitemplate.backend.codegen> generated 8 library srcs
INFO <aitemplate.backend.cuda.builder_cmake> Executing "cmake.EXE" -B "A:/SDXL_vae/build" -S "A:/SDXL_vae"
INFO <aitemplate.backend.cuda.builder_cmake> Executing msbuild "A:/SDXL_vae/build/SDXL_vae.sln" -m /property:Configuration=Release
INFO <aitemplate.compiler.compiler> compiled the final .so file elapsed time: 0:02:49.192663
```

## Changes

### CLIP
* CLIP outputs `last_hidden_state`, `pooled_output`, `text_embeds` if `text_projection_dim` is set, and `hidden_state_{idx}` if `output_hidden_states` is set
* `pooled_output` uses argmax, so this PR includes #878, the fix in that PR works in my testing
* `last_hidden_state` is **not** one of the `hidden_states`, this differs from [Transformers implementation](https://github.com/huggingface/transformers/blob/e42587f596181396e1c4b63660abf0c736b10dae/src/transformers/models/clip/modeling_clip.py#L668)

### UNet
* dtype
* includes #875 
* includes #860
* various updates

### VAE
* dtype
* Encoder

## Notes
* `addition_time_embed` being separate slightly improves performance and provides compatibility with community implementations of SD
* On Windows UNet weights are too big, `RC : fatal error RW1023: I/O error seeking in file`, mapping at runtime is required
* default is `--fp32-vae False`, this replaces VAE with [madebyollin/sdxl-vae-fp16-fix](https://huggingface.co/madebyollin/sdxl-vae-fp16-fix) which works in fp16, set `--fp32-vae True` to use pipeline's VAE and the module will be compiled in fp32, this uses more VRAM
* Also fixes Controlnet dynamic shape, and removes some unused code

## Pipeline
`scripts/demo_xl.py`

e.g.
`python .\scripts\demo_xl.py --unet-module A:\SDXL_unet\SDXL_unet.dll --text-encoder-module "A:\SDXL_text_encoder\SDXL_text_encoder.dll" --text-encoder-2-module "A:\SDXL_text_encoder_2\SDXL_text_encoder_2.dll" --time-embed-module "A:\SDXL_addition_time_embed\SDXL_addition_time_embed.dll" --vae-module "A:\SDXL_vae\SDXL_vae.dll"
`
Set module paths according to the compiled modules.

To lower resource usage, modules and weights are loaded then applied when required, i.e. CLIP is unloaded after usage, UNet is not loaded until needed

On my machine I usually lock core clock for best performance e.g. `nvidia-smi.exe -lgc 1920`

```
3060 12GB Windows
100%|| 50/50 [00:22<00:00,  2.18it/s]
```

![example_ait_0](https://github.com/facebookincubator/AITemplate/assets/106811348/0b03ba44-26aa-4724-8d1e-cec3e0ca98b0)


## Todo
* Documentation