### PR TITLE
allow split_size_or_sections to contain IntVarTensor

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -1138,7 +1138,7 @@ def ait_acc_ops_split(
         raise ValueError(f"Non-tensor inputs for {name}: {input_val}")
 
     split_size_or_sections = kwargs["split_size_or_sections"]
-    if not isinstance(split_size_or_sections, (int, list)):
+    if not isinstance(split_size_or_sections, (int, list, IntVarTensor)):
         raise ValueError(
             f"Unexpected value for split_size_or_sections in {name}: {split_size_or_sections}"
         )

--- a/python/aitemplate/compiler/ops/tensor/split.py
+++ b/python/aitemplate/compiler/ops/tensor/split.py
@@ -20,6 +20,7 @@ from typing import List, Sequence, Union
 from aitemplate import backend
 from aitemplate.backend import registry
 from aitemplate.compiler.base import IntImm, IntVar, Operator, Tensor
+from aitemplate.utils import shape_utils
 from aitemplate.utils.tensor_utils import wrap_dim
 
 # pylint: disable=C0103,W0221
@@ -89,9 +90,12 @@ class split(Operator):
         self._attrs["split_dim"] = dim
         self._set_depth()
         if isinstance(split_size_or_sections, (List, tuple)):
+            split_size_or_sections = [
+                shape_utils.convert_IntVar_to_int(d) for d in split_size_or_sections
+            ]
             split_sizes = list(split_size_or_sections)
         else:
-            split_size = split_size_or_sections
+            split_size = shape_utils.convert_IntVar_to_int(split_size_or_sections)
             if not isinstance(split_size, int):
                 raise RuntimeError("split_size expected to be of int")
             # TODO: support split along dynamic axis


### PR DESCRIPTION
Summary:
This PR enables us to pass IntVarTensor to the split op through
split_size_or_sections

Reviewed By: frank-wei

Differential Revision: D50877870


