### PR TITLE
Return early from permute ops on zero-size input

### DIFF
--- a/python/aitemplate/backend/common/tensor/permute0213_common.py
+++ b/python/aitemplate/backend/common/tensor/permute0213_common.py
@@ -377,6 +377,10 @@ void {{function_name}} (
     int64_t x_dim3,
     {{prefix}}Stream_t stream
 ) {
+  if (x_dim0 == 0 || x_dim1 == 0 || x_dim2 == 0 || x_dim3 == 0) {
+    // empty input: nothing to do
+    return;
+  }
   if (!in_ptr) {
     throw std::runtime_error("in_ptr is NULL!");
   }

--- a/python/aitemplate/backend/common/tensor/permute021_common.py
+++ b/python/aitemplate/backend/common/tensor/permute021_common.py
@@ -197,6 +197,12 @@ void {{function_name}} (
     const int64_t* x_dims,
     {{prefix}}Stream_t stream
 ) {
+  for (int i = 0; i < rank; i++) {
+      if (x_dims[i] == 0) {
+          // empty input: nothing to do
+          return;
+      }
+  }
   if (!in_ptr) {
     throw std::runtime_error("in_ptr is NULL!");
   }

--- a/python/aitemplate/backend/common/tensor/permute102_common.py
+++ b/python/aitemplate/backend/common/tensor/permute102_common.py
@@ -363,6 +363,10 @@ void {{function_name}} (
     int64_t x_dim2,
     {{prefix}}Stream_t stream
 ) {
+  if (x_dim0 == 0 || x_dim1 == 0 || x_dim2 == 0) {
+    // empty input: nothing to do
+    return;
+  }
   if (!in_ptr) {
     throw std::runtime_error("in_ptr is NULL!");
   }

--- a/python/aitemplate/backend/common/tensor/permute210_common.py
+++ b/python/aitemplate/backend/common/tensor/permute210_common.py
@@ -179,6 +179,10 @@ void {{function_name}} (
     int64_t x_dim2,
     {{prefix}}Stream_t stream
 ) {
+  if (x_dim0 == 0 || x_dim1 == 0 || x_dim2 == 0) {
+    // empty input: nothing to do
+    return;
+  }
   if (!in_ptr) {
     throw std::runtime_error("in_ptr is NULL!");
   }

--- a/python/aitemplate/backend/cuda/tensor/permute.py
+++ b/python/aitemplate/backend/cuda/tensor/permute.py
@@ -91,6 +91,12 @@ void {{func_name}}(
 {% endfor %}
   *dim_{{input_rank - 1}}
     };
+    for (int i = 0; i < {{input_rank}}; i++) {
+        if (src_dims[i] == 0) {
+            // empty input: nothing to do
+            return;
+        }
+    }
     invokePermute<{{input_rank}}, {{elem_type}}>(dst, src, src_dims, permutation, stream);
 }
 

--- a/tests/unittest/ops/test_permute.py
+++ b/tests/unittest/ops/test_permute.py
@@ -139,6 +139,38 @@ class GenericPermuteTest(unittest.TestCase):
             testname="test_generic_permute_bf16",
         )
 
+    def test_zero_size_input(self):
+        self._test_generic_permute(
+            input_shapes=[0, 4, 8],
+            dims=[0, 2, 1],
+            torch_dtype=torch.float16,
+            testname="test_zero_size_input_021",
+        )
+        self._test_generic_permute(
+            input_shapes=[4, 0, 8],
+            dims=[1, 0, 2],
+            torch_dtype=torch.float16,
+            testname="test_zero_size_input_102",
+        )
+        self._test_generic_permute(
+            input_shapes=[4, 8, 0],
+            dims=[2, 1, 0],
+            torch_dtype=torch.float16,
+            testname="test_zero_size_input_210",
+        )
+        self._test_generic_permute(
+            input_shapes=[0, 32, 0, 8],
+            dims=[0, 2, 1, 3],
+            torch_dtype=torch.float16,
+            testname="test_zero_size_input_0213",
+        )
+        self._test_generic_permute(
+            input_shapes=[4, 0, 8, 0],
+            dims=[0, 3, 1, 2],
+            torch_dtype=torch.float16,
+            testname="test_zero_size_input_0312",
+        )
+
 
 if __name__ == "__main__":
     torch.manual_seed(0)


### PR DESCRIPTION
Summary:
Previously with the `permute` ops, we could have run into an edge case when the input to the permute op is a model input. Apparently, zero-size PT tensors return `nullptr` as `.data_ptr()`. This has led to an error in the permute ops' back-end which validates the input pointers to be non-NULL.

In this diff, an early exit condition is added to all permute ops' back-end before the input pointer validation. This remediates the error from the edge case described above.

Differential Revision: D50118462


