### PR TITLE
Use IntVar.upper_bound in _remove_no_op_concats

### DIFF
--- a/python/aitemplate/compiler/transform/remove_no_ops.py
+++ b/python/aitemplate/compiler/transform/remove_no_ops.py
@@ -84,7 +84,7 @@ def _remove_no_op_concats(sorted_graph: List[Tensor]) -> List[Tensor]:
         if isinstance(dim, IntImm):
             return dim.value() > 0
         elif isinstance(dim, IntVar):
-            return dim.lower_bound() > 0
+            return dim.upper_bound() > 0
 
     ops = graph_utils.get_sorted_ops(sorted_graph)
     for op in ops:


### PR DESCRIPTION
Summary:
Jagged tensors' dynamic dimension (i.e., `IntVar` at the `x._attrs["shape"][0]`) has the lower bound of 0, covering the case when all (dynamic) sequence lenghts adding up to the first dim are empty. This, however, doesn't mean that the jagged tensor is always empty.

As a result, we can't optimize away concats with JT in the `_remove_no_op_concats` pass. However, they are currently optimized away, because we currently check `dim.lower_bound() > 0` [here](https://www.internalfb.com/code/fbsource/[3c32469b6ff1ab3e8da5bdcbbfa17e5f6953e273]/fbcode/aitemplate/AITemplate/python/aitemplate/compiler/transform/remove_no_ops.py?lines=87) to verify that the tensor is not empty.

In this diff, we switch to `dim.upper_bound() > 0` to exclude inputs with (possibly) non-zero dynamic dim values at runtime from being optimized away by the `_remove_no_op_concats` pass.

Differential Revision: D48825557

