### PR TITLE
Skip fuse_mm_elementwise fusion with model output in the middle

### DIFF
--- a/python/aitemplate/compiler/transform/fuse_utils.py
+++ b/python/aitemplate/compiler/transform/fuse_utils.py
@@ -80,6 +80,12 @@ def _find_fusion_root(tensor: Tensor, fusion_patterns: List[Any]) -> int:
                 fusion_idx = idx
                 break
 
+            if curr_tensor._attrs["is_output"]:
+                # if we don't break here, the curr_tensor will be
+                # eliminated as an intermediate tensor in the linear
+                # op pattern, but we can't eliminate a graph output
+                break
+
             dst_op = extract_only_one_op(curr_tensor._attrs["dst_ops"])
             if dst_op is None:
                 break


### PR DESCRIPTION
Summary: `fuse_mm_elementwise` transformation fuses linear patterns into single ops. As a result, all intermediate outputs in the pattern are eliminated. In a special case when one or more of those intermediate outputs are model outputs, this leads to those model outputs vanishing after the fusion. Here we add skipping the fusion when one of the intermediate outputs in the detected pattern is a model output.

Differential Revision: D56340320


