### PR TITLE
Remove internal cub dependency

### DIFF
--- a/python/aitemplate/backend/cuda/target_def.py
+++ b/python/aitemplate/backend/cuda/target_def.py
@@ -286,7 +286,6 @@ class FBCUDA(CUDA):
         cutlass_src_path = parutil.get_dir_path(
             "aitemplate/AITemplate/fb/3rdparty/cutlass"
         )
-        cub_src_path = parutil.get_dir_path("aitemplate/AITemplate/fb/3rdparty/cub")
         static_files_path = parutil.get_dir_path("aitemplate/AITemplate/static")
         if "optimize_for_compilation_time" in kwargs:
             FBCUDA.optimize_for_compilation_time_ = kwargs[
@@ -302,9 +301,7 @@ class FBCUDA(CUDA):
             self._include_path = tempfile.mkdtemp()
 
             FBCUDA.cutlass_path_ = self._include_path + "/cutlass"
-            self.cub_path_ = self._include_path + "/cub"
             shutil.copytree(cutlass_src_path, FBCUDA.cutlass_path_)
-            shutil.copytree(cub_src_path, self.cub_path_)
 
             attention_src_path = parutil.get_dir_path(
                 "aitemplate/AITemplate/python/aitemplate/backend/cuda/attention/src"


### PR DESCRIPTION
Summary:
Following the investigation in D49853192, it has become clear that the internal cub dependency in the `AITemplate/fb/3rdparty` is not actually used during AIT-driven compilation.

Consequently, in this diff we're trying to remove the internal cub dependency.

Differential Revision: D50011260


