### PR TITLE
Better profile_callable

### DIFF
--- a/python/aitemplate/testing/profile.py
+++ b/python/aitemplate/testing/profile.py
@@ -16,6 +16,8 @@
 Torch module profiling utility.
 """
 import logging
+
+import re
 from operator import itemgetter
 from typing import Callable, List, Tuple
 
@@ -28,6 +30,7 @@ def profile_callable(
     func: Callable,
     cache_flush_slab: torch.Tensor,
     n_iter: int,
+    events_of_interest: List[re.Pattern] = None,
 ) -> Tuple[List[int], List[int]]:
     """
     Profile the callable and return the device and wall time for each iteration.
@@ -49,6 +52,10 @@ def profile_callable(
         A slab of GPU memory. We flush the device L2 cache by filling the slab.
     n_iter: int
         The number of iterations to call the callable.
+    events_of_interest: List[re.Pattern]
+        Optional. The names of events that we want to gather profiling data for.
+        If omitted, we will gather profiling data for all events minus the
+        ones ending in " Sync".
     Returns
     -------
         device_times: List[int]
@@ -88,14 +95,19 @@ def profile_callable(
         if e.cuda_time != 0
     ]
 
-    sorted_events = sorted(
-        filter(lambda e: e["name"] != "Context Sync", events), key=itemgetter("start")
-    )
+    def filter_fn(e):
+        if events_of_interest is not None:
+            return any(r.search(e["name"]) for r in events_of_interest)
+        return not e["name"].endswith(" Sync")
+
+    sorted_events = sorted(filter(filter_fn, events), key=itemgetter("start"))
     assert 0 == len(sorted_events) % n_iter
     n_groups = len(sorted_events) // n_iter
-    # in each group (corresponding to a profiling iteration),
-    # skip measuring the first kernel, which is the l2 cache flush
-    event_groups = [g[1:] for g in zip(*([iter(sorted_events)] * n_groups))]
+    event_groups = list(zip(*([iter(sorted_events)] * n_groups), strict=True))
+    if events_of_interest is None:
+        # in each group (corresponding to a profiling iteration),
+        # skip measuring the first kernel, which is the l2 cache flush
+        event_groups = [g[1:] for g in event_groups]
     logger.info(
         f"First kernel sequence: {list(map(itemgetter('name'), event_groups[0]))}"
     )

--- a/tests/unittest/ops/test_softmax.py
+++ b/tests/unittest/ops/test_softmax.py
@@ -17,6 +17,7 @@ Unittests for LayerNorm Operator.
 """
 import json
 import math
+import re
 import tempfile
 import unittest
 from collections import namedtuple
@@ -210,44 +211,7 @@ class SoftmaxTestCase(unittest.TestCase):
             dim=dim,
         )
 
-    def _test_benchmark_softmax(self):
-        dtype = "float16"
-        torch_dtype = string_to_torch_dtype(dtype)
-        results = []
-        shape = (260, 4)
-        batch_sizes = [2**p for p in range(0, 16)]
-        for reduction_dim in [-1, -2]:
-            module = self._build_model(
-                batch_sizes,
-                shape,
-                reduction_dim,
-                dtype,
-                f"bench_softmax_{abs(reduction_dim)}",
-            )
-
-            for batch_size in batch_sizes:
-                x_pt = torch.ones(batch_size, *shape, dtype=torch_dtype).cuda()
-                y_pt = torch.empty([batch_size, *shape], dtype=torch_dtype).cuda()
-                with tempfile.NamedTemporaryFile("r") as f:
-                    module.profile_with_tensors(
-                        inputs={"X": x_pt},
-                        outputs={"Y": y_pt},
-                        num_iters=1000,
-                        filename=f.name,
-                    )
-                    profiling_data = json.loads(f.read())
-
-                    runtime_ms = 0
-                    for func_name, record in profiling_data.items():
-                        if func_name.startswith("softmax"):
-                            runtime_ms += record["ms_per_iter"]
-                    results.append(BenchResult(reduction_dim, batch_size, runtime_ms))
-
-        for r in results:
-            items = r.batch_size * math.prod(shape)
-            print(f"{r.dim=}, {items=}, {r.runtime_ms=}")
-
-    def _test_benchmark_pytorch_softmax(self):
+    def _benchmark(self, make_callable):
         batch_sizes = [2**p for p in range(0, 16)]
         shape = (260, 4)
         dtype = "float16"
@@ -259,12 +223,15 @@ class SoftmaxTestCase(unittest.TestCase):
 
         results = []
         for reduction_dim in [-1, -2]:
+            to_profile = make_callable(batch_sizes, shape, reduction_dim, dtype)
             for batch_size in batch_sizes:
                 x_pt = torch.ones(batch_size, *shape, dtype=torch_dtype).cuda()
+                y_pt = torch.empty([batch_size, *shape], dtype=torch_dtype).cuda()
                 _, wall_times = profile_callable(
-                    lambda: torch.nn.functional.softmax(x_pt, dim=reduction_dim),
+                    lambda: to_profile(x_pt, y_pt),  # noqa: B023
                     cache_flush_slab,
                     n_iter=1000,
+                    events_of_interest=[re.compile("softmax", re.I)],
                 )
                 results.append(
                     BenchResult(reduction_dim, batch_size, mean(wall_times) / 1000.0)
@@ -273,6 +240,27 @@ class SoftmaxTestCase(unittest.TestCase):
         for r in results:
             items = r.batch_size * math.prod(shape)
             print(f"{r.dim=}, {items=}, {r.runtime_ms=}")
+
+    def _test_benchmark_pytorch(self):
+        def make_callable(batch_sizes, shape, reduction_dim, dtype):
+            return lambda x_pt, _: torch.nn.functional.softmax(x_pt, reduction_dim)
+
+        self._benchmark(make_callable)
+
+    def _test_benchmark_ait(self):
+        def make_callable(batch_sizes, shape, reduction_dim, dtype):
+            module = self._build_model(
+                batch_sizes,
+                shape,
+                reduction_dim,
+                dtype,
+                f"bench_softmax_{abs(reduction_dim)}",
+            )
+            return lambda x_pt, y_pt: module.run_with_tensors(
+                inputs={"X": x_pt}, outputs={"Y": y_pt}
+            )
+
+        self._benchmark(make_callable)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
I extended profile_callable to accept a list of events of interest. In
the case where this parameter is not specified, profile_callable will collect
the timings of all events except those ending in " Sync". This gives us more
accurate results; we no longer measure overhead from the syncs.

Finally, I converted the softmax benchmark to use profile_callable for both the
AIT and PT2 benchmarking. Using the same profiling function ensures we are
comparing apples to apples.

Differential Revision: D48252668

