### PR TITLE
Modify fuse_elementwise pass to preserve original ordering of inputs & outputs

### DIFF
--- a/python/aitemplate/compiler/ops/common/fused_elementwise.py
+++ b/python/aitemplate/compiler/ops/common/fused_elementwise.py
@@ -15,7 +15,7 @@
 """
 Fused elementwise operator definition.
 """
-from typing import List, Set
+from typing import Iterable, List
 
 from aitemplate import backend
 from aitemplate.backend import registry
@@ -52,7 +52,7 @@ class fused_elementwise(Operator):
                 )
 
     def _update_inputs_outputs(
-        self, inputs: Set[Operator], outputs: Set[Operator]
+        self, inputs: Iterable[Operator], outputs: Iterable[Operator]
     ) -> None:
         self._attrs["inputs"] = list(inputs)
         self._attrs["input_accessors"] = [
@@ -89,8 +89,8 @@ class fused_elementwise(Operator):
     def __init__(
         self,
         elementwise_ops: List[elementwise],
-        inputs: Set[Operator],
-        outputs: Set[Operator],
+        inputs: Iterable[Operator],
+        outputs: Iterable[Operator],
     ) -> None:
         super().__init__()
 

--- a/tests/unittest/ops/test_fused_elementwise.py
+++ b/tests/unittest/ops/test_fused_elementwise.py
@@ -87,7 +87,7 @@ class FusedElementwiseTestCase(unittest.TestCase):
         inputs, outputs, external_inputs, external_outputs = _get_inputs_outputs(
             {op1, op2}, {op1, op2}
         )
-        for tensor in inputs | outputs:
+        for tensor in itertools.chain(inputs, outputs):
             tensor._attrs["src_ops"] = tensor._attrs["src_ops"] - {op1, op2}
             tensor._attrs["dst_ops"] = tensor._attrs["dst_ops"] - {op1, op2}
         fused_op = ops.fused_elementwise(


### PR DESCRIPTION
Summary:
### Why?
In `fuse_elementwise`, the inputs and outputs are a `set`. The set doesn't preserve insertion order. This is problematic for passes that compare the inputs between two `FusedElementwise` operators (only for pointwise comparison).

### What?
When fusing, we insert the input / output tensors into a list instead. Then remove duplicates but keep the original insertion order. Now the `FusedElementwise` operator's input ordering matches the ordering used by the sub-elementwise operators.

### Visual Example
Let's create an example AIT graph.
```
a = gen_input_tensor(shape=[2, 4, 6], name="a")
b = gen_input_tensor(shape=[2, 4, 6], name="b")
c = gen_input_tensor(shape=[2, 4, 6], name="c")

y1 = (a - b) * c          # aka fused_elementwise_1
y2 = (a - c) * b          # aka fused_elementwise_2

y1._attrs["is_output"] = True
y1._attrs["name"] = "y1"
y2._attrs["is_output"] = True
y2._attrs["name"] = "y2"

compile_model([y1, y2], detect_target(), "/tmp", "_example")
```

Now, let's compare the inputs ordering before and after this diff.

Before this diff, `fused_elementwise_2` has `inputs=[a, b, c]` but this doesn't match how the elementwise operators use the inputs `y2 = (a - c) * b`.
| Before | After |
|---
|  {F1071405400} |  {F1071405426}

Reviewed By: aakhundov

Differential Revision: D48442103

