### PR TITLE
Race condition in test_chunk

### DIFF
--- a/tests/unittest/ops/test_chunk.py
+++ b/tests/unittest/ops/test_chunk.py
@@ -49,7 +49,12 @@ class ChunkTestCase(unittest.TestCase):
             Y._attrs["name"] = "output_{}".format(idx)
             Y._attrs["is_output"] = True
 
-        module = compile_model(Ys, target, "./tmp", "chunk")
+        # Use unique test name to avoid race condition
+        shape_hash = hash(str(input_shape))
+        test_name = f"chunks_{chunks}_{dim}_{input_type}_{shape_hash}"
+        module = compile_model(
+            Ys, target, "./tmp", test_name=test_name, dll_name=f"{test_name}.so"
+        )
 
         for batch_size in input_shape[0]._attrs["values"]:
             logging.info(f"Testing {batch_size=}")


### PR DESCRIPTION
Summary:
`test_chunk` is flaky:
```
input_shape=[{'depth': 0, 'name': None, 'nop': False, 'symbolic_value': 17, 'values': [17]}, {'depth': 0, 'name': None, 'nop': False, 'symbolic_value': 5, 'values': [5]}, {'depth': 0, 'name': None, 'nop': False, 'symbolic_value': 29, 'values': [29]}], chunks=2, dim=0
...
    raise ValueError(
ValueError: Did not get correct number of outputs expected 5, got 10
```

Even though the error log contains `chunks=2`, the op sees a different number of chunks.  The only explanation I see is a race condition when different tests execute on the same machine, and write to the same test directory, as we've seen before in other AIT tests. This diff makes directory unique for every test case, similar to D46323114

I can't reproduce the issue locally with stress test.

Differential Revision: D49571274


