### PR TITLE
Add max_acc_splits

### DIFF
--- a/fx2ait/fx2ait/ait_splitter.py
+++ b/fx2ait/fx2ait/ait_splitter.py
@@ -115,12 +115,14 @@ class AITSplitterSettings(splitter_base._SplitterSettingBase):
         min_acc_module_size=DEFAULT_MIN_ACC_MODULE_SIZE,
         allow_int_inputs=False,
         debug_operator_range=None,
+        max_acc_splits=-1,
     ):
         super().__init__()
         self.min_acc_module_size = min_acc_module_size
         self.exclude_support_node_name: set = set()
         self.allow_int_inputs: bool = allow_int_inputs
         self.debug_operator_range = debug_operator_range
+        self.max_acc_splits = max_acc_splits
 
 
 class SelectedOperatorSupport(ops.OperatorSupportBase):

--- a/fx2ait/fx2ait/lower/lower.py
+++ b/fx2ait/fx2ait/lower/lower.py
@@ -100,6 +100,7 @@ def default_split_function(
     settings = AITSplitterSettings(
         min_acc_module_size=lower_settings.min_acc_module_size,
         allow_int_inputs=lower_settings.allow_int_inputs,
+        max_acc_splits=lower_settings.max_acc_splits,
     )
     splitter = AITSplitter(model, inputs, settings=settings)
     splitter.node_support_preview()

--- a/fx2ait/fx2ait/lower/lower_settings.py
+++ b/fx2ait/fx2ait/lower/lower_settings.py
@@ -61,6 +61,9 @@ class LowerSettings:
 
     max_batch_size: int = 2048
     min_acc_module_size: int = 10
+    # Maximum number of splits for lowered module
+    # (eg. if lowered module is split into _run_on_gpu_0(unlowered submodule) and _run_on_acc_1(lowered submodule) it has 2 splits)
+    max_acc_splits: int = -1
     workdir: str = ""
     name: str = ""
     dll_name: str = "ait_engine.so"


### PR DESCRIPTION
Summary: Model owners can set the lower_settings with max_acc_splits=2, and lowering will fail during model iteration, to alert them of possible performance degradation from increased fragmentation.

Differential Revision: D60133589
