### PR TITLE
Add index_select AIT converter

### DIFF
--- a/fx2ait/fx2ait/test/converters/test_ait_index_select.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_index_select.py
@@ -1,0 +1,56 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import torch
+from fx2ait.acc_tracer import acc_ops
+from fx2ait.tools.common_fx2ait import AITTestCase
+from parameterized import param, parameterized
+
+
+class TestIndexSelectConverter(AITTestCase):
+    @parameterized.expand(
+        [
+            param(
+                "first_dim",
+                torch.randn(5, 10, 20),
+                0,
+                torch.randint(low=0, high=5, size=(3,)),
+            ),
+            param(
+                "mid_dim",
+                torch.randn(5, 10, 20),
+                1,
+                torch.randint(low=0, high=10, size=(20,)),
+            ),
+            param(
+                "last_dim",
+                torch.randn(5, 10, 20),
+                2,
+                torch.randint(low=0, high=20, size=(10,)),
+            ),
+        ]
+    )
+    def test_index_select(self, _, inp, dim, index):
+        class TestModule(torch.nn.Module):
+            def forward(
+                self,
+                inp: torch.Tensor,
+                index: torch.Tensor,
+            ) -> torch.Tensor:
+                return torch.index_select(inp, dim, index=index)
+
+        model = TestModule().eval().half().cuda()
+        inputs = [inp.cuda(), index.cuda()]
+
+        self.run_test(model, inputs, expected_ops={acc_ops.index_select})

--- a/python/aitemplate/backend/common/tensor/permute0213_common.py
+++ b/python/aitemplate/backend/common/tensor/permute0213_common.py
@@ -377,6 +377,10 @@ void {{function_name}} (
     int64_t x_dim3,
     {{prefix}}Stream_t stream
 ) {
+  if (x_dim0 == 0 || x_dim1 == 0 || x_dim2 == 0 || x_dim3 == 0) {
+    // empty input: nothing to do
+    return;
+  }
   if (!in_ptr) {
     throw std::runtime_error("in_ptr is NULL!");
   }

--- a/python/aitemplate/backend/common/tensor/permute021_common.py
+++ b/python/aitemplate/backend/common/tensor/permute021_common.py
@@ -197,6 +197,12 @@ void {{function_name}} (
     const int64_t* x_dims,
     {{prefix}}Stream_t stream
 ) {
+  for (int i = 0; i < rank; i++) {
+      if (x_dims[i] == 0) {
+          // empty input: nothing to do
+          return;
+      }
+  }
   if (!in_ptr) {
     throw std::runtime_error("in_ptr is NULL!");
   }

--- a/python/aitemplate/backend/common/tensor/permute102_common.py
+++ b/python/aitemplate/backend/common/tensor/permute102_common.py
@@ -363,6 +363,10 @@ void {{function_name}} (
     int64_t x_dim2,
     {{prefix}}Stream_t stream
 ) {
+  if (x_dim0 == 0 || x_dim1 == 0 || x_dim2 == 0) {
+    // empty input: nothing to do
+    return;
+  }
   if (!in_ptr) {
     throw std::runtime_error("in_ptr is NULL!");
   }

--- a/python/aitemplate/backend/common/tensor/permute210_common.py
+++ b/python/aitemplate/backend/common/tensor/permute210_common.py
@@ -179,6 +179,10 @@ void {{function_name}} (
     int64_t x_dim2,
     {{prefix}}Stream_t stream
 ) {
+  if (x_dim0 == 0 || x_dim1 == 0 || x_dim2 == 0) {
+    // empty input: nothing to do
+    return;
+  }
   if (!in_ptr) {
     throw std::runtime_error("in_ptr is NULL!");
   }

--- a/python/aitemplate/backend/cuda/tensor/permute.py
+++ b/python/aitemplate/backend/cuda/tensor/permute.py
@@ -91,6 +91,12 @@ void {{func_name}}(
 {% endfor %}
   *dim_{{input_rank - 1}}
     };
+    for (int i = 0; i < {{input_rank}}; i++) {
+        if (src_dims[i] == 0) {
+            // empty input: nothing to do
+            return;
+        }
+    }
     invokePermute<{{input_rank}}, {{elem_type}}>(dst, src, src_dims, permutation, stream);
 }
 

--- a/python/aitemplate/compiler/public/__init__.py
+++ b/python/aitemplate/compiler/public/__init__.py
@@ -73,6 +73,7 @@ from aitemplate.compiler.ops.padding import ndhwc3to8, nhwc3to8, pad_last_dim
 from aitemplate.compiler.ops.pool.avg_pool2d import avg_pool2d
 from aitemplate.compiler.ops.pool.max_pool2d import max_pool2d
 from aitemplate.compiler.ops.softmax.softmax import softmax
+from aitemplate.compiler.ops.tensor.index_select import index_select
 from aitemplate.compiler.ops.tensor.masked_select import masked_select
 from aitemplate.compiler.ops.tensor.size import size
 from aitemplate.compiler.ops.tensor.topk import topk

--- a/tests/unittest/ops/test_index_select.py
+++ b/tests/unittest/ops/test_index_select.py
@@ -280,6 +280,46 @@ class IndexSelectTest(unittest.TestCase):
                     benchmark=benchmark,
                 )
 
+    @parameterized.expand(
+        [
+            [(5, 4, 3, 2), False],
+            # [(2, 6), False],
+            # [(20, 6), False],
+            # [(300, 80), False],
+            # Uncomment to benchmark
+            # [(5, 4, 3, 2), True],
+            # [(2, 6), True],
+            # [(20, 6), True],
+            # [(300, 80), True],
+            # [(1024, 128, 256), True],
+            # [(1024, 1024, 100), True],
+            # [(1, 1), True],
+            # [(10, 1), True],
+            # [(100, 1), True],
+            # [(1000, 1), True],
+            # [(10000, 1), True], #revisit
+            # [(100000, 1), True],
+            # [(1000000, 1), True],
+            # [(10000000, 1), True],
+            # [(100000000, 1), True],
+            # [(10000, 10000), True],
+            # [(10, 10, 10, 10, 10, 10, 10, 10), True],
+        ]
+    )
+    def test_bf16(self, shape, benchmark=False):
+        torch.manual_seed(1024)
+        random.seed(1024)
+        for idx, _ in enumerate(shape):
+            for dim_idx_len in [1, int(shape[idx] / 2), shape[idx]]:
+                self._test_index_select(
+                    shape=shape,
+                    dim_idx=idx,
+                    dim_idx_len=dim_idx_len if dim_idx_len > 0 else 1,
+                    test_name="index_select_bf16",
+                    dtype="bfloat16",
+                    benchmark=benchmark,
+                )
+
 
 if __name__ == "__main__":
     torch.manual_seed(1024)

--- a/tests/unittest/ops/test_permute.py
+++ b/tests/unittest/ops/test_permute.py
@@ -139,6 +139,38 @@ class GenericPermuteTest(unittest.TestCase):
             testname="test_generic_permute_bf16",
         )
 
+    def test_zero_size_input(self):
+        self._test_generic_permute(
+            input_shapes=[0, 4, 8],
+            dims=[0, 2, 1],
+            torch_dtype=torch.float16,
+            testname="test_zero_size_input_021",
+        )
+        self._test_generic_permute(
+            input_shapes=[4, 0, 8],
+            dims=[1, 0, 2],
+            torch_dtype=torch.float16,
+            testname="test_zero_size_input_102",
+        )
+        self._test_generic_permute(
+            input_shapes=[4, 8, 0],
+            dims=[2, 1, 0],
+            torch_dtype=torch.float16,
+            testname="test_zero_size_input_210",
+        )
+        self._test_generic_permute(
+            input_shapes=[0, 32, 0, 8],
+            dims=[0, 2, 1, 3],
+            torch_dtype=torch.float16,
+            testname="test_zero_size_input_0213",
+        )
+        self._test_generic_permute(
+            input_shapes=[4, 0, 8, 0],
+            dims=[0, 3, 1, 2],
+            torch_dtype=torch.float16,
+            testname="test_zero_size_input_0312",
+        )
+
 
 if __name__ == "__main__":
     torch.manual_seed(0)


### PR DESCRIPTION
Summary: `index_select` op has been [available](https://github.com/facebookincubator/AITemplate/blob/main/python/aitemplate/compiler/ops/tensor/index_select.py) in AIT for a while, but we never had an fx2ait converter for it. This diff adds one.

Differential Revision: D50119460

