### PR TITLE
Update OSS black linter version to 24.4.0

### DIFF
--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ufmt==2.0.1 click==8.1.3 black==22.12.0 flake8==5.0.4
+        pip install ufmt==2.0.1 click==8.1.3 black==24.4.0 flake8==5.0.4
     - name: Analyzing the code with flake8
       run: |
         echo "::add-matcher::tests/lint/flake8_problem_matcher.json"


### PR DESCRIPTION
Summary: There are some [linter errors](https://github.com/facebookincubator/AITemplate/actions/runs/8680791999/job/23802124952) in OSS trunk caused by D54447738 updating black version to 2024 in fbcode. Here we match the black version in OSS.

Differential Revision: D56340613


