### PR TITLE
disable maskedSelectTestCase.test_fp32_input_broadcast_shape_4

### DIFF
--- a/tests/unittest/ops/test_masked_select.py
+++ b/tests/unittest/ops/test_masked_select.py
@@ -307,7 +307,8 @@ class maskedSelectTestCase(unittest.TestCase):
             [(32, 1), (64, 1, 16), False],
             [(64, 32, 64), (64,), False],
             [(128, 256), (1024, 128, 256), False],
-            [(10, 1, 1, 256), (10, 10, 10, 10, 128, 256), False],
+            # FIXME: the test case below is flaky in circle ci
+            # [(10, 1, 1, 256), (10, 10, 10, 10, 128, 256), False],
             # Uncomment to benchmark
             # [(32, 16), (1, 16), True],
             # [(32, 1), (64, 1, 16), True],


### PR DESCRIPTION
This test is flaky in circle ci

