### PR TITLE
c10::optional -> std::optional in aiplatform/distributed_inference/pytorch/ops/tests/distributed_inference_operators_test_fixture.h +20

### DIFF
--- a/fx2ait/fx2ait/csrc/AITModel.cpp
+++ b/fx2ait/fx2ait/csrc/AITModel.cpp
@@ -62,8 +62,8 @@ static auto registerAITModel =
              std::string,
              std::vector<std::string>,
              std::vector<std::string>,
-             c10::optional<at::ScalarType>,
-             c10::optional<at::ScalarType>,
+             std::optional<at::ScalarType>,
+             std::optional<at::ScalarType>,
              int64_t>())
         .def("forward", &AITModel::forward)
         .def("profile", &AITModel::profile)

--- a/fx2ait/fx2ait/csrc/AITModel.h
+++ b/fx2ait/fx2ait/csrc/AITModel.h
@@ -25,8 +25,8 @@ class AITModel : public torch::CustomClassHolder {
       const std::string& model_path,
       std::vector<std::string> input_names,
       std::vector<std::string> output_names,
-      c10::optional<at::ScalarType> input_dtype,
-      c10::optional<at::ScalarType> output_dtype,
+      std::optional<at::ScalarType> input_dtype,
+      std::optional<at::ScalarType> output_dtype,
       int64_t num_runtimes = 2,
       bool use_cuda_graph = false)
       : aitModelImpl_(

--- a/fx2ait/fx2ait/csrc/AITModelImpl.cpp
+++ b/fx2ait/fx2ait/csrc/AITModelImpl.cpp
@@ -133,8 +133,8 @@ AITModelImpl::AITModelImpl(
     const std::string& model_path,
     std::vector<std::string> input_names,
     std::vector<std::string> output_names,
-    c10::optional<at::ScalarType> input_dtype,
-    c10::optional<at::ScalarType> output_dtype,
+    std::optional<at::ScalarType> input_dtype,
+    std::optional<at::ScalarType> output_dtype,
     int64_t num_runtimes,
     bool use_cuda_graph)
     : handle_(dlopen(model_path.c_str(), RTLD_NOW | RTLD_LOCAL)),

--- a/fx2ait/fx2ait/csrc/AITModelImpl.h
+++ b/fx2ait/fx2ait/csrc/AITModelImpl.h
@@ -43,8 +43,8 @@ class AITModelImpl {
       const std::string& model_path,
       std::vector<std::string> input_names,
       std::vector<std::string> output_names,
-      c10::optional<at::ScalarType> input_dtype,
-      c10::optional<at::ScalarType> output_dtype,
+      std::optional<at::ScalarType> input_dtype,
+      std::optional<at::ScalarType> output_dtype,
       int64_t num_runtimes = 2,
       bool use_cuda_graph = false);
 
@@ -102,11 +102,11 @@ class AITModelImpl {
     return output_names_;
   }
 
-  const c10::optional<at::ScalarType> floatingPointInputDtype() const {
+  const std::optional<at::ScalarType> floatingPointInputDtype() const {
     return floating_point_input_dtype_;
   }
 
-  const c10::optional<at::ScalarType> floatingPointOutputDtype() const {
+  const std::optional<at::ScalarType> floatingPointOutputDtype() const {
     return floating_point_output_dtype_;
   }
 
@@ -182,8 +182,8 @@ class AITModelImpl {
   const std::string library_path_;
   const std::vector<std::string> input_names_;
   const std::vector<std::string> output_names_;
-  const c10::optional<at::ScalarType> floating_point_input_dtype_;
-  const c10::optional<at::ScalarType> floating_point_output_dtype_;
+  const std::optional<at::ScalarType> floating_point_input_dtype_;
+  const std::optional<at::ScalarType> floating_point_output_dtype_;
 #ifdef FBCODE_AIT
   folly::F14FastMap<const char*, size_t> input_name_to_index_;
   folly::F14FastMap<const char*, size_t> output_name_to_index_;


### PR DESCRIPTION
Summary: `c10::optional` was switched to be `std::optional` after PyTorch moved to C++17. Let's eliminate `c10::optional`, if we can.

Reviewed By: albanD, swolchok

Differential Revision: D57294299


