### PR TITLE
Use torch.all to check tensor equality

### DIFF
--- a/fx2ait/fx2ait/fx2ait.py
+++ b/fx2ait/fx2ait/fx2ait.py
@@ -354,7 +354,7 @@ class AITInterpreter(torch.fx.Interpreter):
         if ait_friendly_name in self._loaded_params:
             existing_tensor = self._loaded_params[ait_friendly_name]
             assert existing_tensor._attrs["dtype"] == ait_dtype
-            assert existing_tensor._attrs["data"].tensor == ait_val
+            assert torch.all(existing_tensor._attrs["data"].tensor == ait_val)
             return existing_tensor
 
         data = _TorchConstantTensorData(ait_val)


### PR DESCRIPTION
Summary: When the tensor contains 0 or >=2 elements, this check will fail.

Reviewed By: muchulee8

Differential Revision: D57636627


