### PR TITLE
fix circular import in aitemplate

### DIFF
--- a/python/aitemplate/compiler/ops/gemm_universal/bmm_rcr_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/bmm_rcr_permute.py
@@ -19,7 +19,7 @@ Batch GEMM specialization for A[RowMajor], B[ColMajor], C[RowMajor] with permuta
 from typing import Tuple
 
 from aitemplate.compiler.base import Tensor
-from aitemplate.compiler.ops.common import reshape
+from aitemplate.compiler.ops.common.view_ops import reshape
 from aitemplate.compiler.ops.gemm_universal.bmm_xxx import bmm_rcr
 from aitemplate.compiler.tensor_accessor import TensorAccessor
 

--- a/python/aitemplate/compiler/ops/gemm_universal/bmm_rrr_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/bmm_rrr_permute.py
@@ -19,7 +19,7 @@ Batch GEMM specialization for A[RowMajor], B[RowMajor], C[RowMajor] with permuta
 from typing import Tuple
 
 from aitemplate.compiler.base import Tensor
-from aitemplate.compiler.ops.common import reshape
+from aitemplate.compiler.ops.common.view_ops import reshape
 from aitemplate.compiler.ops.gemm_universal.bmm_xxx import bmm_rrr
 from aitemplate.compiler.tensor_accessor import TensorAccessor
 

--- a/python/aitemplate/compiler/ops/gemm_universal/bmm_softmax_bmm_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/bmm_softmax_bmm_permute.py
@@ -18,7 +18,7 @@ BMM_RCR + Softmax + BMM_RRR + Permute Specialization
 from typing import Tuple
 
 from aitemplate.compiler.base import IntImm, Tensor
-from aitemplate.compiler.ops.common import reshape
+from aitemplate.compiler.ops.common.view_ops import reshape
 from aitemplate.compiler.ops.gemm_universal import gemm_common as common
 from aitemplate.compiler.ops.gemm_universal.bmm import bmm
 from aitemplate.compiler.tensor_accessor import TensorAccessor

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_permute.py
@@ -19,7 +19,7 @@ gemm rcr with bias + permute
 from typing import Tuple
 
 from aitemplate.compiler.base import Tensor
-from aitemplate.compiler.ops.common import reshape
+from aitemplate.compiler.ops.common.view_ops import reshape
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr_bias
 from aitemplate.compiler.tensor_accessor import TensorAccessor
 

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_permute.py
@@ -22,7 +22,7 @@ When use for `linear`, need set A->Data, B->Weight
 from typing import Tuple
 
 from aitemplate.compiler.base import IntImm, IntVar, Tensor
-from aitemplate.compiler.ops.common import reshape
+from aitemplate.compiler.ops.common.view_ops import reshape
 
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr
 from aitemplate.compiler.tensor_accessor import TensorAccessor

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rrr_bias_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rrr_bias_permute.py
@@ -19,7 +19,7 @@ gemm rrr with bias + permute
 from typing import Tuple
 
 from aitemplate.compiler.base import Tensor
-from aitemplate.compiler.ops.common import reshape
+from aitemplate.compiler.ops.common.view_ops import reshape
 
 from aitemplate.compiler.ops.gemm_universal import gemm_rrr_bias
 from aitemplate.compiler.tensor_accessor import TensorAccessor

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rrr_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rrr_permute.py
@@ -22,7 +22,7 @@ When use for `linear`, need set A->Data, B->Weight
 from typing import Tuple
 
 from aitemplate.compiler.base import Tensor
-from aitemplate.compiler.ops.common import reshape
+from aitemplate.compiler.ops.common.view_ops import reshape
 
 from aitemplate.compiler.ops.gemm_universal import gemm_rrr
 from aitemplate.compiler.tensor_accessor import TensorAccessor

--- a/python/aitemplate/compiler/ops/gemm_universal/perm021fc_ccr_bias_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/perm021fc_ccr_bias_permute.py
@@ -16,7 +16,7 @@
 GEMM Specialization: (A.permute(0, 2, 1)[col] @ B[col] + Bias).permute(0, 2, 1)
 """
 from aitemplate.compiler.base import Tensor
-from aitemplate.compiler.ops.common import reshape
+from aitemplate.compiler.ops.common.view_ops import reshape
 from aitemplate.compiler.ops.gemm_universal.perm021fc_ccr_bias import perm021fc_ccr_bias
 from aitemplate.compiler.tensor_accessor import TensorAccessor
 

--- a/python/aitemplate/compiler/ops/tensor/padded_dense_to_jagged.py
+++ b/python/aitemplate/compiler/ops/tensor/padded_dense_to_jagged.py
@@ -21,7 +21,7 @@ from typing import List
 from aitemplate.backend import registry
 from aitemplate.backend.target import Target
 from aitemplate.compiler.base import IntVar, JaggedDim, JaggedIntVar, Operator, Tensor
-from aitemplate.compiler.ops import make_jagged
+from aitemplate.compiler.ops.common.view_ops import make_jagged
 
 
 class padded_dense_to_jagged(Operator):

--- a/python/aitemplate/compiler/transform/dedup_make_jagged_ops.py
+++ b/python/aitemplate/compiler/transform/dedup_make_jagged_ops.py
@@ -21,7 +21,7 @@ from typing import Dict, List, Set
 
 from aitemplate.compiler.base import IntVar, JaggedIntVar, Operator, Tensor
 
-from aitemplate.compiler.ops import make_jagged
+from aitemplate.compiler.ops.common.view_ops import make_jagged
 from aitemplate.compiler.transform.toposort import toposort
 from aitemplate.compiler.transform.transform_utils import (
     remove_dst_op_from_tensor,


### PR DESCRIPTION
Summary:
aitemplate.compiler.ops.common imports every thing from submodules (https://www.internalfb.com/code/fbsource/[04b9b9d13911]/fbcode/aitemplate/AITemplate/python/aitemplate/compiler/ops/common/__init__.py?lines=19-25) so that you can conveniently call functions from submodules. However it causes import cycle like: P852820857

This diff fixes the cycle by importing from the original path.

Differential Revision: D50291521


