### PR TITLE
cast only supported dtypes

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -1605,7 +1605,8 @@ def acc_ops_to_dtype(
             return None
 
         if isinstance(kwargs["acc_out_ty"].dtype, torch.dtype):
-            return torch_dtype_to_ait_dtype_str[kwargs["acc_out_ty"].dtype]
+            return torch_dtype_to_ait_dtype_str.get(kwargs["acc_out_ty"].dtype)
+
         elif isinstance(kwargs["acc_out_ty"].dtype, AITTensor):
             return kwargs["acc_out_ty"].dtype.dtype()
         return None


### PR DESCRIPTION
Summary: Adding a quick fix in case the converted dtype isn't in the torch_dtype_to_ait_dtype_str dict, otws lowering may fail. Leave the to_dtype as a no-op.

Differential Revision: D48656539

