### PR TITLE
Del using namespace aitemplate/AITemplate/static/include/kernels/mem_eff_attention/kernel_forward.h

### DIFF
--- a/static/include/kernels/mem_eff_attention/kernel_forward.h
+++ b/static/include/kernels/mem_eff_attention/kernel_forward.h
@@ -76,8 +76,6 @@
 
 #include <inttypes.h>
 
-using namespace gemm_kernel_utils;
-
 namespace {
 template <typename scalar_t, typename Arch>
 constexpr int getWarpsPerSm() {


### PR DESCRIPTION
Summary:
Removes a `using namespace` from the global namespace in pursuit of enabling `-Wheader-hygiene`.
Qualifies instances that relied on the `using namespace`.

Differential Revision: D60066235
