### PR TITLE
Make V100 tests runnable on {A,H}100 in Sandcastle CI

### DIFF
--- a/python/aitemplate/compiler/base.py
+++ b/python/aitemplate/compiler/base.py
@@ -738,7 +738,7 @@ class Tensor(Node):
     def __init__(
         self,
         shape: List[IntVar],
-        name: str = None,
+        name: Optional[str] = None,
         src_ops: Iterable[Node] = None,
         dst_ops: Iterable[Node] = None,
         dtype: str = "float16",


### PR DESCRIPTION
Summary:
~80% of the AIT tests target V100 programmatically (skipped on non-V100) in Sandcastle CI. This leaves those tests not being run internally.

Here we follow the suggestion to change the AIT "testing framework" to run the tests internally on a more modern HW than intended.

Differential Revision: D60998882
