### PR TITLE
add support for permute call with tuple args

### DIFF
--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -376,9 +376,19 @@ def acc_ops_permute(
 ) -> ConverterOutput:
     input_val = kwargs["input"]
     if not isinstance(input_val, AITTensor):
-        raise ValueError(f"Unexpected input for {name}: {input_val}")
+        raise ValueError(f"Unexpected input for {name}: input={input_val}")
 
     permutation = kwargs["permutation"]
+
+    if (
+        isinstance(permutation, (list, tuple))
+        and permutation
+        and isinstance(permutation[0], (list, tuple))
+    ):
+        # If permutation is a nested list or tuple, unwrap one level.
+        # This is needed for some valid invocations of permute like
+        # t.permute((2, 0, 1)).
+        permutation = permutation[0]
 
     return permute()(input_val, permutation)
 

--- a/fx2ait/fx2ait/test/converters/test_ait_permute.py
+++ b/fx2ait/fx2ait/test/converters/test_ait_permute.py
@@ -1,0 +1,67 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#!/usr/bin/env fbpython
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import torch
+from fx2ait.acc_tracer import acc_ops
+from fx2ait.tools.common_fx2ait import AITTestCase
+
+
+class TestPermuteConverter(AITTestCase):
+    def test_permute_torch_op(
+        self,
+    ):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return torch.permute(x, (2, 0, 1))
+
+        model = TestModule().half().cuda()
+        inputs = [torch.randn(32, 256, 256).cuda().half()]
+        self.run_test(
+            model,
+            inputs,
+            expected_ops={acc_ops.permute},
+        )
+
+    def test_permute_op_on_tensor_tuple(
+        self,
+    ):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x.permute((2, 0, 1))
+
+        model = TestModule().half().cuda()
+        inputs = [torch.randn(32, 256, 256).cuda().half()]
+        self.run_test(
+            model,
+            inputs,
+            expected_ops={acc_ops.permute},
+        )
+
+    def test_permute_op_on_tensor_args(
+        self,
+    ):
+        class TestModule(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x.permute(2, 0, 1)
+
+        model = TestModule().half().cuda()
+        inputs = [torch.randn(32, 256, 256).cuda().half()]
+        self.run_test(
+            model,
+            inputs,
+            expected_ops={acc_ops.permute},
+        )

--- a/tests/unittest/compiler/test_op_common_elementwise.py
+++ b/tests/unittest/compiler/test_op_common_elementwise.py
@@ -1,0 +1,98 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import unittest
+
+from aitemplate.compiler import compile_model, ops
+
+from aitemplate.compiler.base import Tensor
+from aitemplate.compiler.ops.common.epilogue import FuncEnum
+from aitemplate.testing import detect_target
+from aitemplate.testing.test_utils import (
+    get_random_torch_tensor,
+    get_torch_empty_tensor,
+)
+
+
+def _make_graph():
+    X0 = Tensor(
+        shape=[3, 5, 7, 9],
+        dtype="float16",
+        name="X0",
+        is_input=True,
+    )
+
+    Y = ops.elementwise(FuncEnum.ABS)(ops.elementwise(FuncEnum.SIN)(X0))
+
+    Y._attrs["is_output"] = True
+    Y._attrs["name"] = "Y"
+    return Y
+
+
+class OpCommonElementwiseTestCase(unittest.TestCase):
+    def test_elementwise_type_promotion_bool_rhs(self):
+        X0 = Tensor(
+            shape=[3, 5, 2],
+            dtype="float16",
+            name="X0",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[3, 5, 2],
+            dtype="bool",
+            name="X1",
+            is_input=True,
+        )
+        Y = ops.elementwise(FuncEnum.MUL)(X0, X1)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+        target = detect_target()
+        module = compile_model(
+            Y,
+            target,
+            "./tmp",
+            "test_elementwise_type_promotion_bool_rhs",
+        )
+        x0_pt = get_random_torch_tensor([3, 5, 2], "float16")
+        x1_pt = get_random_torch_tensor([3, 5, 2], "bool")
+        out_pt = get_torch_empty_tensor([3, 5, 2], "float16")
+        module.run_with_tensors({"X0": x0_pt, "X1": x1_pt}, {"output0": out_pt})
+
+    def test_elementwise_type_promotion_bool_lhs(self):
+        X0 = Tensor(
+            shape=[3, 5, 2],
+            dtype="bool",
+            name="X1",
+            is_input=True,
+        )
+        X1 = Tensor(
+            shape=[3, 5, 2],
+            dtype="float16",
+            name="X0",
+            is_input=True,
+        )
+        Y = ops.elementwise(FuncEnum.MUL)(X0, X1)
+        Y._attrs["name"] = "output0"
+        Y._attrs["is_output"] = True
+        target = detect_target()
+        module = compile_model(
+            Y,
+            target,
+            "./tmp",
+            "test_elementwise_type_promotion_bool_lhs",
+        )
+        x0_pt = get_random_torch_tensor([3, 5, 2], "float16")
+        x1_pt = get_random_torch_tensor([3, 5, 2], "bool")
+        out_pt = get_torch_empty_tensor([3, 5, 2], "float16")
+        module.run_with_tensors({"X0": x0_pt, "X1": x1_pt}, {"output0": out_pt})


### PR DESCRIPTION
Summary: PyTorch allows permute ops to be called on tensors with tuple args, e.g. `tensor.permute((1, 0, 2))`. this diff adds support for unwrapping the nested tuple/list.

Differential Revision: D53236434


