### PR TITLE
support nvcc host compiler

### DIFF
--- a/docs/source/reference/env.rst
+++ b/docs/source/reference/env.rst
@@ -14,6 +14,10 @@ Codegen
 
 **AIT_COMPILER_OPT**: The optimization level for a compiler, which is directly passed to the host compiler command line. AITemplate host code may be very light in certain cases, so there is nothing to optimize for a host compiler. Thus, there is no need to make host compiler perform time costly optimizations. It may be very useful to use "-O0" value for debugging GPU kernels. "-O3" by default.
 
+**AIT_NVCC_CCBIN**: nvcc host compiler (ccbin).
+
+**AIT_ENABLE_CUDA_LTO**: If set to "1", nvcc will use LTO flags during compilation. Default value is "0".
+
 **AIT_TIME_COMPILATION**: If set to "1", time each make command at the compilation time. This helps us to do compilation time analysis. Requires to install `time <https://man7.org/linux/man-pages/man1/time.1.html>`_ package.
 
 **AIT_MULTISTREAM_MODE**: Controls multi-stream mode. Default mode is "0".

--- a/python/aitemplate/backend/builder.py
+++ b/python/aitemplate/backend/builder.py
@@ -844,14 +844,16 @@ clean:
         # for cache invalidation purposes (different compiler versions
         # should not reuse same cached build artifacts )
         cc = Target.current().cc()
-        compilers = {"main_compiler": cc}
+        compilers = {}
         if "nvcc" in cc:
-            ccbin_match = re.search(r'-ccbin "?([^ "]+)', cc)
+            ccbin_match = re.search(r'(.*) -ccbin "?([^ "]+)', cc)
             if ccbin_match:
-                nvcc_host_compiler = ccbin_match.group(1)
+                cc = ccbin_match.group(1)
+                nvcc_host_compiler = ccbin_match.group(2)
             else:
                 nvcc_host_compiler = "g++"  # default, using PATH resolution
             compilers["nvcc_host_compiler"] = nvcc_host_compiler
+        compilers["main_compiler"] = cc
 
         # Write compiler version string(s)
         # into the build directory, to enable using them for cache hash determination

--- a/python/aitemplate/utils/environ.py
+++ b/python/aitemplate/utils/environ.py
@@ -63,6 +63,13 @@ def enable_cuda_lto() -> bool:
     return os.getenv("AIT_ENABLE_CUDA_LTO", "0") == "1"
 
 
+def nvcc_ccbin() -> str:
+    """
+    nvcc host compiler (ccbin)
+    """
+    return os.getenv("AIT_NVCC_CCBIN", "")
+
+
 def force_profiler_cache() -> bool:
     """
     Force the profiler to use the cached results. The profiler will throw


### PR DESCRIPTION
Add `AIT_NVCC_CCBIN` env variable to set nvcc host compiler

Minor fixes:
- document `AIT_ENABLE_CUDA_LTO`
- eliminate an empty space caused by debug options