### PR TITLE
Change to nvidia docker image for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ setup_env: &setup_env
       name: Setup environment
       command: |
         for i in {1..3}; do
+          sudo update-alternatives --set cuda /usr/local/cuda-11.4
           echo 'export PATH=/usr/local/cuda/bin:$PATH' >> $BASH_ENV &&
           source "$BASH_ENV"
           python3.8 --version &&


### PR DESCRIPTION
Summary: Changing to nvidia image nvidia/cuda:11.4.3-devel-ubuntu20.04 for CircleCI builds, in an attempt to resolve build failures

Differential Revision: D48116786

