### PR TITLE
Disable Bugbear warning B905 (zip() without strict=)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -101,6 +101,8 @@ ignore =
   W504,
 
   # Too opinionated.
+  # zip() without strict= (strict isn't available in python < 3.10)
+  B905,
   # Block comment should start with '# '.
   E265,
   # Too many leading '#' for block comment.


### PR DESCRIPTION
Summary:
`zip` with the `strict` parameter isn't supported in python < 3.10

https://github.com/PyCQA/flake8-bugbear#opinionated-warnings

Reviewed By: aakhundov

Differential Revision: D48539088

