### PR TITLE
Prevent erroneous deduping of the full op

### DIFF
--- a/python/aitemplate/compiler/ops/tensor/full.py
+++ b/python/aitemplate/compiler/ops/tensor/full.py
@@ -64,6 +64,12 @@ class full(Operator):
         self._attrs["inputs"] = []
         self._attrs["fill_value"] = fill_value
 
+        # although not used downstream, these attrs
+        # are necessary to avoid erroneously deduping
+        # legitimately different fill op instances
+        self._attrs["shape"] = shape
+        self._attrs["dtype"] = dtype
+
         self._set_depth()
         output = Tensor(
             shape, src_ops={self}, dtype=dtype, skip_constant_folding=not static_shape


### PR DESCRIPTION
Summary: The `full` op can be erroneously deduped in the `refine_graph` when the shape and / or dtype of the output are different, but the fill value is the same. Here we add the former to the `_attrs` of the op to avoid this erroneous deduping.

Differential Revision: D60990475
