### PR TITLE
Support hash in IntImm

### DIFF
--- a/python/aitemplate/compiler/base.py
+++ b/python/aitemplate/compiler/base.py
@@ -364,6 +364,9 @@ class IntImm(IntVar):
             and self._attrs["values"] == another._attrs["values"]
         )
 
+    def __hash__(self) -> int:
+        return super().__hash__()
+
     def value(self) -> int:
         """Returns value of this IntImm."""
         return self._attrs["values"][0]


### PR DESCRIPTION
Summary: IntImm is a child class of IntVar. IntImm overrides `__eq__` but not `__hash__`. If a class overrides `__eq__`, it must also override `__hash__`. Otherwise hash will not work.

Differential Revision: D50436141


