### PR TITLE
Convert directory fbcode/aitemplate to use the Ruff Formatter

### DIFF
--- a/examples/01_resnet-50/benchmark_ait.py
+++ b/examples/01_resnet-50/benchmark_ait.py
@@ -45,7 +45,6 @@ def mark_output(y):
 
 
 def compile_module(model_name, batch_size, **kwargs):
-
     if model_name != "resnet50":
         raise NotImplementedError
 

--- a/examples/01_resnet-50/weight_utils.py
+++ b/examples/01_resnet-50/weight_utils.py
@@ -17,7 +17,6 @@ script for converting model from timm to aitemplate
 Only tested on resnet50
 """
 
-
 import pickle
 import re
 

--- a/examples/02_detectron2/demo.py
+++ b/examples/02_detectron2/demo.py
@@ -15,6 +15,7 @@
 """
 A main inference script for rcnn models
 """
+
 import glob
 import os
 

--- a/examples/02_detectron2/modeling/roi_heads/roi_heads.py
+++ b/examples/02_detectron2/modeling/roi_heads/roi_heads.py
@@ -59,7 +59,6 @@ class StandardROIHeads(nn.Module):
         return shape
 
     def forward(self, features: Dict[str, Tensor], rois: Tensor, proposals: Tensor):
-
         box_features = [features[f] for f in self.in_features]
         roi_feat = self.box_head(box_features, rois)
         detections = self.box_predictor(roi_feat, proposals)

--- a/examples/02_detectron2/predictor/builtin_meta.py
+++ b/examples/02_detectron2/predictor/builtin_meta.py
@@ -25,7 +25,6 @@ Users don't have to download a COCO json (which contains metadata), in order to 
 COCO model (with correct class names and colors).
 """
 
-
 # All coco categories, together with their nice-looking visualization colors
 # It's from https://github.com/cocodataset/panopticapi/blob/master/panoptic_coco_categories.json
 COCO_CATEGORIES = [

--- a/examples/04_vit/weight_utils.py
+++ b/examples/04_vit/weight_utils.py
@@ -12,8 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-"""script for converting vit model from timm to ait
-"""
+"""script for converting vit model from timm to ait"""
+
 import pickle
 
 import click

--- a/examples/05_stable_diffusion/scripts/download_pipeline.py
+++ b/examples/05_stable_diffusion/scripts/download_pipeline.py
@@ -36,7 +36,6 @@ from diffusers import StableDiffusionPipeline
     help="Pipeline files local directory.",
 )
 def download_pipeline_files(model_name, token, save_directory) -> None:
-
     StableDiffusionPipeline.from_pretrained(
         model_name,
         revision="fp16",

--- a/fx2ait/fx2ait/acc_tracer/acc_normalizer.py
+++ b/fx2ait/fx2ait/acc_tracer/acc_normalizer.py
@@ -283,7 +283,10 @@ def move_kwargs_to_acc_out_ty(
 
     for kwarg_replacement_tuple in normalization_info.kwargs_to_move_to_acc_out_ty:
         if len(kwarg_replacement_tuple) == 2:
-            orig_kwarg_name, tmd_field_name, move_to_qparams = *kwarg_replacement_tuple, False  # type: ignore[misc]
+            orig_kwarg_name, tmd_field_name, move_to_qparams = (
+                *kwarg_replacement_tuple,
+                False,
+            )  # type: ignore[misc]
         else:
             assert len(kwarg_replacement_tuple) == 3
             orig_kwarg_name, tmd_field_name, move_to_qparams = kwarg_replacement_tuple  # type: ignore[misc]
@@ -331,9 +334,7 @@ def get_normalized_kwargs(
                 new_kwargs[new_kwarg_name] = node.args[i]
             else:
                 # Verify the arg we're trying to normalize was optional.
-                assert (
-                    is_optional
-                ), f"Cannot normalize {orig_kwargs_names} to {new_kwarg_name} for {node.name}"
+                assert is_optional, f"Cannot normalize {orig_kwargs_names} to {new_kwarg_name} for {node.name}"
         else:
             new_kwargs[new_kwarg_name] = node.kwargs[orig_kwargs_name]
 

--- a/fx2ait/fx2ait/acc_tracer/acc_tracer.py
+++ b/fx2ait/fx2ait/acc_tracer/acc_tracer.py
@@ -462,7 +462,10 @@ def _rewrite(
                 for k, v in orig.__dict__.items():
                     if k == "_modules":
                         for mod_k, mod_v in v.items():
-                            if getattr(mod_v, "_base_class_origin", type(mod_v)) in leaf_module_list:  # type: ignore[operator]
+                            if (
+                                getattr(mod_v, "_base_class_origin", type(mod_v))
+                                in leaf_module_list
+                            ):  # type: ignore[operator]
                                 _LOGGER.info(
                                     f"Skip rewriting leaf module {type(mod_v)}"
                                 )

--- a/fx2ait/fx2ait/converters/ait_converters.py
+++ b/fx2ait/fx2ait/converters/ait_converters.py
@@ -920,8 +920,8 @@ def acc_ops_conv_transpose2d(
         # Grouped conv doesn't currently work on AIT CUDA, manually map
         groups = kwargs["groups"]
         assert (
-            w_last_dim * groups
-        ) % 8 == 0, f"cutlass needs weight output channel={w_last_dim*groups} is not divisble by 8! This restriction may be not valid in newer version"
+            (w_last_dim * groups) % 8 == 0
+        ), f"cutlass needs weight output channel={w_last_dim*groups} is not divisble by 8! This restriction may be not valid in newer version"
 
         group_size = input_val.shape()[3]._attrs["values"][0] // groups
         w_group_size = weight.shape()[0]._attrs["values"][0] // groups
@@ -1767,7 +1767,7 @@ def acc_ops_to_dtype(
     input_val = kwargs["input"]
 
     def _get_cast_to_dtype_from_kwargs(
-        kwargs: Dict[str, Argument]
+        kwargs: Dict[str, Argument],
     ) -> Optional[torch.dtype]:
         torch_dtype_to_ait_dtype_str = {
             torch.float: "float32",

--- a/fx2ait/fx2ait/extension.py
+++ b/fx2ait/fx2ait/extension.py
@@ -27,7 +27,6 @@ def is_oss_ait_model():
 
 
 def _get_extension_path(lib_name):
-
     lib_dir = os.path.dirname(__file__)
 
     loader_details = (

--- a/fx2ait/fx2ait/tools/ait_subgraph_rewriter.py
+++ b/fx2ait/fx2ait/tools/ait_subgraph_rewriter.py
@@ -348,7 +348,6 @@ def _replace_pattern(
     replacement: Union[Callable, GraphModule],
     match_filters: List[Callable[["InternalMatch", Graph, Graph], bool]] = None,  # type: ignore[name-defined]
 ) -> List[ReplacedPatterns]:
-
     if match_filters is None:
         match_filters = []
 
@@ -392,7 +391,6 @@ def _replace_pattern(
 
     match_and_replacements = []
     for match in _matches:
-
         # Build connecting between replacement graph's input and original graph input producer node
 
         # Initialize `val_map` with mappings from placeholder nodes in
@@ -458,7 +456,6 @@ def _replace_pattern(
                 and node.op != "output"
                 and node.target != torch.ops.aten.sym_size
             ):
-
                 gn = match.nodes_map[node]
                 gm.graph.erase_node(gn)
         match_and_replacements.append(

--- a/python/aitemplate/backend/__init__.py
+++ b/python/aitemplate/backend/__init__.py
@@ -15,6 +15,7 @@
 """
 Backend for AITemplate.
 """
+
 from aitemplate.backend import (  # noqa
     backend_spec,
     builder,

--- a/python/aitemplate/backend/codegen.py
+++ b/python/aitemplate/backend/codegen.py
@@ -651,9 +651,7 @@ class ModelContainerGenerator:
         elif external_tensor is not None:
             # Special view cases for outputs; we can hit this case if the output
             # is a view of a constant, input, or another output.
-            assert (
-                is_view
-            ), f"orig_tensor is not None, but node {name} is not marked as a view! Node: {tensor}"
+            assert is_view, f"orig_tensor is not None, but node {name} is not marked as a view! Node: {tensor}"
             self.set_inputs.append(
                 check_not_null(tensor, output_idx, skip_if_lower_bound_is_zero=True)
             )

--- a/python/aitemplate/backend/common/concatenate_common.py
+++ b/python/aitemplate/backend/common/concatenate_common.py
@@ -15,6 +15,7 @@
 """
 backend concatenate function common templates.
 """
+
 from copy import deepcopy
 from typing import List
 

--- a/python/aitemplate/backend/common/split_common.py
+++ b/python/aitemplate/backend/common/split_common.py
@@ -15,6 +15,7 @@
 """
 Backend-agnostic function templates for split.
 """
+
 import jinja2
 
 FUNC_DECL_TEMPLATE = jinja2.Template(

--- a/python/aitemplate/backend/common/tensor/permute0213_common.py
+++ b/python/aitemplate/backend/common/tensor/permute0213_common.py
@@ -23,6 +23,7 @@ is added as a blockIdx.z for the tiled kernel launch and encoded
 in the blockIdx.z for the direct kernel launch. The input and output
 pointers are shifted accordingly in the kernel code.
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/common/tensor/permute021_common.py
+++ b/python/aitemplate/backend/common/tensor/permute021_common.py
@@ -21,6 +21,7 @@ For higher-rank input, treat the first n-2 dims as a single flat dim.
 i.e. Output[d0, ..., dn-3, dn-1, dn-2] = Input[d0, ..., dn-3, dn-2, dn-1]
 
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/common/tensor/permute102_common.py
+++ b/python/aitemplate/backend/common/tensor/permute102_common.py
@@ -36,6 +36,7 @@ write of the whole d2-sized block. The cutoff of > 16 is chosen, as
 starting from 17 items, the approach #1 corresponds to the same data
 movement, just through the SMEM and with more index computation.
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/common/tensor/permute210_common.py
+++ b/python/aitemplate/backend/common/tensor/permute210_common.py
@@ -26,6 +26,7 @@ For each, we have shared memory of size (TILE_SIZE, TILE_SIZE+1)
 The 4 for thread blocks indicates each thread is responsible of 4 elements.
 We use TILE_SIZE = 32 for the time being.
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/common/tensor/slice_common.py
+++ b/python/aitemplate/backend/common/tensor/slice_common.py
@@ -15,6 +15,7 @@
 """
 Slice backend common implementation.
 """
+
 import jinja2
 
 

--- a/python/aitemplate/backend/common/tensor/slice_reshape_scatter_common.py
+++ b/python/aitemplate/backend/common/tensor/slice_reshape_scatter_common.py
@@ -15,6 +15,7 @@
 """
 Slice reshape backend common implementation.
 """
+
 import functools
 
 import jinja2

--- a/python/aitemplate/backend/common/vision_ops/efficient_nms_kernel.py
+++ b/python/aitemplate/backend/common/vision_ops/efficient_nms_kernel.py
@@ -15,6 +15,7 @@
 """
 efficient_nms function gpu kernel.
 """
+
 import jinja2
 
 kernel = jinja2.Template(

--- a/python/aitemplate/backend/common/vision_ops/nms_kernel.py
+++ b/python/aitemplate/backend/common/vision_ops/nms_kernel.py
@@ -15,6 +15,7 @@
 """
 nms kernel template.
 """
+
 import jinja2
 
 KERNEL_TEMPLATE = jinja2.Template(

--- a/python/aitemplate/backend/cuda/__init__.py
+++ b/python/aitemplate/backend/cuda/__init__.py
@@ -16,6 +16,7 @@
 """
 CUDA backend codegen functions.
 """
+
 from aitemplate.backend.cuda import (
     builder_cmake,
     cuda_common,

--- a/python/aitemplate/backend/cuda/attention/__init__.py
+++ b/python/aitemplate/backend/cuda/attention/__init__.py
@@ -15,6 +15,7 @@
 """
 cuda flash_attention module init
 """
+
 from aitemplate.backend.cuda.attention import flash_attention, mem_eff_attention
 
 __all__ = ["flash_attention", "mem_eff_attention"]

--- a/python/aitemplate/backend/cuda/attention/flash_attention.py
+++ b/python/aitemplate/backend/cuda/attention/flash_attention.py
@@ -15,6 +15,7 @@
 """
 attention kernel codegen for CUDA.
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/cuda/attention/mem_eff_attention.py
+++ b/python/aitemplate/backend/cuda/attention/mem_eff_attention.py
@@ -15,6 +15,7 @@
 """
 Attention kernel codegen for CUDA.
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/cuda/b2b_bmm/classic_b2b_bmm.py
+++ b/python/aitemplate/backend/cuda/b2b_bmm/classic_b2b_bmm.py
@@ -15,6 +15,7 @@
 """
 classic_b2b_bmm kernel codegen for CUDA.
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/cuda/b2b_bmm/fmha_style_b2b_bmm.py
+++ b/python/aitemplate/backend/cuda/b2b_bmm/fmha_style_b2b_bmm.py
@@ -15,6 +15,7 @@
 """
 fmha_style_b2b_bmm kernel codegen for CUDA.
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/cuda/b2b_bmm/grouped_classic_b2b_bmm.py
+++ b/python/aitemplate/backend/cuda/b2b_bmm/grouped_classic_b2b_bmm.py
@@ -15,6 +15,7 @@
 """
 classic_b2b_bmm kernel codegen for CUDA.
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/cuda/b2b_bmm/grouped_fmha_style_b2b_bmm.py
+++ b/python/aitemplate/backend/cuda/b2b_bmm/grouped_fmha_style_b2b_bmm.py
@@ -15,6 +15,7 @@
 """
 grouped_fmha_style_b2b_bmm kernel codegen for CUDA.
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/cuda/common/__init__.py
+++ b/python/aitemplate/backend/cuda/common/__init__.py
@@ -16,4 +16,5 @@
 """
 CUDA Common module init
 """
+
 from aitemplate.backend.cuda.common.dummy_op import *

--- a/python/aitemplate/backend/cuda/conv2d/__init__.py
+++ b/python/aitemplate/backend/cuda/conv2d/__init__.py
@@ -16,6 +16,7 @@
 """
 cuda conv2d module init
 """
+
 from aitemplate.backend.cuda.conv2d import (
     conv2d,
     conv2d_bias,

--- a/python/aitemplate/backend/cuda/conv2d/common.py
+++ b/python/aitemplate/backend/cuda/conv2d/common.py
@@ -15,6 +15,7 @@
 """
 common template for conv2d
 """
+
 import re
 
 from collections import OrderedDict

--- a/python/aitemplate/backend/cuda/conv2d/conv2d.py
+++ b/python/aitemplate/backend/cuda/conv2d/conv2d.py
@@ -15,6 +15,7 @@
 """
 Codegen for conv2d.
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.conv2d import common
 

--- a/python/aitemplate/backend/cuda/conv2d/conv2d_bias.py
+++ b/python/aitemplate/backend/cuda/conv2d/conv2d_bias.py
@@ -15,6 +15,7 @@
 """
 conv2d bias codegen
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.conv2d import common, common_conv2d_bias_activation as cba
 

--- a/python/aitemplate/backend/cuda/conv2d/conv2d_bias_add.py
+++ b/python/aitemplate/backend/cuda/conv2d/conv2d_bias_add.py
@@ -15,6 +15,7 @@
 """
 conv2d bias add codegen
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.conv2d import (
     common,

--- a/python/aitemplate/backend/cuda/conv2d/conv2d_bias_add_hardswish.py
+++ b/python/aitemplate/backend/cuda/conv2d/conv2d_bias_add_hardswish.py
@@ -15,6 +15,7 @@
 """
 conv2d bias add hardswish codegen
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.conv2d import (
     common,

--- a/python/aitemplate/backend/cuda/conv2d/conv2d_bias_add_relu.py
+++ b/python/aitemplate/backend/cuda/conv2d/conv2d_bias_add_relu.py
@@ -15,6 +15,7 @@
 """
 conv2d bias add relu codegen
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.conv2d import (
     common,

--- a/python/aitemplate/backend/cuda/conv2d/conv2d_bias_hardswish.py
+++ b/python/aitemplate/backend/cuda/conv2d/conv2d_bias_hardswish.py
@@ -15,6 +15,7 @@
 """
 conv2d bias hardswish codegen
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.conv2d import common, common_conv2d_bias_activation as cba
 

--- a/python/aitemplate/backend/cuda/conv2d/conv2d_bias_relu.py
+++ b/python/aitemplate/backend/cuda/conv2d/conv2d_bias_relu.py
@@ -15,6 +15,7 @@
 """
 conv2d bias relu codegen
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.conv2d import common, common_conv2d_bias_activation as cba
 

--- a/python/aitemplate/backend/cuda/conv2d/conv2d_depthwise.py
+++ b/python/aitemplate/backend/cuda/conv2d/conv2d_depthwise.py
@@ -15,6 +15,7 @@
 """
 Codegen for conv2d_depthwise.
 """
+
 from collections import OrderedDict
 
 from aitemplate.backend import registry
@@ -85,7 +86,6 @@ def extract_config(func_attrs, dtype="float16"):
             and op.accumulator_type() == acc_type
             and op.group_mode == cutlass_lib.library.GroupMode.NoneGroup
         ):
-
             op = copy.deepcopy(op)
             # set epilogue
             epilogue_name = func_attrs["epilogue"]

--- a/python/aitemplate/backend/cuda/conv2d/transposed_conv2d.py
+++ b/python/aitemplate/backend/cuda/conv2d/transposed_conv2d.py
@@ -15,6 +15,7 @@
 """
 transposed conv2d op codegen
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.conv2d import common, common_transposed_conv2d as ctc
 

--- a/python/aitemplate/backend/cuda/conv2d/transposed_conv2d_bias.py
+++ b/python/aitemplate/backend/cuda/conv2d/transposed_conv2d_bias.py
@@ -15,6 +15,7 @@
 """
 transposed conv2d + bias + (relu) codegen
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.conv2d import common, common_transposed_conv2d as ctc
 

--- a/python/aitemplate/backend/cuda/conv3d/__init__.py
+++ b/python/aitemplate/backend/cuda/conv3d/__init__.py
@@ -15,6 +15,7 @@
 """
 CUDA conv3d module init
 """
+
 from aitemplate.backend.cuda.conv3d import (
     conv3d,
     conv3d_bias,

--- a/python/aitemplate/backend/cuda/conv3d/common.py
+++ b/python/aitemplate/backend/cuda/conv3d/common.py
@@ -15,6 +15,7 @@
 """
 CUDA conv3d common functions
 """
+
 import re
 from hashlib import sha1
 from typing import List

--- a/python/aitemplate/backend/cuda/conv3d/common_bias.py
+++ b/python/aitemplate/backend/cuda/conv3d/common_bias.py
@@ -15,6 +15,7 @@
 """
 CUDA conv3d common functions
 """
+
 import re
 from hashlib import sha1
 from typing import List

--- a/python/aitemplate/backend/cuda/conv3d/conv3d.py
+++ b/python/aitemplate/backend/cuda/conv3d/conv3d.py
@@ -16,6 +16,7 @@
 """
 Codegen for conv3d.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/conv3d/conv3d_bias.py
+++ b/python/aitemplate/backend/cuda/conv3d/conv3d_bias.py
@@ -16,6 +16,7 @@
 """
 Codegen for conv3d.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/conv3d/depthwise_conv3d.py
+++ b/python/aitemplate/backend/cuda/conv3d/depthwise_conv3d.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for depthwise_conv3d.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/conv3d/depthwise_conv3d_bias.py
+++ b/python/aitemplate/backend/cuda/conv3d/depthwise_conv3d_bias.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for depthwise_conv3d_bias.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/cuda_common.py
+++ b/python/aitemplate/backend/cuda/cuda_common.py
@@ -15,6 +15,7 @@
 """
 CUDA common functions for codegen.
 """
+
 from typing import Dict
 
 DTYPE_TO_CUDATYPE: Dict[str, str] = {

--- a/python/aitemplate/backend/cuda/elementwise/__init__.py
+++ b/python/aitemplate/backend/cuda/elementwise/__init__.py
@@ -15,6 +15,7 @@
 """
 (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 """
+
 from aitemplate.backend.cuda.elementwise import fused_elementwise, int_elementwise
 
 __all__ = ["fused_elementwise", "int_elementwise"]

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/bmm_rcr_softmax.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/bmm_rcr_softmax.py
@@ -18,6 +18,7 @@ This is special in template based gemm solution
 This is used for `torch.nn.functional.linear`
 When use for `linear`, need set A->Data, B->Weight
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/common_softmax.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/common_softmax.py
@@ -15,6 +15,7 @@
 """
 Common template for softmax.
 """
+
 import os
 import re
 from hashlib import sha1

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/dual_bmm_rrr_div.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/dual_bmm_rrr_div.py
@@ -17,6 +17,7 @@ Batch GEMM Specialization for
 C = BMM_RRR(A, B0) / BMM_RRR(A, B1)
 where A[RowMajor][M, K], B[RowMajor][K, N], B1[RowMajor][K, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/dual_gemm_rcr_fast_gelu.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/dual_gemm_rcr_fast_gelu.py
@@ -17,6 +17,7 @@ GEMM Specialization for
 C = FAST_GELU(GEMM_RCR(A, B)) * GEMM_RCR(A, B1)
 where A[RowMajor][M, K], B[ColMajor][N, K], B1[ColMajor][N, K]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/dual_gemm_rcr_silu.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/dual_gemm_rcr_silu.py
@@ -17,6 +17,7 @@ GEMM Specialization for
 C = SILU(GEMM_RCR(A, B)) * GEMM_RCR(A, B1)
 where A[RowMajor][M, K], B[ColMajor][N, K], B1[ColMajor][N, K]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/gemm_rcr_bias_softmax.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/gemm_rcr_bias_softmax.py
@@ -18,6 +18,7 @@ This is special in template based gemm solution
 This is used for `torch.nn.functional.linear`
 When use for `linear`, need set A->Data, B->Weight
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_epilogue_vistor/gemm_rcr_softmax.py
+++ b/python/aitemplate/backend/cuda/gemm_epilogue_vistor/gemm_rcr_softmax.py
@@ -18,6 +18,7 @@ This is special in template based gemm solution
 This is used for `torch.nn.functional.linear`
 When use for `linear`, need set A->Data, B->Weight
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_special/__init__.py
+++ b/python/aitemplate/backend/cuda/gemm_special/__init__.py
@@ -15,6 +15,7 @@
 """
 special gemm ops
 """
+
 from aitemplate.backend.cuda.gemm_special import (
     batched_dense_vec_jagged_2d_mul,
     bmm_rcr_n1,

--- a/python/aitemplate/backend/cuda/gemm_special/batched_dense_vec_jagged_2d_mul.py
+++ b/python/aitemplate/backend/cuda/gemm_special/batched_dense_vec_jagged_2d_mul.py
@@ -15,6 +15,7 @@
 """
 Define batched_dense_vec_jagged_2d_mul codegen and CUDA kernel
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/cuda/gemm_special/bmm_rrr_k1_tanh.py
+++ b/python/aitemplate/backend/cuda/gemm_special/bmm_rrr_k1_tanh.py
@@ -20,6 +20,7 @@ A[RowMajor]: [B, M, 1]
 B[RowMajor]: [B, 1, N]
 C[RowMajor]: [B, M, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/bmm_common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/bmm_common.py
@@ -15,6 +15,7 @@
 """
 Common functions and templates for bmm-family ops
 """
+
 import dataclasses
 
 import jinja2

--- a/python/aitemplate/backend/cuda/gemm_universal/bmm_permute_common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/bmm_permute_common.py
@@ -15,6 +15,7 @@
 """
 Common functions and templates for bmm_permute-family ops
 """
+
 from aitemplate.backend.backend_spec import CUDASpec
 from aitemplate.backend.common import gemm_common
 

--- a/python/aitemplate/backend/cuda/gemm_universal/bmm_xxx_add.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/bmm_xxx_add.py
@@ -23,7 +23,6 @@ func_call, and filter for each layout combination under names like
 "cuda.bmm_rcr_add.func_call".
 """
 
-
 from aitemplate.backend import registry
 from aitemplate.backend.common import gemm_common
 from aitemplate.backend.cuda.gemm_universal import bmm_common, common

--- a/python/aitemplate/backend/cuda/gemm_universal/common_bias_activation.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/common_bias_activation.py
@@ -16,6 +16,7 @@
 """
 Common codegen functions for gemm_bias_activation.
 """
+
 import jinja2
 
 from aitemplate.backend.backend_spec import CUDASpec

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr.py
@@ -17,6 +17,7 @@ GEMM Specialization for
 C = GeMM(A, B)
 where A[RowMajor][M, K], B[ColMajor][N, K]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias.py
@@ -17,6 +17,7 @@ GEMM Specialization for
 C = GeMM(A, B) + bias
 where A[RowMajor][M, K], B[ColMajor][N, K], bias[RowMajor][N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_elementwise.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_elementwise.py
@@ -16,6 +16,7 @@
 GEMM Specialization for
 C = UnaryOp2(BinaryOp2(BinaryOp1(UnaryOp1(GeMM(A, B) + bias), D1), D2)),
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.gemm_universal import common, common_bias_broadcast
 from aitemplate.backend.cuda.gemm_universal.layout import RCR

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_fast_gelu.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_fast_gelu.py
@@ -16,6 +16,7 @@
 GEMM Specialization for C = fast_gelu(GeMM(A, B) + bias)
 where A[RowMajor][M, K], B[ColMajor][N, K], bias[RowMajor][K], C[RowMajor][M, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_gelu.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_gelu.py
@@ -16,6 +16,7 @@
 GEMM Specialization for C = gelu(GeMM(A, B) + bias)
 where A[RowMajor][M, K], B[ColMajor][N, K], bias[RowMajor][K], C[RowMajor][M, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_hardswish.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_hardswish.py
@@ -16,6 +16,7 @@
 GEMM Specialization for C = hard_swish(GeMM(A, B) + bias)
 where A[RowMajor][M, K], B[ColMajor][N, K], bias[RowMajor][K], C[RowMajor][M, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_sigmoid.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_sigmoid.py
@@ -17,6 +17,7 @@ GEMM Specialization for
 C = Sigmoid(GeMM(A, B) + bias)
 where A[RowMajor][M, K], B[ColMajor][N, K], bias[RowMajor][N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_swish.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_swish.py
@@ -17,6 +17,7 @@ GEMM Specialization for
 C = swish(GeMM(A, B) + bias)
 where A[RowMajor][M, K], B[ColMajor][N, K], bias[RowMajor][N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_tanh.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_bias_tanh.py
@@ -17,6 +17,7 @@ GEMM Specialization for
 C = tanh(GeMM(A, B) + bias)
 where A[RowMajor][M, K], B[ColMajor][N, K], bias[RowMajor][N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_fast_gelu.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_fast_gelu.py
@@ -16,6 +16,7 @@
 GEMM Specialization for C = fast_gelu(GeMM(A, B) + bias)
 where A[RowMajor][M, K], B[ColMajor][N, K], bias[RowMajor][K], C[RowMajor][M, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_permute.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_permute.py
@@ -17,6 +17,7 @@ GEMM Specialization for
 C = permute(GeMM(A, B) + bias)
 where A[RowMajor][M, K], B[ColMajor][N, K], bias[RowMajor][N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_permute_elup1.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rcr_permute_elup1.py
@@ -17,6 +17,7 @@ GEMM Specialization for
 C = permute(elu(GeMM(A, B) + bias) + 1.0)
 where A[RowMajor][M, K], B[ColMajor][N, K], bias[RowMajor][N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rrr.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rrr.py
@@ -17,6 +17,7 @@ GEMM Specialization for
 C = GeMM(A, B)
 where A[RowMajor][M, K], B[RowMajor][K, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rrr_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rrr_bias.py
@@ -17,6 +17,7 @@ GEMM Specialization for
 C = GeMM(A, B) + bias
 where A[RowMajor][M, K], B[ColMajor][K, N], bias[RowMajor][N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/gemm_rrr_permute.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/gemm_rrr_permute.py
@@ -17,6 +17,7 @@ GEMM Specialization for
 C = permute(GeMM(A, B) + bias)
 where A[RowMajor][M, K], B[RowMajor][K, N], bias[RowMajor][N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/group_common.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/group_common.py
@@ -15,6 +15,7 @@
 """
 Common functions and templates for group-gemm-family kernels
 """
+
 import re
 from hashlib import sha1
 from typing import Any, Dict, List

--- a/python/aitemplate/backend/cuda/gemm_universal/group_common_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/group_common_bias.py
@@ -15,6 +15,7 @@
 """
 Common codegen functions for group_gemm_bias-family kernels.
 """
+
 import jinja2
 
 from aitemplate.backend.cuda.gemm_universal import group_common

--- a/python/aitemplate/backend/cuda/gemm_universal/group_gemm_rcr.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/group_gemm_rcr.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for group_gemm_rcr.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/gemm_universal/group_gemm_rcr_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/group_gemm_rcr_bias.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for group_gemm_rcr_bias.
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.gemm_universal import (
     common,

--- a/python/aitemplate/backend/cuda/gemm_universal/group_gemm_rcr_bias_relu.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/group_gemm_rcr_bias_relu.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for group_gemm_rcr_bias_relu.
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.gemm_universal import (
     common,

--- a/python/aitemplate/backend/cuda/gemm_universal/group_gemm_rcr_bias_sigmoid.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/group_gemm_rcr_bias_sigmoid.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for group_gemm_rcr_bias_sigmoid.
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.gemm_universal import (
     common,

--- a/python/aitemplate/backend/cuda/gemm_universal/perm021fc_ccr.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm021fc_ccr.py
@@ -16,6 +16,7 @@
 Codegen functions for perm021fc_ccr, which computes
 [b, m, n] = bmm([b, k, m], [1, n, k]).
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.gemm_universal import bmm_common, common
 

--- a/python/aitemplate/backend/cuda/gemm_universal/perm021fc_ccr_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm021fc_ccr_bias.py
@@ -16,6 +16,7 @@
 Codegen functions for perm021fc_ccr_bias, which computes
 [b, m, n] = bmm([b, k, m], [1, n, k]) + bias[n].
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.gemm_universal import (
     bmm_common,

--- a/python/aitemplate/backend/cuda/gemm_universal/perm021fc_ccr_bias_permute.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm021fc_ccr_bias_permute.py
@@ -16,6 +16,7 @@
 Common functions and templates for perm021_ccr_bias_permute, which computes
 (A.permute(0, 2, 1)[col] @ B[col] + Bias).permute(0, 2, 1)
 """
+
 from aitemplate.backend import registry
 
 from aitemplate.backend.cuda.gemm_universal import (

--- a/python/aitemplate/backend/cuda/gemm_universal/perm021fc_crc.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm021fc_crc.py
@@ -16,6 +16,7 @@
 Codegen functions for perm021fc_crc, which computes
 [b, n, m](col) = bmm([1, k, n](col), [b, k, m](row)).
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.gemm_universal import bmm_common, common
 

--- a/python/aitemplate/backend/cuda/gemm_universal/perm021fc_crc_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm021fc_crc_bias.py
@@ -16,6 +16,7 @@
 Codegen functions for perm021fc_crc_bias, which computes
 [b, n, m](col) = bmm([1, k, n](col), [b, k, m](row)) + bias[n].
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.cuda.gemm_universal import (
     bmm_common,

--- a/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rcr.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rcr.py
@@ -16,6 +16,7 @@
 Codegen functions for perm102_bmm_rcr, which computes
 C[m, b, n](row) = bmm(A[m, b, k](row), B[b, n, k](col))
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.backend_spec import CUDASpec
 from aitemplate.backend.cuda.gemm_universal import bmm_common, common

--- a/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rcr_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rcr_bias.py
@@ -16,6 +16,7 @@
 Codegen functions for perm102_bmm_rcr_bias, which computes
 C[m, b, n](row) = bmm(A[m, b, k](row), B[b, n, k](col)) + bias[n].
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.backend_spec import CUDASpec
 from aitemplate.backend.cuda.gemm_universal import (

--- a/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rrr.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rrr.py
@@ -16,6 +16,7 @@
 Codegen functions for perm102_bmm_rrr, which computes
 C[m, b, n](row) = bmm(A[m, b, k](row), B[b, k, n](row))
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.backend_spec import CUDASpec
 from aitemplate.backend.cuda.gemm_universal import bmm_common, common

--- a/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rrr_bias.py
+++ b/python/aitemplate/backend/cuda/gemm_universal/perm102_bmm_rrr_bias.py
@@ -16,6 +16,7 @@
 Codegen functions for perm102_bmm_rrr_bias, which computes
 C[m, b, n](row) = bmm(A[m, b, k](row), B[b, k, n](row)) + bias[n]
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.backend_spec import CUDASpec
 from aitemplate.backend.cuda.gemm_universal import (

--- a/python/aitemplate/backend/cuda/jagged/__init__.py
+++ b/python/aitemplate/backend/cuda/jagged/__init__.py
@@ -15,6 +15,7 @@
 """
 CUDA jagged tensor-specific ops module init
 """
+
 from aitemplate.backend.cuda.jagged import (
     jagged_lengths_to_offsets,
     jagged_lengths_to_presences,

--- a/python/aitemplate/backend/cuda/jagged/jagged_lengths_to_offsets.py
+++ b/python/aitemplate/backend/cuda/jagged/jagged_lengths_to_offsets.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for the jagged_lengths_to_offsets op.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/jagged/jagged_lengths_to_presences.py
+++ b/python/aitemplate/backend/cuda/jagged/jagged_lengths_to_presences.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for the jagged_lengths_to_presences op.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/layernorm_sigmoid_mul/__init__.py
+++ b/python/aitemplate/backend/cuda/layernorm_sigmoid_mul/__init__.py
@@ -15,6 +15,7 @@
 """
 (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 """
+
 from aitemplate.backend.cuda.layernorm_sigmoid_mul import (
     batch_layernorm_sigmoid_mul,
     group_layernorm_sigmoid_mul,

--- a/python/aitemplate/backend/cuda/lib_template.py
+++ b/python/aitemplate/backend/cuda/lib_template.py
@@ -15,6 +15,7 @@
 """
 Common function templates for CUDA codegen.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/padding/__init__.py
+++ b/python/aitemplate/backend/cuda/padding/__init__.py
@@ -15,6 +15,7 @@
 """
 CUDA padding init
 """
+
 from aitemplate.backend.cuda.padding import ndhwc3to8, nhwc3to4, nhwc3to8, pad_last_dim
 
 __all__ = ["ndhwc3to8", "nhwc3to8", "pad_last_dim", "nhwc3to4"]

--- a/python/aitemplate/backend/cuda/padding/ndhwc3to8.py
+++ b/python/aitemplate/backend/cuda/padding/ndhwc3to8.py
@@ -15,6 +15,7 @@
 """
 CUDA codegen for ndhwc3to8 op
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/padding/nhwc3to4.py
+++ b/python/aitemplate/backend/cuda/padding/nhwc3to4.py
@@ -15,6 +15,7 @@
 """
 CUDA codegen for nhwc3to4 op
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/padding/nhwc3to8.py
+++ b/python/aitemplate/backend/cuda/padding/nhwc3to8.py
@@ -15,6 +15,7 @@
 """
 CUDA codegen for nhwc3to8 op
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/padding/pad_last_dim.py
+++ b/python/aitemplate/backend/cuda/padding/pad_last_dim.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for pad_last_dim.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/pool2d/__init__.py
+++ b/python/aitemplate/backend/cuda/pool2d/__init__.py
@@ -15,6 +15,7 @@
 """
 CUDA pool2d module init
 """
+
 from aitemplate.backend.cuda.pool2d import avg_pool2d, max_pool2d
 
 __all__ = ["avg_pool2d", "max_pool2d"]

--- a/python/aitemplate/backend/cuda/pool2d/pool2d.py
+++ b/python/aitemplate/backend/cuda/pool2d/pool2d.py
@@ -15,6 +15,7 @@
 """
 CUDA pool2d common functions
 """
+
 import jinja2
 
 FUNC_DECL_TEMPLATE = jinja2.Template(

--- a/python/aitemplate/backend/cuda/reduce/__init__.py
+++ b/python/aitemplate/backend/cuda/reduce/__init__.py
@@ -15,6 +15,7 @@
 """
 CUDA reduce module init
 """
+
 from aitemplate.backend.cuda.reduce import (
     reduce_3d,
     reduce_common,

--- a/python/aitemplate/backend/cuda/reduce/reduce_3d.py
+++ b/python/aitemplate/backend/cuda/reduce/reduce_3d.py
@@ -20,6 +20,7 @@ respectively. So, this common kernel can be used to implement a family of
 reduction ops such as reduce_mean and norm where we need to apply a scalar-op
 to each final element.
 """
+
 import bisect
 
 import jinja2

--- a/python/aitemplate/backend/cuda/reduce/reduce_common.py
+++ b/python/aitemplate/backend/cuda/reduce/reduce_common.py
@@ -15,6 +15,7 @@
 """
 CUDA reduce common functions
 """
+
 import jinja2
 
 from aitemplate.backend.backend_spec import CUDASpec

--- a/python/aitemplate/backend/cuda/reduce/reduce_common_slim_tensor.py
+++ b/python/aitemplate/backend/cuda/reduce/reduce_common_slim_tensor.py
@@ -17,7 +17,6 @@ A simply reduction implementation for "slim" tensors. Currently only reduction
 along dim=1 for 3D tensors is supported.
 """
 
-
 from typing import List
 
 import jinja2

--- a/python/aitemplate/backend/cuda/softmax/__init__.py
+++ b/python/aitemplate/backend/cuda/softmax/__init__.py
@@ -15,6 +15,7 @@
 """
 (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 """
+
 from aitemplate.backend.cuda.softmax import softmax
 
 __all__ = ["softmax"]

--- a/python/aitemplate/backend/cuda/softmax/softmax.py
+++ b/python/aitemplate/backend/cuda/softmax/softmax.py
@@ -15,6 +15,7 @@
 """
 Softmax codegen for CUDA.
 """
+
 from __future__ import annotations
 
 import math

--- a/python/aitemplate/backend/cuda/target_def.py
+++ b/python/aitemplate/backend/cuda/target_def.py
@@ -15,6 +15,7 @@
 """
 CUDA target specialization
 """
+
 import json
 import logging
 import os
@@ -161,15 +162,17 @@ class CUDA(Target):
             "-DCUTLASS_DEBUG_TRACE_LEVEL=" + environ.get_cutlass_debug_trace_level(),
         ]
         if environ.enable_ptxas_info():
-            options.extend(
-                [
-                    "--keep",  # Keep the intermediate files for debugging (including ptx, sass, cubin etc.)
-                    "--ptxas-options=--warn-on-local-memory-usage",  # warn us if local memory is used in CUDA Kernels
-                    "--ptxas-options=--warn-on-spills",  # warn us if register spilling happens in CUDA Kernels
-                    "--resource-usage",  # Report on CUDA resource usage (shared mem, registers etc.)
-                    "--source-in-ptx",
-                ]
-            ),  # Annotate the ptx file with source information
+            (
+                options.extend(
+                    [
+                        "--keep",  # Keep the intermediate files for debugging (including ptx, sass, cubin etc.)
+                        "--ptxas-options=--warn-on-local-memory-usage",  # warn us if local memory is used in CUDA Kernels
+                        "--ptxas-options=--warn-on-spills",  # warn us if register spilling happens in CUDA Kernels
+                        "--resource-usage",  # Report on CUDA resource usage (shared mem, registers etc.)
+                        "--source-in-ptx",
+                    ]
+                ),
+            )  # Annotate the ptx file with source information
         options.extend(self._get_nvcc_debug_options())
         if self._ndebug == 1:
             options.append("-DNDEBUG")
@@ -449,15 +452,17 @@ class FBCUDA(CUDA):
                 )
             )
             if environ.enable_ptxas_info():
-                options.extend(
-                    [
-                        "--keep",  # Keep the intermediate files for debugging (including ptx, sass, cubin etc.)
-                        "--ptxas-options=--warn-on-local-memory-usage",  # warn us if local memory is used in CUDA Kernels
-                        "--ptxas-options=--warn-on-spills",  # warn us if register spilling happens in CUDA Kernels
-                        "--resource-usage",  # Report on CUDA resource usage (shared mem, registers etc.)
-                        "--source-in-ptx",  # Annotate the ptx file with source information
-                    ]
-                ),
+                (
+                    options.extend(
+                        [
+                            "--keep",  # Keep the intermediate files for debugging (including ptx, sass, cubin etc.)
+                            "--ptxas-options=--warn-on-local-memory-usage",  # warn us if local memory is used in CUDA Kernels
+                            "--ptxas-options=--warn-on-spills",  # warn us if register spilling happens in CUDA Kernels
+                            "--resource-usage",  # Report on CUDA resource usage (shared mem, registers etc.)
+                            "--source-in-ptx",  # Annotate the ptx file with source information
+                        ]
+                    ),
+                )
             options.extend(self._get_nvcc_debug_options())
             if self._ndebug == 1:
                 options.append("-DNDEBUG")

--- a/python/aitemplate/backend/cuda/tensor/__init__.py
+++ b/python/aitemplate/backend/cuda/tensor/__init__.py
@@ -15,6 +15,7 @@
 """
 CUDA tensor ops module init
 """
+
 from aitemplate.backend.cuda.tensor import (
     argmax,
     batch_gather,

--- a/python/aitemplate/backend/cuda/tensor/concatenate_tanh.py
+++ b/python/aitemplate/backend/cuda/tensor/concatenate_tanh.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for concatenate_tanh.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/tensor/gather.py
+++ b/python/aitemplate/backend/cuda/tensor/gather.py
@@ -15,6 +15,7 @@
 """
 CUDA gather function
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/tensor/index_select.py
+++ b/python/aitemplate/backend/cuda/tensor/index_select.py
@@ -40,6 +40,7 @@ Num threads = 256.
 Blocks are(N + threads - 1) / threads;
 
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/tensor/jagged_to_padded_dense.py
+++ b/python/aitemplate/backend/cuda/tensor/jagged_to_padded_dense.py
@@ -15,6 +15,7 @@
 """
 The back-end bindings of the jagged_to_padded_dense op.
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/cuda/tensor/masked_select.py
+++ b/python/aitemplate/backend/cuda/tensor/masked_select.py
@@ -15,6 +15,7 @@
 """
 Define masked_select codegen and CUDA kernel
 """
+
 from typing import List
 
 import jinja2

--- a/python/aitemplate/backend/cuda/tensor/padded_dense_to_jagged.py
+++ b/python/aitemplate/backend/cuda/tensor/padded_dense_to_jagged.py
@@ -15,6 +15,7 @@
 """
 The back-end bindings of the padded_dense_to_jagged op.
 """
+
 from typing import Any, Dict, List
 
 import jinja2

--- a/python/aitemplate/backend/cuda/tensor/permute.py
+++ b/python/aitemplate/backend/cuda/tensor/permute.py
@@ -15,6 +15,7 @@
 """
 permute for cuda
 """
+
 import os
 from typing import Any, Dict
 

--- a/python/aitemplate/backend/cuda/tensor/slice_reshape_scatter.py
+++ b/python/aitemplate/backend/cuda/tensor/slice_reshape_scatter.py
@@ -15,6 +15,7 @@
 """
 Slice reshape scatter CUDA implementation.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/upsample/__init__.py
+++ b/python/aitemplate/backend/cuda/upsample/__init__.py
@@ -15,6 +15,7 @@
 """
 CUDA upsampling module init
 """
+
 from aitemplate.backend.cuda.upsample import upsampling2d, upsampling2d_add
 
 __all__ = ["upsampling2d", "upsampling2d_add"]

--- a/python/aitemplate/backend/cuda/utils.py
+++ b/python/aitemplate/backend/cuda/utils.py
@@ -15,6 +15,7 @@
 """
 Util functions for CUDA codegen.
 """
+
 import logging
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/view_ops/__init__.py
+++ b/python/aitemplate/backend/cuda/view_ops/__init__.py
@@ -15,6 +15,7 @@
 """
 CUDA view_ops module init
 """
+
 from aitemplate.backend.cuda.view_ops import make_jagged, view_ops
 
 __all__ = [

--- a/python/aitemplate/backend/cuda/view_ops/make_jagged.py
+++ b/python/aitemplate/backend/cuda/view_ops/make_jagged.py
@@ -28,6 +28,7 @@ The main responsibilities of the make_jagged backend are:
   of the constraints can be checked on the device, in which
   case an std::runtime_error is thrown on violation.
 """
+
 from typing import Set
 
 import jinja2

--- a/python/aitemplate/backend/cuda/view_ops/view_ops.py
+++ b/python/aitemplate/backend/cuda/view_ops/view_ops.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for view ops.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/vision_ops/nms/__init__.py
+++ b/python/aitemplate/backend/cuda/vision_ops/nms/__init__.py
@@ -15,6 +15,7 @@
 """
 (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 """
+
 from aitemplate.backend.cuda.vision_ops.nms import (  # noqa
     batched_nms,
     efficient_nms,

--- a/python/aitemplate/backend/cuda/vision_ops/roi_ops/__init__.py
+++ b/python/aitemplate/backend/cuda/vision_ops/roi_ops/__init__.py
@@ -15,6 +15,7 @@
 """
 CUDA roi_align module init
 """
+
 from aitemplate.backend.cuda.vision_ops.roi_ops import multi_level_roi_align, roi_align
 
 __all__ = ["roi_align", "multi_level_roi_align"]

--- a/python/aitemplate/backend/cuda/vision_ops/roi_ops/multi_level_roi_align.py
+++ b/python/aitemplate/backend/cuda/vision_ops/roi_ops/multi_level_roi_align.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for multi-level roi align.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/cuda/vision_ops/roi_ops/roi_ops.py
+++ b/python/aitemplate/backend/cuda/vision_ops/roi_ops/roi_ops.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for roi ops.
 """
+
 import jinja2
 
 FUNC_DECL_TEMPLATE = jinja2.Template(

--- a/python/aitemplate/backend/main_templates.py
+++ b/python/aitemplate/backend/main_templates.py
@@ -15,6 +15,7 @@
 """
 This file contains class definitions used in the generated main.cu file.
 """
+
 import jinja2
 
 MODEL_TEMPLATE = jinja2.Template(

--- a/python/aitemplate/backend/profiler_cache.py
+++ b/python/aitemplate/backend/profiler_cache.py
@@ -15,6 +15,7 @@
 """
 SQLite backend for conv/gemm profiling cache
 """
+
 import enum
 import logging
 import sqlite3

--- a/python/aitemplate/backend/profiler_runner.py
+++ b/python/aitemplate/backend/profiler_runner.py
@@ -15,6 +15,7 @@
 """
 A subprocess based multiple GPUs runner for auto-tuning
 """
+
 from __future__ import annotations
 
 import concurrent.futures

--- a/python/aitemplate/backend/rocm/__init__.py
+++ b/python/aitemplate/backend/rocm/__init__.py
@@ -16,6 +16,7 @@
 """
 Rocm backend init.
 """
+
 from aitemplate.backend.rocm import lib_template, target_def, utils
 from aitemplate.backend.rocm.attention import *
 from aitemplate.backend.rocm.common import *

--- a/python/aitemplate/backend/rocm/attention/mem_eff_attention.py
+++ b/python/aitemplate/backend/rocm/attention/mem_eff_attention.py
@@ -15,6 +15,7 @@
 """
 attention kernel codegen for ROCM.
 """
+
 from typing import Any, Dict
 
 import jinja2

--- a/python/aitemplate/backend/rocm/common/__init__.py
+++ b/python/aitemplate/backend/rocm/common/__init__.py
@@ -16,4 +16,5 @@
 """
 ROCM Common module init
 """
+
 from aitemplate.backend.rocm.common.dummy_op import *

--- a/python/aitemplate/backend/rocm/conv2d/__init__.py
+++ b/python/aitemplate/backend/rocm/conv2d/__init__.py
@@ -15,6 +15,7 @@
 """
 ROCM conv2d init.
 """
+
 from aitemplate.backend.rocm.conv2d import (
     conv2d,
     conv2d_bias,

--- a/python/aitemplate/backend/rocm/conv2d/common.py
+++ b/python/aitemplate/backend/rocm/conv2d/common.py
@@ -15,6 +15,7 @@
 """
 Common ROCM template for conv2d.
 """
+
 import os
 import re
 from collections import OrderedDict

--- a/python/aitemplate/backend/rocm/conv2d/conv2d.py
+++ b/python/aitemplate/backend/rocm/conv2d/conv2d.py
@@ -15,6 +15,7 @@
 """
 ROCM codegen functions for conv2d.
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.rocm.conv2d import common
 

--- a/python/aitemplate/backend/rocm/conv2d/conv2d_bias.py
+++ b/python/aitemplate/backend/rocm/conv2d/conv2d_bias.py
@@ -15,6 +15,7 @@
 """
 ROCM codegen functions for Conv2dBias: conv2d(w, x) + b
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.rocm.conv2d import common
 

--- a/python/aitemplate/backend/rocm/conv2d/conv2d_bias_add.py
+++ b/python/aitemplate/backend/rocm/conv2d/conv2d_bias_add.py
@@ -15,6 +15,7 @@
 """
 conv2d bias add codegen
 """
+
 from ... import registry
 from . import common
 

--- a/python/aitemplate/backend/rocm/conv2d/conv2d_bias_add_relu.py
+++ b/python/aitemplate/backend/rocm/conv2d/conv2d_bias_add_relu.py
@@ -15,6 +15,7 @@
 """
 ROCM codegen functions for conv2d_bias_add_relu.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/conv2d/conv2d_bias_relu.py
+++ b/python/aitemplate/backend/rocm/conv2d/conv2d_bias_relu.py
@@ -15,6 +15,7 @@
 """
 ROCM codegen functions for conv2d_bias_relu.
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.rocm.conv2d import common
 

--- a/python/aitemplate/backend/rocm/conv2d/conv2d_bias_sigmoid.py
+++ b/python/aitemplate/backend/rocm/conv2d/conv2d_bias_sigmoid.py
@@ -15,6 +15,7 @@
 """
 ROCM codegen functions for conv2d_bias_sigmoid.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/conv2d/transposed_conv2d.py
+++ b/python/aitemplate/backend/rocm/conv2d/transposed_conv2d.py
@@ -15,6 +15,7 @@
 """
 ROCM codegen functions for transposed_conv2d.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/conv2d/transposed_conv2d_bias_relu.py
+++ b/python/aitemplate/backend/rocm/conv2d/transposed_conv2d_bias_relu.py
@@ -15,6 +15,7 @@
 """
 ROCM codegen functions for transposed_conv2d_bias_relu.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/elementwise/__init__.py
+++ b/python/aitemplate/backend/rocm/elementwise/__init__.py
@@ -15,6 +15,7 @@
 """
 (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 """
+
 from aitemplate.backend.rocm.elementwise import fused_elementwise
 
 __all__ = ["fused_elementwise"]

--- a/python/aitemplate/backend/rocm/gemm/__init__.py
+++ b/python/aitemplate/backend/rocm/gemm/__init__.py
@@ -15,6 +15,7 @@
 """
 Rocm gemm init.
 """
+
 from aitemplate.backend.rocm.gemm import (  # noqa: F401
     bmm_ccr,
     bmm_ccr_add,

--- a/python/aitemplate/backend/rocm/gemm/bmm_ccr.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_ccr.py
@@ -17,6 +17,7 @@ Batched Gemm ROCM backend for A[ColumnMajor], B[ColumnMajor], C[RowMajor], i.e.
 c[b, m, n] = bmm(a[b, k, m], b[b, n, k])
 This is used for `ops.bmm_ccr`.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/bmm_ccr_add.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_ccr_add.py
@@ -17,6 +17,7 @@ Batched Gemm ROCM backend A[RowMajor], B[RowMajor], C[RowMajor], i.e.
 c[b, m, n] = a[b, k, m] * b[b, n, k]
 This is used for `ops.bmm_ccr_add`.
 """
+
 import jinja2
 
 from ... import registry

--- a/python/aitemplate/backend/rocm/gemm/bmm_common.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_common.py
@@ -15,6 +15,7 @@
 """
 Common template for bmm
 """
+
 import jinja2
 
 from aitemplate.backend.rocm.gemm import common

--- a/python/aitemplate/backend/rocm/gemm/bmm_crr.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_crr.py
@@ -17,6 +17,7 @@ Batched Gemm ROCM backend for A[ColumnMajor], B[RowMajor], C[RowMajor], i.e.
 c[b, m, n] = bmm(a[b, k, m], b[b, k, n])
 This is used for `ops.bmm_crr`.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/bmm_crr_add.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_crr_add.py
@@ -17,6 +17,7 @@ Batched Gemm ROCM backend A[RowMajor], B[RowMajor], C[RowMajor], i.e.
 c[b, m, n] = a[b, k, m] * b[b, k, n]
 This is used for `ops.bmm_crr_add`.
 """
+
 import jinja2
 
 from ... import registry

--- a/python/aitemplate/backend/rocm/gemm/bmm_permute_common.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_permute_common.py
@@ -15,6 +15,7 @@
 """
 Common template for bmm
 """
+
 import jinja2
 
 EXTRA_HEADER_TEMPLATE = jinja2.Template(

--- a/python/aitemplate/backend/rocm/gemm/bmm_rcr.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_rcr.py
@@ -17,6 +17,7 @@ Batched Gemm ROCM backend for A[RowMajor], B[ColumnMajor], C[RowMajor], i.e.
 c[b, m, n] = bmm(a[b, m, k], b[b, n, k])
 This is used for `ops.bmm_rcr`.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/bmm_rcr_permute.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_rcr_permute.py
@@ -17,6 +17,7 @@ Batched Gemm ROCM backend for A[RowMajor], B[ColumnMajor], C[RowMajor], i.e.
 c[b, m, n] = bmm(a[b, m, k], b[b, n, k])
 This is used for `ops.bmm_rcr`.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/bmm_rrr.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_rrr.py
@@ -17,6 +17,7 @@ Batched Gemm ROCM backend A[RowMajor], B[RowMajor], C[RowMajor], i.e.
 c[b, m, n] = a[b, m, k] * b[b, k, n]
 This is used for `ops.bmm_rrr`.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/bmm_rrr_add.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_rrr_add.py
@@ -17,6 +17,7 @@ Batched Gemm ROCM backend A[RowMajor], B[RowMajor], C[RowMajor], i.e.
 c[b, m, n] = a[b, m, k] * b[b, k, n]
 This is used for `ops.bmm_rrr_add`.
 """
+
 import jinja2
 
 from ... import registry

--- a/python/aitemplate/backend/rocm/gemm/bmm_rrr_permute.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_rrr_permute.py
@@ -17,6 +17,7 @@ Batched Gemm ROCM backend for A[RowMajor], B[ColumnMajor], C[RowMajor], i.e.
 c[b, m, n] = bmm(a[b, m, k], b[b, n, k])
 This is used for `ops.bmm_rrr_permute`.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/bmm_softmax_bmm.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_softmax_bmm.py
@@ -17,6 +17,7 @@ Batched Gemm ROCM backend for A[RowMajor], B[ColumnMajor], C[RowMajor], i.e.
 c[b, m, n] = bmm(a[b, m, k], b[b, n, k])
 This is used for `ops.bmm_rcr`.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/bmm_softmax_bmm_permute.py
+++ b/python/aitemplate/backend/rocm/gemm/bmm_softmax_bmm_permute.py
@@ -22,6 +22,7 @@ Batched Gemm ROCM backend for
 
 This is used for `ops.bmm_softmax_bmm_permute`.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/common.py
+++ b/python/aitemplate/backend/rocm/gemm/common.py
@@ -15,6 +15,7 @@
 """
 Common template for gemm
 """
+
 import os
 import re
 from collections import OrderedDict

--- a/python/aitemplate/backend/rocm/gemm/gemm_epilogue.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_epilogue.py
@@ -15,6 +15,7 @@
 """
 Templates for different GeMM epilogues.
 """
+
 from typing import Dict, List, NamedTuple
 
 from aitemplate.compiler.ops.common.epilogue import EpilogueOp

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr.py
@@ -18,6 +18,7 @@ c[m, n] = a[m, k] * b[n, k]
 This is used for `torch.nn.functional.linear(bias=false)`
 When used for `linear`, need to set A->Data, B->Weight
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.rocm.gemm import common
 from aitemplate.backend.rocm.gemm.layout import RCR

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias.py
@@ -18,6 +18,7 @@ c[m, n] = a[m, k] * b[n, k] + bias[n]
 This is used for `torch.nn.functional.linear`
 When used for `linear`, need to set A->Data, B->Weight, C->Bias
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.rocm.gemm import common
 from aitemplate.backend.rocm.gemm.layout import RCR

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add.py
@@ -18,6 +18,7 @@ C = Add(GeMM(A, B) + bias, D0)),
 where A[RowMajor][M, K], B[ColMajor][N, K], C[RowMajor][M, N]
 bias[RowMajor][N], D0[RowMajor][M, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_add.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_add.py
@@ -18,6 +18,7 @@ C = Relu(Add(Add(GeMM(A, B) + bias, D0), D1)),
 where A[RowMajor][M, K], B[ColMajor][N, K], C[RowMajor][M, N]
 bias[RowMajor][N], D0[RowMajor][M, N], D1[RowMajor][M, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_add_relu.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_add_relu.py
@@ -18,6 +18,7 @@ C = Relu(Add(Add(GeMM(A, B) + bias, D0), D1)),
 where A[RowMajor][M, K], B[ColMajor][N, K], C[RowMajor][M, N]
 bias[RowMajor][N], D0[RowMajor][M, N], D1[RowMajor][M, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_relu.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_add_relu.py
@@ -18,6 +18,7 @@ C = Relu(Add(GeMM(A, B) + bias, D0)),
 where A[RowMajor][M, K], B[ColMajor][N, K], C[RowMajor][M, N]
 bias[RowMajor][N], D0[RowMajor][M, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_fast_gelu.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_fast_gelu.py
@@ -18,6 +18,7 @@ c[m, n] = fast_gelu(a[m, k] * b[n, k] + bias[n])
 This is used for `torch.nn.functional.linear + swish`
 When used for `linear`, need to set A->Data, B->Weight, C->Bias
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.rocm.gemm import common
 from aitemplate.backend.rocm.gemm.layout import RCR

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul.py
@@ -18,6 +18,7 @@ C = Add(GeMM(A, B) + bias, D0)),
 where A[RowMajor][M, K], B[ColMajor][N, K], C[RowMajor][M, N]
 bias[RowMajor][N], D0[RowMajor][M, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul_add.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul_add.py
@@ -18,6 +18,7 @@ C = Add(Mul(GeMM(A, B) + bias, D0), D1),
 where A[RowMajor][M, K], B[ColMajor][N, K], C[RowMajor][M, N]
 bias[RowMajor][N], D0[RowMajor][M, N], D1[RowMajor][M, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul_tanh.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_mul_tanh.py
@@ -18,6 +18,7 @@ C = Add(GeMM(A, B) + bias, D0)),
 where A[RowMajor][M, K], B[ColMajor][N, K], C[RowMajor][M, N]
 bias[RowMajor][N], D0[RowMajor][M, N]
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_permute.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_permute.py
@@ -18,6 +18,7 @@ c[m, n] = a[m, k] * b[n, k] + bias[n]
 This is used for `torch.nn.functional.linear`
 When used for `linear`, need to set A->Data, B->Weight, C->Bias
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_permute_m2n3.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_permute_m2n3.py
@@ -19,6 +19,7 @@ where m = M0 * M1 , n = N1 * N0 * N2
 c = c.reshape(M0, M1, N0, N1, N2)
 output = torch.permute(c, [2, 0, 3, 1, 4])
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_permute_m3n2.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_permute_m3n2.py
@@ -19,6 +19,7 @@ where m = M0 * M1 * M2, n = N0 * N1
 c = c.reshape(M0, M1, M2, N0, N1)
 output = torch.permute(c, [2, 0, 3, 1, 4])
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_relu.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_relu.py
@@ -18,6 +18,7 @@ c[m, n] = RELU(a[m, k] * b[n, k] + bias[n])
 This is used for `torch.nn.functional.linear + relu`
 When used for `linear`, need to set A->Data, B->Weight, C->Bias
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.rocm.gemm import common
 from aitemplate.backend.rocm.gemm.layout import RCR

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid.py
@@ -18,6 +18,7 @@ c[m, n] = Sigmoid(a[m, k] * b[n, k] + bias[n])
 This is used for `torch.nn.functional.linear + sigmoid`
 When used for `linear`, need to set A->Data, B->Weight, C->Bias
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul.py
@@ -18,6 +18,7 @@ C = Mul(Sigmoid(GeMM(A, B) + bias), D0),
 where A[RowMajor][M, K], B[ColMajor][N, K], C[RowMajor][M, N]
 bias[RowMajor][N], D0[RowMajor][M, N].
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul_tanh.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_sigmoid_mul_tanh.py
@@ -18,6 +18,7 @@ C = Tanh(Mul(Sigmoid(GeMM(A, B) + bias), D0)),
 where A[RowMajor][M, K], B[ColMajor][N, K], C[RowMajor][M, N]
 bias[RowMajor][N], D0[RowMajor][M, N].
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_tanh.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_bias_tanh.py
@@ -18,6 +18,7 @@ c[m, n] = tanh(a[m, k] * b[n, k] + bias[n])
 This is used for `torch.nn.functional.linear + tanh`
 When used for `linear`, need to set A->Data, B->Weight, C->Bias
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rcr_permute_m2n3.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rcr_permute_m2n3.py
@@ -19,6 +19,7 @@ where m = M0 * M1 , n = N1 * N0 * N2
 c = c.reshape(M0, M1, N0, N1, N2)
 output = torch.permute(c, [2, 0, 3, 1, 4])
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/gemm/gemm_rrr.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rrr.py
@@ -18,6 +18,7 @@ c[m, n] = a[m, k] * b[k, n]
 This is used for `torch.mm`
 When used for `mm`, need to set A->Data, B->Weight
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.rocm.gemm import common
 from aitemplate.backend.rocm.gemm.layout import RRR

--- a/python/aitemplate/backend/rocm/gemm/gemm_rrr_bias_permute.py
+++ b/python/aitemplate/backend/rocm/gemm/gemm_rrr_bias_permute.py
@@ -18,6 +18,7 @@ c[new_dim] = permute(a[m, k] * b[k, n] + bias[n], new_dim), where *new_dim = m*n
 This is used for `torch.nn.functional.linear`
 When used for `linear`, need to set A->Data, B->Weight, C->Bias
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.rocm.gemm import common, permute_common
 from aitemplate.backend.rocm.gemm.layout import RRR

--- a/python/aitemplate/backend/rocm/lib_template.py
+++ b/python/aitemplate/backend/rocm/lib_template.py
@@ -15,6 +15,7 @@
 """
 Common codegen functions for ROCM.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/normalization/__init__.py
+++ b/python/aitemplate/backend/rocm/normalization/__init__.py
@@ -15,4 +15,5 @@
 """
 Common modules for backends
 """
+
 from aitemplate.backend.rocm.normalization import norm_common, softmax  # noqa

--- a/python/aitemplate/backend/rocm/normalization/groupnorm.py
+++ b/python/aitemplate/backend/rocm/normalization/groupnorm.py
@@ -15,6 +15,7 @@
 """
 Groupnorm codegen for ROCM.
 """
+
 from collections import OrderedDict
 from hashlib import sha1
 from typing import Any, Dict

--- a/python/aitemplate/backend/rocm/normalization/layernorm.py
+++ b/python/aitemplate/backend/rocm/normalization/layernorm.py
@@ -15,6 +15,7 @@
 """
 Layernorm codegen for ROCM.
 """
+
 from collections import OrderedDict
 from hashlib import sha1
 from typing import Any, Dict

--- a/python/aitemplate/backend/rocm/padding/__init__.py
+++ b/python/aitemplate/backend/rocm/padding/__init__.py
@@ -15,6 +15,7 @@
 """
 CUDA padding init
 """
+
 from . import nhwc3to4, nhwc3to8, pad_last_dim
 
 __all__ = ["nhwc3to8", "pad_last_dim", "nhwc3to4"]

--- a/python/aitemplate/backend/rocm/padding/nhwc3to4.py
+++ b/python/aitemplate/backend/rocm/padding/nhwc3to4.py
@@ -15,6 +15,7 @@
 """
 CUDA codegen for nhwc3to4 op
 """
+
 import jinja2
 
 from ... import registry

--- a/python/aitemplate/backend/rocm/padding/nhwc3to8.py
+++ b/python/aitemplate/backend/rocm/padding/nhwc3to8.py
@@ -15,6 +15,7 @@
 """
 CUDA codegen for nhwc3to8 op
 """
+
 import jinja2
 
 from ... import registry

--- a/python/aitemplate/backend/rocm/padding/pad_last_dim.py
+++ b/python/aitemplate/backend/rocm/padding/pad_last_dim.py
@@ -15,6 +15,7 @@
 """
 Codegen functions for pad_last_dim.
 """
+
 import jinja2
 
 from ... import registry

--- a/python/aitemplate/backend/rocm/pool2d/__init__.py
+++ b/python/aitemplate/backend/rocm/pool2d/__init__.py
@@ -15,6 +15,7 @@
 """
 ROCM pool2d init
 """
+
 from aitemplate.backend.rocm.pool2d import avg_pool2d, max_pool2d
 
 __all__ = ["avg_pool2d", "max_pool2d"]

--- a/python/aitemplate/backend/rocm/pool2d/avg_pool2d.py
+++ b/python/aitemplate/backend/rocm/pool2d/avg_pool2d.py
@@ -15,6 +15,7 @@
 """
 ROCM avg_pool2d funcs
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.rocm.pool2d import pool2d
 

--- a/python/aitemplate/backend/rocm/pool2d/max_pool2d.py
+++ b/python/aitemplate/backend/rocm/pool2d/max_pool2d.py
@@ -15,6 +15,7 @@
 """
 ROCM max_pool2d funcs
 """
+
 from aitemplate.backend import registry
 from aitemplate.backend.rocm.pool2d import pool2d
 

--- a/python/aitemplate/backend/rocm/pool2d/pool2d.py
+++ b/python/aitemplate/backend/rocm/pool2d/pool2d.py
@@ -15,6 +15,7 @@
 """
 ROCM codegen functions for pool2d.
 """
+
 from hashlib import sha1
 
 import jinja2

--- a/python/aitemplate/backend/rocm/tensor/__init__.py
+++ b/python/aitemplate/backend/rocm/tensor/__init__.py
@@ -15,6 +15,7 @@
 """
 ROCM tensor ops module init
 """
+
 from aitemplate.backend.rocm.tensor import (  # noqa
     argmax,
     batch_gather,

--- a/python/aitemplate/backend/rocm/tensor/concatenate_tanh.py
+++ b/python/aitemplate/backend/rocm/tensor/concatenate_tanh.py
@@ -15,6 +15,7 @@
 """
 Concatenate tanh op for ROCM backend.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/upsample/__init__.py
+++ b/python/aitemplate/backend/rocm/upsample/__init__.py
@@ -15,6 +15,7 @@
 """
 ROCM upsampling module init
 """
+
 from aitemplate.backend.rocm.upsample import upsampling2d, upsampling2d_add
 
 __all__ = ["upsampling2d", "upsampling2d_add"]

--- a/python/aitemplate/backend/rocm/utils.py
+++ b/python/aitemplate/backend/rocm/utils.py
@@ -15,6 +15,7 @@
 """
 Util functions for ROCM.
 """
+
 import os
 import pathlib
 import re

--- a/python/aitemplate/backend/rocm/view_ops/__init__.py
+++ b/python/aitemplate/backend/rocm/view_ops/__init__.py
@@ -15,6 +15,7 @@
 """
 ROCM view_ops module init
 """
+
 from aitemplate.backend.rocm.view_ops import view_ops
 
 __all__ = ["view_ops"]

--- a/python/aitemplate/backend/rocm/view_ops/view_ops.py
+++ b/python/aitemplate/backend/rocm/view_ops/view_ops.py
@@ -15,6 +15,7 @@
 """
 ROCM codegen functions for view ops.
 """
+
 import jinja2
 
 from aitemplate.backend import registry

--- a/python/aitemplate/backend/rocm/vision_ops/__init__.py
+++ b/python/aitemplate/backend/rocm/vision_ops/__init__.py
@@ -15,6 +15,7 @@
 """
 (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 """
+
 from aitemplate.backend.rocm.vision_ops import efficient_nms, nms  # noqa
 from aitemplate.backend.rocm.vision_ops.roi_ops import (  # noqa  # noqa
     multi_level_roi_align,

--- a/python/aitemplate/backend/rocm/vision_ops/roi_ops/__init__.py
+++ b/python/aitemplate/backend/rocm/vision_ops/roi_ops/__init__.py
@@ -15,6 +15,7 @@
 """
 ROCM roi_align module init
 """
+
 from aitemplate.backend.rocm.vision_ops.roi_ops import multi_level_roi_align, roi_align
 
 __all__ = ["roi_align", "multi_level_roi_align"]

--- a/python/aitemplate/backend/target.py
+++ b/python/aitemplate/backend/target.py
@@ -15,6 +15,7 @@
 """
 Target object for AITemplate.
 """
+
 import logging
 import os
 import pathlib

--- a/python/aitemplate/compiler/base.py
+++ b/python/aitemplate/compiler/base.py
@@ -15,6 +15,7 @@
 """
 Basic data types of AITemplate.
 """
+
 from __future__ import annotations
 
 import copy

--- a/python/aitemplate/compiler/compiler.py
+++ b/python/aitemplate/compiler/compiler.py
@@ -15,6 +15,7 @@
 """
 build a test module from a tensor
 """
+
 import logging
 import os
 from datetime import datetime

--- a/python/aitemplate/compiler/dtype.py
+++ b/python/aitemplate/compiler/dtype.py
@@ -16,7 +16,6 @@
 dtype definitions and utility functions of AITemplate
 """
 
-
 _DTYPE2BYTE = {
     "bool": 1,
     "float16": 2,

--- a/python/aitemplate/compiler/model.py
+++ b/python/aitemplate/compiler/model.py
@@ -15,6 +15,7 @@
 """
 Python bindings to the AIT runtime.
 """
+
 import ctypes
 import enum
 import logging
@@ -161,8 +162,8 @@ def _reshape_tensor(tensor: TorchTensor, shape: List[int]) -> TorchTensor:
     Reinterpret a blob of contiguous memory as some shape. Used to convert
     outputs in RunWithTensors.
     """
-    assert tensor.ndim == len(
-        shape
+    assert (
+        tensor.ndim == len(shape)
     ), f"Expected output tensor's ndim to match the length of Run()'s return value: {tensor.ndim=} != {len(shape)=}"
     numel = math.prod(shape)
     new_tensor = tensor.flatten()[:numel]

--- a/python/aitemplate/compiler/op_registry.py
+++ b/python/aitemplate/compiler/op_registry.py
@@ -16,6 +16,7 @@
 """
 Registry for basic operators and math functions.
 """
+
 from typing import Callable, Dict
 
 # OP_REGISTRY defines a mapping from a FuncEnum name to a function to create this elementwise operator.

--- a/python/aitemplate/compiler/ops/__init__.py
+++ b/python/aitemplate/compiler/ops/__init__.py
@@ -16,6 +16,7 @@
 """
 AIT operators.
 """
+
 from aitemplate.compiler.ops.common import *
 from aitemplate.compiler.ops.conv import *
 from aitemplate.compiler.ops.embedding import *

--- a/python/aitemplate/compiler/ops/attention/__init__.py
+++ b/python/aitemplate/compiler/ops/attention/__init__.py
@@ -15,6 +15,7 @@
 """
 flash attention module init
 """
+
 from aitemplate.compiler.ops.attention.flash_attention import flash_attention
 from aitemplate.compiler.ops.attention.mem_eff_attention import mem_eff_attention
 

--- a/python/aitemplate/compiler/ops/attention/flash_attention.py
+++ b/python/aitemplate/compiler/ops/attention/flash_attention.py
@@ -15,6 +15,7 @@
 """
 Flash attention.
 """
+
 import itertools
 from collections import OrderedDict
 from typing import List

--- a/python/aitemplate/compiler/ops/attention/mem_eff_attention.py
+++ b/python/aitemplate/compiler/ops/attention/mem_eff_attention.py
@@ -15,6 +15,7 @@
 """
 Flash attention.
 """
+
 import itertools
 import logging
 from collections import OrderedDict

--- a/python/aitemplate/compiler/ops/common/__init__.py
+++ b/python/aitemplate/compiler/ops/common/__init__.py
@@ -16,6 +16,7 @@
 """
 Common ops.
 """
+
 from aitemplate.compiler.ops.common.elementwise import *
 from aitemplate.compiler.ops.common.int_elementwise import *
 from aitemplate.compiler.ops.common.epilogue import *

--- a/python/aitemplate/compiler/ops/common/elementwise.py
+++ b/python/aitemplate/compiler/ops/common/elementwise.py
@@ -15,6 +15,7 @@
 """
 Elementwise operator definition, which covers UNARY / Binary / Ternary operators.
 """
+
 import functools
 from typing import Any, List
 

--- a/python/aitemplate/compiler/ops/common/fused_elementwise.py
+++ b/python/aitemplate/compiler/ops/common/fused_elementwise.py
@@ -15,6 +15,7 @@
 """
 Fused elementwise operator definition.
 """
+
 from typing import Iterable, List
 
 from aitemplate import backend

--- a/python/aitemplate/compiler/ops/common/int_elementwise.py
+++ b/python/aitemplate/compiler/ops/common/int_elementwise.py
@@ -15,6 +15,7 @@
 """
 Int elementwise operator definition, for integer calcuation on tensor dimensions.
 """
+
 import functools
 from functools import reduce
 

--- a/python/aitemplate/compiler/ops/common/python_ops.py
+++ b/python/aitemplate/compiler/ops/common/python_ops.py
@@ -15,6 +15,7 @@
 """
 Syntax sugar ops to support List/Tuples in the IR. These ops don't generate any code.
 """
+
 from typing import Any, List, Tuple, Union
 
 from aitemplate.compiler.base import IntImm, IntVar, Operator, Tensor

--- a/python/aitemplate/compiler/ops/common/view_ops.py
+++ b/python/aitemplate/compiler/ops/common/view_ops.py
@@ -332,9 +332,7 @@ class reshape(_reshape_base):
                         else:
                             symbol_names = {s.name for s in dynamic_symbol.free_symbols}
                             unknown_symbols = symbol_names - get_global_symbol_set()
-                            assert (
-                                not unknown_symbols
-                            ), f"Unable to deduce dynamic symbol, because the following symbols are not in global symbol set: {unknown_symbols}"
+                            assert not unknown_symbols, f"Unable to deduce dynamic symbol, because the following symbols are not in global symbol set: {unknown_symbols}"
 
                             values = simplify_intvar_values(dynamic_symbol)
                             new_var = IntVar(values, symbolic_value=dynamic_symbol)

--- a/python/aitemplate/compiler/ops/conv/__init__.py
+++ b/python/aitemplate/compiler/ops/conv/__init__.py
@@ -16,6 +16,7 @@
 """
 Conv2d family operators.
 """
+
 from aitemplate.compiler.ops.conv.conv2d import conv2d
 from aitemplate.compiler.ops.conv.conv2d_bias import conv2d_bias
 from aitemplate.compiler.ops.conv.conv2d_bias_add import conv2d_bias_add

--- a/python/aitemplate/compiler/ops/conv/cache_entry.py
+++ b/python/aitemplate/compiler/ops/conv/cache_entry.py
@@ -15,6 +15,7 @@
 """
 Cache entry for conv2d.
 """
+
 from dataclasses import dataclass
 
 # pylint: disable=C0103

--- a/python/aitemplate/compiler/ops/conv/common_conv2d_bias_activation.py
+++ b/python/aitemplate/compiler/ops/conv/common_conv2d_bias_activation.py
@@ -15,6 +15,7 @@
 """
 Fused conv2d_bias_activation op.
 """
+
 from typing import Tuple
 
 from aitemplate.compiler.base import Tensor

--- a/python/aitemplate/compiler/ops/conv/conv2d.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d.py
@@ -15,6 +15,7 @@
 """
 Base class for conv2d.
 """
+
 import itertools
 import logging
 import os

--- a/python/aitemplate/compiler/ops/conv/conv2d_bias.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d_bias.py
@@ -15,6 +15,7 @@
 """
 Conv2d with bias.
 """
+
 from aitemplate.compiler.ops.conv.common_conv2d_bias_activation import (
     conv2d_bias_activation,
 )

--- a/python/aitemplate/compiler/ops/conv/conv2d_bias_add.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d_bias_add.py
@@ -15,6 +15,7 @@
 """
 fused conv2d_bias_add op
 """
+
 from aitemplate.compiler.ops.conv.common_conv2d_bias_add_activation import (
     conv2d_bias_add_activation,
 )

--- a/python/aitemplate/compiler/ops/conv/conv2d_bias_add_hardswish.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d_bias_add_hardswish.py
@@ -15,6 +15,7 @@
 """
 fused conv2d_bias_add_hardswish op, for residual block
 """
+
 from aitemplate.compiler.ops.conv.common_conv2d_bias_add_activation import (
     conv2d_bias_add_activation,
 )

--- a/python/aitemplate/compiler/ops/conv/conv2d_bias_add_relu.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d_bias_add_relu.py
@@ -15,6 +15,7 @@
 """
 fused conv2d_bias_relu_add op, for residual block
 """
+
 from aitemplate.compiler.ops.conv.common_conv2d_bias_add_activation import (
     conv2d_bias_add_activation,
 )

--- a/python/aitemplate/compiler/ops/conv/conv2d_bias_few_channels.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d_bias_few_channels.py
@@ -15,6 +15,7 @@
 """
 Fused conv2d_bias_few_channels op.
 """
+
 from aitemplate.compiler.ops.conv.special_conv2d_bias_activation import (
     special_conv2d_bias_activation,
 )

--- a/python/aitemplate/compiler/ops/conv/conv2d_bias_hardswish.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d_bias_hardswish.py
@@ -15,6 +15,7 @@
 """
 Fused conv2d_bias_hardswish op.
 """
+
 from aitemplate.compiler.ops.conv.common_conv2d_bias_activation import (
     conv2d_bias_activation,
 )

--- a/python/aitemplate/compiler/ops/conv/conv2d_bias_hardswish_few_channels.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d_bias_hardswish_few_channels.py
@@ -15,6 +15,7 @@
 """
 Fused conv2d_bias_hardswish_few_channels op.
 """
+
 from aitemplate.compiler.ops.conv.special_conv2d_bias_activation import (
     special_conv2d_bias_activation,
 )

--- a/python/aitemplate/compiler/ops/conv/conv2d_bias_relu.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d_bias_relu.py
@@ -15,6 +15,7 @@
 """
 Fused conv2d_bias_relu op.
 """
+
 from aitemplate.compiler.ops.conv.common_conv2d_bias_activation import (
     conv2d_bias_activation,
 )

--- a/python/aitemplate/compiler/ops/conv/conv2d_bias_relu_few_channels.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d_bias_relu_few_channels.py
@@ -15,6 +15,7 @@
 """
 Fused conv2d_bias_relu_few_channels op.
 """
+
 from aitemplate.compiler.ops.conv.special_conv2d_bias_activation import (
     special_conv2d_bias_activation,
 )

--- a/python/aitemplate/compiler/ops/conv/conv2d_bias_sigmoid.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d_bias_sigmoid.py
@@ -15,6 +15,7 @@
 """
 Fused conv2d_bias_sigmoid op.
 """
+
 from aitemplate.compiler.ops.conv.common_conv2d_bias_activation import (
     conv2d_bias_activation,
 )

--- a/python/aitemplate/compiler/ops/conv/conv2d_depthwise.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d_depthwise.py
@@ -15,6 +15,7 @@
 """
 Fused conv2d_depthwise op.
 """
+
 from typing import List, Tuple
 
 from aitemplate.compiler.base import Tensor

--- a/python/aitemplate/compiler/ops/conv/conv2d_depthwise_bias.py
+++ b/python/aitemplate/compiler/ops/conv/conv2d_depthwise_bias.py
@@ -15,6 +15,7 @@
 """
 Fused conv2d_depthwise op.
 """
+
 from typing import List, Tuple
 
 from aitemplate.compiler.base import Tensor

--- a/python/aitemplate/compiler/ops/conv/conv3d.py
+++ b/python/aitemplate/compiler/ops/conv/conv3d.py
@@ -16,6 +16,7 @@
 """
 Base class for conv3d.
 """
+
 import itertools
 import logging
 import os

--- a/python/aitemplate/compiler/ops/conv/conv3d_bias.py
+++ b/python/aitemplate/compiler/ops/conv/conv3d_bias.py
@@ -16,6 +16,7 @@
 """
 Conv3d with bias.
 """
+
 from typing import List
 
 from aitemplate.compiler.base import Tensor

--- a/python/aitemplate/compiler/ops/conv/depthwise_conv3d.py
+++ b/python/aitemplate/compiler/ops/conv/depthwise_conv3d.py
@@ -15,6 +15,7 @@
 """
 Base class for depthwise_conv3d.
 """
+
 import itertools
 import re
 from collections import OrderedDict

--- a/python/aitemplate/compiler/ops/conv/special_conv2d_bias_activation.py
+++ b/python/aitemplate/compiler/ops/conv/special_conv2d_bias_activation.py
@@ -15,6 +15,7 @@
 """
 Fused special_conv2d_bias_activation op.
 """
+
 from aitemplate.compiler.base import Tensor
 from aitemplate.compiler.ops.conv.conv2d import conv2d
 from aitemplate.compiler.ops.padding import nhwc3to4, nhwc3to8

--- a/python/aitemplate/compiler/ops/conv/transposed_conv2d_bias_relu.py
+++ b/python/aitemplate/compiler/ops/conv/transposed_conv2d_bias_relu.py
@@ -15,6 +15,7 @@
 """
 Fused transposed_conv2d_bias_relu op.
 """
+
 from aitemplate.compiler.ops.conv.transposed_conv2d_bias import transposed_conv2d_bias
 
 

--- a/python/aitemplate/compiler/ops/embedding/bert_embeddings.py
+++ b/python/aitemplate/compiler/ops/embedding/bert_embeddings.py
@@ -15,6 +15,7 @@
 """
 Operator definition for bert_embeddings.
 """
+
 from aitemplate import backend
 from aitemplate.backend import registry
 from aitemplate.compiler.base import IntImm, Operator, Tensor
@@ -79,10 +80,13 @@ class bert_embeddings(Operator):
             "int64",
         ], f"Expected dtype int/int32/int64 for index, got dtype {dtype_input_ids}"
 
-        assert dtype_word_embeddings in [
-            "float16",
-            "float32",
-        ], f"Expected dtype float16/float32 for embeddings, got dtype {dtype_word_embeddings}"
+        assert (
+            dtype_word_embeddings
+            in [
+                "float16",
+                "float32",
+            ]
+        ), f"Expected dtype float16/float32 for embeddings, got dtype {dtype_word_embeddings}"
 
         # expecting all three ids to have the same shapes
         assert shape_utils.is_same_shape(input_ids.shape(), token_type_ids.shape()), (

--- a/python/aitemplate/compiler/ops/gemm_epilogue_vistor/dual_bmm_rrr_div.py
+++ b/python/aitemplate/compiler/ops/gemm_epilogue_vistor/dual_bmm_rrr_div.py
@@ -15,6 +15,7 @@
 """
 Batch GEMM specialization: BMM_RRR(A, B0) / BMM_RRR(A, B1)
 """
+
 from aitemplate.compiler.base import Tensor
 from aitemplate.compiler.ops.gemm_universal import bmm_rrr
 from aitemplate.compiler.tensor_accessor import TensorAccessor

--- a/python/aitemplate/compiler/ops/gemm_epilogue_vistor/dual_gemm_rcr_fast_gelu.py
+++ b/python/aitemplate/compiler/ops/gemm_epilogue_vistor/dual_gemm_rcr_fast_gelu.py
@@ -15,6 +15,7 @@
 """
 GEMM Specialization: FAST_GELU(GEMM_RCR(A, B)) * GEMM_RCR(A, B1)
 """
+
 from aitemplate.compiler.base import Tensor
 from aitemplate.compiler.ops.gemm_universal.gemm_rcr import gemm_rcr
 from aitemplate.compiler.tensor_accessor import TensorAccessor

--- a/python/aitemplate/compiler/ops/gemm_epilogue_vistor/dual_gemm_rcr_silu.py
+++ b/python/aitemplate/compiler/ops/gemm_epilogue_vistor/dual_gemm_rcr_silu.py
@@ -15,6 +15,7 @@
 """
 GEMM Specialization: SILU(GEMM_RCR(A, B)) * GEMM_RCR(A, B1)
 """
+
 from aitemplate.compiler.base import Tensor
 from aitemplate.compiler.ops.gemm_universal.gemm_rcr import gemm_rcr
 from aitemplate.compiler.tensor_accessor import TensorAccessor

--- a/python/aitemplate/compiler/ops/gemm_epilogue_vistor/gemm_rcr_bias_softmax.py
+++ b/python/aitemplate/compiler/ops/gemm_epilogue_vistor/gemm_rcr_bias_softmax.py
@@ -15,6 +15,7 @@
 """
 Operator definition for gemm_rcr_bias_softmax.
 """
+
 from aitemplate.compiler.base import Tensor
 from aitemplate.compiler.ops.gemm_epilogue_vistor.gemm_rcr_softmax import (
     gemm_rcr_softmax,

--- a/python/aitemplate/compiler/ops/gemm_special/__init__.py
+++ b/python/aitemplate/compiler/ops/gemm_special/__init__.py
@@ -15,6 +15,7 @@
 """
 special gemm ops
 """
+
 from aitemplate.compiler.ops.gemm_special.batched_dense_vec_jagged_2d_mul import (
     batched_dense_vec_jagged_2d_mul,
 )

--- a/python/aitemplate/compiler/ops/gemm_special/batched_dense_vec_jagged_2d_mul.py
+++ b/python/aitemplate/compiler/ops/gemm_special/batched_dense_vec_jagged_2d_mul.py
@@ -16,6 +16,7 @@
 """
 Define batched_dense_vec_jagged_2d_mul op
 """
+
 from typing import List
 
 from aitemplate.backend import registry

--- a/python/aitemplate/compiler/ops/gemm_special/bmm_rrr_k1_tanh.py
+++ b/python/aitemplate/compiler/ops/gemm_special/bmm_rrr_k1_tanh.py
@@ -15,6 +15,7 @@
 """
 Operator definition for bmm_rrr_k1_tanh.
 """
+
 from typing import List
 
 from aitemplate.compiler.base import IntVar, Tensor

--- a/python/aitemplate/compiler/ops/gemm_universal/bmm_softmax_bmm_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/bmm_softmax_bmm_permute.py
@@ -15,6 +15,7 @@
 """
 BMM_RCR + Softmax + BMM_RRR + Permute Specialization
 """
+
 from typing import Tuple
 
 from aitemplate.compiler.base import IntImm, Tensor

--- a/python/aitemplate/compiler/ops/gemm_universal/cache_entry.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/cache_entry.py
@@ -15,6 +15,7 @@
 """
 GEMM profiling cache entries
 """
+
 from dataclasses import dataclass
 
 

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_common.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_common.py
@@ -15,6 +15,7 @@
 """
 Common functions/classes for GEMM ops
 """
+
 import itertools
 import logging
 import math

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias.py
@@ -15,6 +15,7 @@
 """
 GEMM Specialization: GEMM_RCR(A, B) + Bias
 """
+
 from aitemplate.compiler.base import IntImm, Tensor
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr
 from aitemplate.compiler.tensor_accessor import TensorAccessor

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_fast_gelu.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_fast_gelu.py
@@ -15,6 +15,7 @@
 """
 GEMM Specialization: FastGELU(GEMM_RCR(A, B) + Bias)
 """
+
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr_bias
 
 # pylint: disable=C0103,W0223,W0221

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_gelu.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_gelu.py
@@ -15,6 +15,7 @@
 """
 GEMM Specialization: GELU(GEMM_RCR(A, B) + Bias)
 """
+
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr_bias
 
 # pylint: disable=C0103,W0223,W0221

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_hardswish.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_hardswish.py
@@ -15,6 +15,7 @@
 """
 GEMM Specialization: HardSwish(GEMM_RCR(A, B) + Bias)
 """
+
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr_bias
 
 # pylint: disable=C0103,W0223,W0221

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_relu.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_relu.py
@@ -15,6 +15,7 @@
 """
 GEMM Specialization: ReLU(GEMM_RCR(A, B) + Bias)
 """
+
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr_bias
 
 # pylint: disable=C0103,W0223,W0221

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_sigmoid.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_sigmoid.py
@@ -15,6 +15,7 @@
 """
 Sigmoid(GEMM_RCR(A, B) + Bias)
 """
+
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr_bias
 
 # pylint: disable=C0103,W0223,W0221

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_swish.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_swish.py
@@ -15,6 +15,7 @@
 """
 GEMM Specialization: SiLU(GEMM_RCR(A, B) + Bias)
 """
+
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr_bias
 
 # pylint: disable=C0103,W0223,W0221

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_tanh.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_bias_tanh.py
@@ -15,6 +15,7 @@
 """
 GEMM Specialization: Tanh(GEMM_RCR(A, B) + Bias)
 """
+
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr_bias
 
 # pylint: disable=C0103,W0223,W0221

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_fast_gelu.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rcr_fast_gelu.py
@@ -15,6 +15,7 @@
 """
 GEMM Specialization: FastGELU(GEMM_RCR(A, B))
 """
+
 from aitemplate.compiler.ops.gemm_universal import gemm_rcr
 
 # pylint: disable=C0103,W0223,W0221

--- a/python/aitemplate/compiler/ops/gemm_universal/gemm_rrr_bias.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/gemm_rrr_bias.py
@@ -15,6 +15,7 @@
 """
 gemm rrr with bias
 """
+
 from aitemplate.compiler.base import IntImm, Tensor
 from aitemplate.compiler.ops.gemm_universal import gemm_rrr
 from aitemplate.compiler.tensor_accessor import TensorAccessor

--- a/python/aitemplate/compiler/ops/gemm_universal/group_gemm_rcr.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/group_gemm_rcr.py
@@ -15,6 +15,7 @@
 """
 Grouped GEMM Specialization for A[RowMajor], B[ColMajor], C[RowMajor]
 """
+
 import logging
 import re
 from collections import OrderedDict

--- a/python/aitemplate/compiler/ops/gemm_universal/group_gemm_rcr_bias.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/group_gemm_rcr_bias.py
@@ -15,6 +15,7 @@
 """
 Grouped GEMM Specialization: GEMM_RCR(A, B) + Bias
 """
+
 from collections import OrderedDict
 from typing import List
 

--- a/python/aitemplate/compiler/ops/gemm_universal/group_gemm_rcr_bias_relu.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/group_gemm_rcr_bias_relu.py
@@ -12,8 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-"""Grouped GEMM Specialization: ReLU(GEMM_RCR(A, B) + Bias)
-"""
+"""Grouped GEMM Specialization: ReLU(GEMM_RCR(A, B) + Bias)"""
 
 from aitemplate.compiler.ops.gemm_universal import group_gemm_rcr_bias
 

--- a/python/aitemplate/compiler/ops/gemm_universal/group_gemm_rcr_bias_sigmoid.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/group_gemm_rcr_bias_sigmoid.py
@@ -12,8 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-"""Grouped GEMM Specialization: Sigmoid(GEMM_RCR(A, B) + Bias)
-"""
+"""Grouped GEMM Specialization: Sigmoid(GEMM_RCR(A, B) + Bias)"""
 
 from aitemplate.compiler.ops.gemm_universal import group_gemm_rcr_bias
 

--- a/python/aitemplate/compiler/ops/gemm_universal/perm021fc_ccr_bias_permute.py
+++ b/python/aitemplate/compiler/ops/gemm_universal/perm021fc_ccr_bias_permute.py
@@ -15,6 +15,7 @@
 """
 GEMM Specialization: (A.permute(0, 2, 1)[col] @ B[col] + Bias).permute(0, 2, 1)
 """
+
 from aitemplate.compiler.base import Tensor
 from aitemplate.compiler.ops.common.view_ops import reshape
 from aitemplate.compiler.ops.gemm_universal.perm021fc_ccr_bias import perm021fc_ccr_bias

--- a/python/aitemplate/compiler/ops/groupnorm/groupnorm.py
+++ b/python/aitemplate/compiler/ops/groupnorm/groupnorm.py
@@ -15,6 +15,7 @@
 """
 Operator definition for groupnorm.
 """
+
 import itertools
 import logging
 import os

--- a/python/aitemplate/compiler/ops/jagged/jagged_lengths_to_offsets.py
+++ b/python/aitemplate/compiler/ops/jagged/jagged_lengths_to_offsets.py
@@ -15,6 +15,7 @@
 """
 Define jagged_lengths_to_offsets op
 """
+
 from typing import List
 
 from aitemplate.backend import registry

--- a/python/aitemplate/compiler/ops/jagged/jagged_lengths_to_presences.py
+++ b/python/aitemplate/compiler/ops/jagged/jagged_lengths_to_presences.py
@@ -15,6 +15,7 @@
 """
 Define jagged_lengths_to_presences op
 """
+
 from typing import List
 
 from aitemplate.backend import registry

--- a/python/aitemplate/compiler/ops/layernorm/batch_layernorm_sigmoid_mul.py
+++ b/python/aitemplate/compiler/ops/layernorm/batch_layernorm_sigmoid_mul.py
@@ -17,6 +17,7 @@ x: [b, m, n]
 gamma: [b, n]
 beta: [b, n]
 """
+
 from typing import List
 
 from aitemplate.compiler.base import IntImm

--- a/python/aitemplate/compiler/ops/layernorm/group_layernorm.py
+++ b/python/aitemplate/compiler/ops/layernorm/group_layernorm.py
@@ -15,6 +15,7 @@
 """
 Operator definition for group_layernorm.
 """
+
 from typing import Any, List
 
 from aitemplate.compiler.base import IntImm, IntVarTensor, Tensor

--- a/python/aitemplate/compiler/ops/layernorm/group_layernorm_sigmoid_mul.py
+++ b/python/aitemplate/compiler/ops/layernorm/group_layernorm_sigmoid_mul.py
@@ -15,6 +15,7 @@
 """
 Operator definition for group_layernorm_sigmoid_mul.
 """
+
 from typing import List
 
 from aitemplate.compiler.base import IntImm

--- a/python/aitemplate/compiler/ops/layernorm/layernorm.py
+++ b/python/aitemplate/compiler/ops/layernorm/layernorm.py
@@ -15,6 +15,7 @@
 """
 Operator definition for layernorm.
 """
+
 import logging
 import os
 import re

--- a/python/aitemplate/compiler/ops/layernorm/layernorm_sigmoid_mul.py
+++ b/python/aitemplate/compiler/ops/layernorm/layernorm_sigmoid_mul.py
@@ -15,6 +15,7 @@
 """
 Operator definition for layernorm_sigmoid_mul.
 """
+
 from aitemplate import backend
 from aitemplate.backend import registry
 from aitemplate.compiler.base import Operator

--- a/python/aitemplate/compiler/ops/padding/__init__.py
+++ b/python/aitemplate/compiler/ops/padding/__init__.py
@@ -15,6 +15,7 @@
 """
 Padding ops module init.
 """
+
 from aitemplate.compiler.ops.padding.ndhwc3to8 import ndhwc3to8
 from aitemplate.compiler.ops.padding.nhwc3to4 import nhwc3to4
 from aitemplate.compiler.ops.padding.nhwc3to8 import nhwc3to8

--- a/python/aitemplate/compiler/ops/padding/ndhwc3to8.py
+++ b/python/aitemplate/compiler/ops/padding/ndhwc3to8.py
@@ -15,6 +15,7 @@
 """
 Common NDHWC3to8 padding op
 """
+
 import itertools
 from typing import List
 

--- a/python/aitemplate/compiler/ops/padding/nhwc_pad_common.py
+++ b/python/aitemplate/compiler/ops/padding/nhwc_pad_common.py
@@ -15,6 +15,7 @@
 """
 Common NHWC padding ops
 """
+
 import itertools
 from typing import List
 

--- a/python/aitemplate/compiler/ops/padding/pad_last_dim.py
+++ b/python/aitemplate/compiler/ops/padding/pad_last_dim.py
@@ -15,6 +15,7 @@
 """
 Pad last dimension.
 """
+
 from typing import List
 
 import jinja2

--- a/python/aitemplate/compiler/ops/pool/__init__.py
+++ b/python/aitemplate/compiler/ops/pool/__init__.py
@@ -15,6 +15,7 @@
 """
 Pool module init.
 """
+
 from aitemplate.compiler.ops.pool.avg_pool2d import avg_pool2d
 from aitemplate.compiler.ops.pool.max_pool2d import max_pool2d
 

--- a/python/aitemplate/compiler/ops/pool/avg_pool2d.py
+++ b/python/aitemplate/compiler/ops/pool/avg_pool2d.py
@@ -15,6 +15,7 @@
 """
 Avg_pool2d op.
 """
+
 from aitemplate.compiler.ops.pool.pool2d import pool2d_base
 
 

--- a/python/aitemplate/compiler/ops/pool/max_pool2d.py
+++ b/python/aitemplate/compiler/ops/pool/max_pool2d.py
@@ -15,6 +15,7 @@
 """
 Max_pool2d op.
 """
+
 from aitemplate.compiler.ops.pool.pool2d import pool2d_base
 
 

--- a/python/aitemplate/compiler/ops/pool/pool2d.py
+++ b/python/aitemplate/compiler/ops/pool/pool2d.py
@@ -15,6 +15,7 @@
 """
 Pool2d.
 """
+
 import itertools
 import logging
 import re

--- a/python/aitemplate/compiler/ops/reduce/__init__.py
+++ b/python/aitemplate/compiler/ops/reduce/__init__.py
@@ -15,6 +15,7 @@
 """
 Reduce module init.
 """
+
 from aitemplate.compiler.ops.reduce.reduce_max import reduce_max
 from aitemplate.compiler.ops.reduce.reduce_mean import reduce_mean
 from aitemplate.compiler.ops.reduce.reduce_min import reduce_min

--- a/python/aitemplate/compiler/ops/reduce/reduce_common.py
+++ b/python/aitemplate/compiler/ops/reduce/reduce_common.py
@@ -15,6 +15,7 @@
 """
 Base operator definition for reduce-family ops.
 """
+
 import itertools
 import logging
 

--- a/python/aitemplate/compiler/ops/reduce/reduce_max.py
+++ b/python/aitemplate/compiler/ops/reduce/reduce_max.py
@@ -15,6 +15,7 @@
 """
 reduce_max op
 """
+
 from aitemplate.compiler.ops.reduce.reduce_common import reduce_base
 
 # pylint: disable=C0103

--- a/python/aitemplate/compiler/ops/reduce/reduce_mean.py
+++ b/python/aitemplate/compiler/ops/reduce/reduce_mean.py
@@ -15,6 +15,7 @@
 """
 Reduce_mean op implementation.
 """
+
 from aitemplate.compiler.ops.reduce.reduce_common import reduce_base
 
 # pylint: disable=C0103

--- a/python/aitemplate/compiler/ops/reduce/reduce_min.py
+++ b/python/aitemplate/compiler/ops/reduce/reduce_min.py
@@ -15,6 +15,7 @@
 """
 reduce_min op
 """
+
 from aitemplate.compiler.ops.reduce.reduce_common import reduce_base
 
 # pylint: disable=C0103

--- a/python/aitemplate/compiler/ops/reduce/reduce_sum.py
+++ b/python/aitemplate/compiler/ops/reduce/reduce_sum.py
@@ -15,6 +15,7 @@
 """
 reduce_sum op
 """
+
 from aitemplate.compiler.ops.reduce.reduce_common import reduce_base
 
 # pylint: disable=C0103

--- a/python/aitemplate/compiler/ops/reduce/var.py
+++ b/python/aitemplate/compiler/ops/reduce/var.py
@@ -15,6 +15,7 @@
 """
 var op implementation
 """
+
 from aitemplate.compiler.ops.reduce.reduce_common import reduce_base
 
 # pylint: disable=C0103

--- a/python/aitemplate/compiler/ops/reduce/vector_norm.py
+++ b/python/aitemplate/compiler/ops/reduce/vector_norm.py
@@ -16,6 +16,7 @@
 vector_norm op implementation that simulates pytorch's linalg.vector_norm.
 Currently, we only support L2 norm.
 """
+
 from aitemplate.compiler.ops.reduce.reduce_common import reduce_base
 
 # pylint: disable=C0103

--- a/python/aitemplate/compiler/ops/softmax/__init__.py
+++ b/python/aitemplate/compiler/ops/softmax/__init__.py
@@ -15,6 +15,7 @@
 """
 softmax module init
 """
+
 from aitemplate.compiler.ops.softmax.softmax import softmax
 
 

--- a/python/aitemplate/compiler/ops/softmax/cache_entry.py
+++ b/python/aitemplate/compiler/ops/softmax/cache_entry.py
@@ -15,6 +15,7 @@
 """
 Softmax cache entry.
 """
+
 from dataclasses import dataclass
 
 # pylint: disable=C0103

--- a/python/aitemplate/compiler/ops/softmax/softmax.py
+++ b/python/aitemplate/compiler/ops/softmax/softmax.py
@@ -15,6 +15,7 @@
 """
 Softmax op implementation
 """
+
 import logging
 import os
 import re

--- a/python/aitemplate/compiler/ops/tensor/__init__.py
+++ b/python/aitemplate/compiler/ops/tensor/__init__.py
@@ -16,6 +16,7 @@
 """
 reduce module init
 """
+
 from aitemplate.compiler.ops.tensor.argmax import argmax
 from aitemplate.compiler.ops.tensor.batch_gather import batch_gather
 from aitemplate.compiler.ops.tensor.cast import cast

--- a/python/aitemplate/compiler/ops/tensor/argmax.py
+++ b/python/aitemplate/compiler/ops/tensor/argmax.py
@@ -15,6 +15,7 @@
 """
 Argmax.
 """
+
 import itertools
 import logging
 import os

--- a/python/aitemplate/compiler/ops/tensor/batch_gather.py
+++ b/python/aitemplate/compiler/ops/tensor/batch_gather.py
@@ -15,6 +15,7 @@
 """
 Batch_gather.
 """
+
 import itertools
 from collections import OrderedDict
 from typing import List
@@ -73,11 +74,14 @@ class batch_gather(Operator):
 
     def __call__(self, x: Tensor, indices: Tensor) -> Tensor:
         dtype = indices._attrs["dtype"]
-        assert dtype in [
-            "int",
-            "int32",
-            "int64",
-        ], f"batch_gather(): Expected dtype int/int32/int64 for index, got dtype {dtype}"
+        assert (
+            dtype
+            in [
+                "int",
+                "int32",
+                "int64",
+            ]
+        ), f"batch_gather(): Expected dtype int/int32/int64 for index, got dtype {dtype}"
         self._attrs["inputs"] = [x, indices]
         self._set_depth()
         self._extract_exec_path(x)

--- a/python/aitemplate/compiler/ops/tensor/chunk.py
+++ b/python/aitemplate/compiler/ops/tensor/chunk.py
@@ -15,6 +15,7 @@
 """
 chunk
 """
+
 import math
 
 from typing import List

--- a/python/aitemplate/compiler/ops/tensor/concatenate.py
+++ b/python/aitemplate/compiler/ops/tensor/concatenate.py
@@ -15,6 +15,7 @@
 """
 Concatenate.
 """
+
 from copy import deepcopy
 from functools import reduce
 from typing import List, Optional, Sequence, Tuple, Union

--- a/python/aitemplate/compiler/ops/tensor/concatenate_tanh.py
+++ b/python/aitemplate/compiler/ops/tensor/concatenate_tanh.py
@@ -15,6 +15,7 @@
 """
 Concatenate_tanh
 """
+
 from aitemplate.compiler.ops.tensor import concatenate
 
 # pylint: disable=C0103

--- a/python/aitemplate/compiler/ops/tensor/dynamic_slice.py
+++ b/python/aitemplate/compiler/ops/tensor/dynamic_slice.py
@@ -15,6 +15,7 @@
 """
 Dynamic_slice.
 """
+
 from typing import List, Optional, Union
 
 import sympy

--- a/python/aitemplate/compiler/ops/tensor/gather.py
+++ b/python/aitemplate/compiler/ops/tensor/gather.py
@@ -15,6 +15,7 @@
 """
 Operator definition for gather.
 """
+
 from aitemplate import backend
 from aitemplate.backend import registry
 from aitemplate.compiler.base import Operator, Tensor

--- a/python/aitemplate/compiler/ops/tensor/identity.py
+++ b/python/aitemplate/compiler/ops/tensor/identity.py
@@ -15,6 +15,7 @@
 """
 identity op
 """
+
 from typing import List
 
 from aitemplate import backend

--- a/python/aitemplate/compiler/ops/tensor/jagged_to_padded_dense.py
+++ b/python/aitemplate/compiler/ops/tensor/jagged_to_padded_dense.py
@@ -16,6 +16,7 @@
 """
 Define jagged_to_padded_dense op
 """
+
 import logging
 from typing import List
 

--- a/python/aitemplate/compiler/ops/tensor/masked_select.py
+++ b/python/aitemplate/compiler/ops/tensor/masked_select.py
@@ -15,6 +15,7 @@
 """
 Define masked_select op
 """
+
 import logging
 from typing import List
 

--- a/python/aitemplate/compiler/ops/tensor/padded_dense_to_jagged.py
+++ b/python/aitemplate/compiler/ops/tensor/padded_dense_to_jagged.py
@@ -16,6 +16,7 @@
 """
 The front-end definition of the padded_dense_to_jagged op.
 """
+
 from typing import List
 
 from aitemplate.backend import registry

--- a/python/aitemplate/compiler/ops/tensor/permute.py
+++ b/python/aitemplate/compiler/ops/tensor/permute.py
@@ -15,6 +15,7 @@
 """
 permute op
 """
+
 from typing import List, Sequence
 
 from aitemplate import backend

--- a/python/aitemplate/compiler/ops/tensor/permute021.py
+++ b/python/aitemplate/compiler/ops/tensor/permute021.py
@@ -15,6 +15,7 @@
 """
 permute(0, 2, 1) op
 """
+
 from typing import List
 
 from aitemplate import backend

--- a/python/aitemplate/compiler/ops/tensor/permute0213.py
+++ b/python/aitemplate/compiler/ops/tensor/permute0213.py
@@ -16,6 +16,7 @@
 Permute(0, 2, 1, 3) op.
 Change the dimensions dim1 and dim2 of input 4d tensor.
 """
+
 from typing import List
 
 from aitemplate import backend

--- a/python/aitemplate/compiler/ops/tensor/permute102.py
+++ b/python/aitemplate/compiler/ops/tensor/permute102.py
@@ -16,6 +16,7 @@
 Permute(1, 0, 2) op.
 Change the dimension of dim0 and dim1 of input 3d tensor.
 """
+
 from typing import List
 
 from aitemplate import backend

--- a/python/aitemplate/compiler/ops/tensor/permute210.py
+++ b/python/aitemplate/compiler/ops/tensor/permute210.py
@@ -16,6 +16,7 @@
 Permute(2, 1, 0) op.
 Swap the dimension of dim0 and dim2 of input 3d tensor.
 """
+
 from typing import List
 
 from aitemplate import backend

--- a/python/aitemplate/compiler/ops/tensor/size.py
+++ b/python/aitemplate/compiler/ops/tensor/size.py
@@ -15,6 +15,7 @@
 """
 Op to return the size of a tensor.
 """
+
 from typing import List, Union
 
 from aitemplate import backend

--- a/python/aitemplate/compiler/ops/tensor/slice_reshape_scatter.py
+++ b/python/aitemplate/compiler/ops/tensor/slice_reshape_scatter.py
@@ -15,6 +15,7 @@
 """
 Slice_reshape_scatter.
 """
+
 from typing import Optional
 
 from aitemplate import backend

--- a/python/aitemplate/compiler/ops/tensor/split.py
+++ b/python/aitemplate/compiler/ops/tensor/split.py
@@ -15,6 +15,7 @@
 """
 Split.
 """
+
 from typing import List, Sequence, Union
 
 from aitemplate import backend

--- a/python/aitemplate/compiler/ops/tensor/topk.py
+++ b/python/aitemplate/compiler/ops/tensor/topk.py
@@ -15,6 +15,7 @@
 """
 Topk.
 """
+
 import itertools
 import logging
 import os

--- a/python/aitemplate/compiler/ops/tensor/where.py
+++ b/python/aitemplate/compiler/ops/tensor/where.py
@@ -71,8 +71,8 @@ class where(Operator):
                 if common_dtype is None:
                     common_dtype = normalize_dtype(tensor.dtype())
                 else:
-                    assert common_dtype == normalize_dtype(
-                        tensor.dtype()
+                    assert (
+                        common_dtype == normalize_dtype(tensor.dtype())
                     ), f"Expect tensor of the same dtype, got {common_dtype} and {normalize_dtype(tensor.dtype())}"
                 inputs.append(tensor)
 

--- a/python/aitemplate/compiler/ops/upsample/__init__.py
+++ b/python/aitemplate/compiler/ops/upsample/__init__.py
@@ -15,6 +15,7 @@
 """
 Upsampling module init.
 """
+
 from aitemplate.compiler.ops.upsample.upsampling2d import upsampling2d
 from aitemplate.compiler.ops.upsample.upsampling2d_add import upsampling2d_add
 

--- a/python/aitemplate/compiler/ops/upsample/upsampling2d.py
+++ b/python/aitemplate/compiler/ops/upsample/upsampling2d.py
@@ -15,6 +15,7 @@
 """
 Upsampling2d op.
 """
+
 from aitemplate.compiler.ops.upsample.upsampling_common import upsampling2d_base
 
 

--- a/python/aitemplate/compiler/ops/upsample/upsampling2d_add.py
+++ b/python/aitemplate/compiler/ops/upsample/upsampling2d_add.py
@@ -15,6 +15,7 @@
 """
 Upsampling2d_add op.
 """
+
 from typing import List
 
 from aitemplate.compiler.base import Tensor

--- a/python/aitemplate/compiler/ops/upsample/upsampling_common.py
+++ b/python/aitemplate/compiler/ops/upsample/upsampling_common.py
@@ -15,6 +15,7 @@
 """
 upsampling2d.
 """
+
 import itertools
 import logging
 import re

--- a/python/aitemplate/compiler/ops/vision_ops/__init__.py
+++ b/python/aitemplate/compiler/ops/vision_ops/__init__.py
@@ -15,5 +15,6 @@
 """
 Vision ops module init.
 """
+
 from aitemplate.compiler.ops.vision_ops.nms import *  # noqa
 from aitemplate.compiler.ops.vision_ops.roi_ops import *  # noqa

--- a/python/aitemplate/compiler/ops/vision_ops/nms/__init__.py
+++ b/python/aitemplate/compiler/ops/vision_ops/nms/__init__.py
@@ -15,6 +15,7 @@
 """
 Nms family ops.
 """
+
 from aitemplate.compiler.ops.vision_ops.nms.batched_nms import batched_nms
 from aitemplate.compiler.ops.vision_ops.nms.efficient_nms import efficient_nms
 from aitemplate.compiler.ops.vision_ops.nms.nms import nms

--- a/python/aitemplate/compiler/ops/vision_ops/nms/batched_nms.py
+++ b/python/aitemplate/compiler/ops/vision_ops/nms/batched_nms.py
@@ -15,6 +15,7 @@
 """
 Batched nms.
 """
+
 import itertools
 from typing import List
 

--- a/python/aitemplate/compiler/ops/vision_ops/nms/efficient_nms.py
+++ b/python/aitemplate/compiler/ops/vision_ops/nms/efficient_nms.py
@@ -15,6 +15,7 @@
 """
 Efficient nms.
 """
+
 import itertools
 import logging
 import os

--- a/python/aitemplate/compiler/ops/vision_ops/nms/nms.py
+++ b/python/aitemplate/compiler/ops/vision_ops/nms/nms.py
@@ -15,6 +15,7 @@
 """
 Nms.
 """
+
 import itertools
 import logging
 import os

--- a/python/aitemplate/compiler/ops/vision_ops/roi_ops/__init__.py
+++ b/python/aitemplate/compiler/ops/vision_ops/roi_ops/__init__.py
@@ -15,6 +15,7 @@
 """
 Roi-align module init.
 """
+
 from aitemplate.compiler.ops.vision_ops.roi_ops.multi_level_roi_align import (
     multi_level_roi_align,
 )

--- a/python/aitemplate/compiler/ops/vision_ops/roi_ops/roi_align.py
+++ b/python/aitemplate/compiler/ops/vision_ops/roi_ops/roi_align.py
@@ -15,6 +15,7 @@
 """
 Roi_align.
 """
+
 from aitemplate.compiler.ops.vision_ops.roi_ops.roi_ops import roi_ops_base
 
 

--- a/python/aitemplate/compiler/ops/vision_ops/roi_ops/roi_ops.py
+++ b/python/aitemplate/compiler/ops/vision_ops/roi_ops/roi_ops.py
@@ -15,6 +15,7 @@
 """
 Roi.
 """
+
 import itertools
 import logging
 import re

--- a/python/aitemplate/compiler/stable_set.py
+++ b/python/aitemplate/compiler/stable_set.py
@@ -19,6 +19,7 @@ It also tries to preserve the original element order as much as possible, which 
 potentially make debugging (e.g. comparison with the original graph, comparison between
 AIT GPU trace and other GPU traces) easier.
 """
+
 from collections import abc
 from typing import Any, Iterable
 

--- a/python/aitemplate/compiler/symbolic.py
+++ b/python/aitemplate/compiler/symbolic.py
@@ -35,6 +35,7 @@ new_var = IntVar(..., symbolic_value=new_sym)
 
 For more advanced usage on Sympy, check: https://docs.sympy.org/latest/tutorials/intro-tutorial/intro.html
 """
+
 from __future__ import annotations
 
 import itertools

--- a/python/aitemplate/compiler/transform/apply_padding.py
+++ b/python/aitemplate/compiler/transform/apply_padding.py
@@ -15,6 +15,7 @@
 """
 Applies paddings to gemms based on alignment requirements.
 """
+
 import logging
 from typing import Callable, Dict, List
 

--- a/python/aitemplate/compiler/transform/dedup_make_jagged_ops.py
+++ b/python/aitemplate/compiler/transform/dedup_make_jagged_ops.py
@@ -15,6 +15,7 @@
 """
 Deduplicate make_jagged ops in the graph.
 """
+
 import logging
 from dataclasses import dataclass
 from typing import Dict, List, Set

--- a/python/aitemplate/compiler/transform/fuse_bmm_permute.py
+++ b/python/aitemplate/compiler/transform/fuse_bmm_permute.py
@@ -17,6 +17,7 @@ Perform fusions for bmm + permute021 operators:
     bmm_xxc + permute021 -> bmm_xxr
     bmm_xxr + permute021 -> bmm_xxc
 """
+
 from typing import List
 
 from aitemplate.compiler.base import Tensor

--- a/python/aitemplate/compiler/transform/fuse_conv_elementwise.py
+++ b/python/aitemplate/compiler/transform/fuse_conv_elementwise.py
@@ -15,6 +15,7 @@
 """
 Fuse conv + elementwise ops.
 """
+
 from typing import List
 
 from aitemplate.compiler.base import Tensor

--- a/python/aitemplate/compiler/transform/fuse_expand_bmm.py
+++ b/python/aitemplate/compiler/transform/fuse_expand_bmm.py
@@ -23,6 +23,7 @@ This pass performs the following fusion:
 The basic idea behind the transformation is that we leverage bmm's
 broadcasting capability to achieve the same functionality as expand.
 """
+
 from typing import List
 
 from aitemplate.compiler.base import Operator, Tensor

--- a/python/aitemplate/compiler/transform/fuse_group_ops.py
+++ b/python/aitemplate/compiler/transform/fuse_group_ops.py
@@ -15,6 +15,7 @@
 """
 Horizontal fusion pass to group ops together.
 """
+
 import collections
 import logging
 import os

--- a/python/aitemplate/compiler/transform/fuse_mm_elementwise.py
+++ b/python/aitemplate/compiler/transform/fuse_mm_elementwise.py
@@ -15,6 +15,7 @@
 """
 Fuse GEMM with elementwise operations
 """
+
 from typing import List
 
 from aitemplate.compiler.base import Tensor

--- a/python/aitemplate/compiler/transform/fuse_mm_reshape_permute.py
+++ b/python/aitemplate/compiler/transform/fuse_mm_reshape_permute.py
@@ -15,6 +15,7 @@
 """
 Fuse GEMM + reshape + permute0213
 """
+
 from typing import List, Sequence
 
 from aitemplate.compiler.base import IntImm, Operator, Tensor

--- a/python/aitemplate/compiler/transform/fuse_ops.py
+++ b/python/aitemplate/compiler/transform/fuse_ops.py
@@ -15,6 +15,7 @@
 """
 Perform operator fusions.
 """
+
 import collections
 import itertools
 import logging

--- a/python/aitemplate/compiler/transform/fuse_permute_bmm_and_gemm.py
+++ b/python/aitemplate/compiler/transform/fuse_permute_bmm_and_gemm.py
@@ -15,6 +15,7 @@
 """
 Perform fusions for permute+bmm operators.
 """
+
 from typing import Callable, List, Optional, Set, Tuple, Type, Union
 
 from aitemplate.compiler import ops

--- a/python/aitemplate/compiler/transform/fuse_split.py
+++ b/python/aitemplate/compiler/transform/fuse_split.py
@@ -15,6 +15,7 @@
 """
 Perform transformations on ops which support strided inputs / outputs.
 """
+
 import logging
 from typing import List
 

--- a/python/aitemplate/compiler/transform/mark_param_tensor.py
+++ b/python/aitemplate/compiler/transform/mark_param_tensor.py
@@ -15,6 +15,7 @@
 """
 mark tensors which are parameters
 """
+
 from typing import List
 
 from aitemplate.compiler.base import Tensor

--- a/python/aitemplate/compiler/transform/memory_planning.py
+++ b/python/aitemplate/compiler/transform/memory_planning.py
@@ -15,6 +15,7 @@
 """
 Graph pass for memory planning.
 """
+
 import bisect
 import logging
 from collections import defaultdict

--- a/python/aitemplate/compiler/transform/move_view_ops.py
+++ b/python/aitemplate/compiler/transform/move_view_ops.py
@@ -16,6 +16,7 @@
 This pass move any view op between two concatenate ops to the front of the
 first concatenate op if possible.
 """
+
 import copy
 from typing import Callable, List, Optional, Tuple
 

--- a/python/aitemplate/compiler/transform/name_graph.py
+++ b/python/aitemplate/compiler/transform/name_graph.py
@@ -15,6 +15,7 @@
 """
 Graph pass to assign names to a sorted graph.
 """
+
 import logging
 import re
 from typing import List

--- a/python/aitemplate/compiler/transform/optimize_graph.py
+++ b/python/aitemplate/compiler/transform/optimize_graph.py
@@ -15,6 +15,7 @@
 """
 Applies graph transformations.
 """
+
 from typing import List
 
 from aitemplate.compiler.base import Tensor

--- a/python/aitemplate/compiler/transform/profile.py
+++ b/python/aitemplate/compiler/transform/profile.py
@@ -15,6 +15,7 @@
 """
 Graph pass to invoke profiling.
 """
+
 import logging
 import os
 from collections import OrderedDict

--- a/python/aitemplate/compiler/transform/profile_dynamic_dim.py
+++ b/python/aitemplate/compiler/transform/profile_dynamic_dim.py
@@ -15,6 +15,7 @@
 """
 Graph pass to invoke profiling with dynamic shapes.
 """
+
 import logging
 from collections import OrderedDict
 from copy import deepcopy

--- a/python/aitemplate/compiler/transform/refine_graph.py
+++ b/python/aitemplate/compiler/transform/refine_graph.py
@@ -15,6 +15,7 @@
 """
 Graph pass to dedup operators with same signatures.
 """
+
 import logging
 from typing import List
 

--- a/python/aitemplate/compiler/transform/remove_elementwise_no_ops.py
+++ b/python/aitemplate/compiler/transform/remove_elementwise_no_ops.py
@@ -15,6 +15,7 @@
 """
 Eliminate elementwise no-ops (*/1, +-0)
 """
+
 from typing import Callable, Dict, List
 
 from aitemplate.compiler.base import Tensor
@@ -67,7 +68,6 @@ def remove_elementwise_no_ops(
 ) -> List[Tensor]:
     """elementwise no-ops (*/1, +-0)"""
     for tensor in sorted_graph:
-
         src_ops = tensor._attrs["src_ops"]
         if len(src_ops) != 1:
             continue

--- a/python/aitemplate/compiler/transform/remove_no_ops.py
+++ b/python/aitemplate/compiler/transform/remove_no_ops.py
@@ -29,6 +29,7 @@ Also, even if the passes in this file avoided sanitize_sorted_graph,
 many other unrelated passes use sanitize_sorted_graph. We don't need to
 call the passes in this file more than once.
 """
+
 from typing import List
 
 from aitemplate.compiler.base import IntImm, IntVar, JaggedIntVar, Operator, Tensor

--- a/python/aitemplate/compiler/transform/remove_unused_ops.py
+++ b/python/aitemplate/compiler/transform/remove_unused_ops.py
@@ -15,6 +15,7 @@
 """
 Remove useless operators from a sorted_graph.
 """
+
 from collections import deque
 from typing import List
 

--- a/python/aitemplate/compiler/transform/split_large_concat_ops.py
+++ b/python/aitemplate/compiler/transform/split_large_concat_ops.py
@@ -17,6 +17,7 @@ This transformation splits a concat with a large number of inputs into multiple
 concat ops, which share the same inputs with correct input_masks and the same
 output.
 """
+
 import copy
 import logging
 

--- a/python/aitemplate/compiler/transform/split_large_slice_scatter_ops.py
+++ b/python/aitemplate/compiler/transform/split_large_slice_scatter_ops.py
@@ -16,6 +16,7 @@
 This transformation splits a slice_scatter or slice_reshape_scatter with a large
 number of inputs into multiple slice_scatter or slice_reshape_scatter ops.
 """
+
 import copy
 import logging
 

--- a/python/aitemplate/compiler/transform/split_large_split_ops.py
+++ b/python/aitemplate/compiler/transform/split_large_split_ops.py
@@ -16,6 +16,7 @@
 This transformation splits a split with a large number of outputs into multiple
 splitt ops, which share the same input with correct output_masks.
 """
+
 import logging
 
 from typing import List

--- a/python/aitemplate/compiler/transform/toposort.py
+++ b/python/aitemplate/compiler/transform/toposort.py
@@ -15,6 +15,7 @@
 """
 Graph pass for topological sort.
 """
+
 import heapq
 from typing import List, Tuple, Union
 

--- a/python/aitemplate/compiler/transform/transform_memory_ops.py
+++ b/python/aitemplate/compiler/transform/transform_memory_ops.py
@@ -15,6 +15,7 @@
 """
 Perform memory operator related transformations.
 """
+
 import copy
 from typing import List
 

--- a/python/aitemplate/compiler/transform/transform_merge_slice_ops.py
+++ b/python/aitemplate/compiler/transform/transform_merge_slice_ops.py
@@ -15,6 +15,7 @@
 """
 This file implements a pass that merges consecutive slice ops if possible.
 """
+
 from typing import List, Optional
 
 from aitemplate.compiler.base import IntImm, IntVar, Operator, Tensor

--- a/python/aitemplate/compiler/transform/transform_merge_view_ops.py
+++ b/python/aitemplate/compiler/transform/transform_merge_view_ops.py
@@ -15,6 +15,7 @@
 """
 This file implements a pass that merges consecutive view ops if possible.
 """
+
 from typing import List, Set
 
 from aitemplate.compiler import ops

--- a/python/aitemplate/compiler/transform/transform_odd_alignment.py
+++ b/python/aitemplate/compiler/transform/transform_odd_alignment.py
@@ -15,6 +15,7 @@
 """
 Add permute for gemm/bmm if alignment is odd.
 """
+
 from math import inf
 from typing import Dict, List, Tuple
 

--- a/python/aitemplate/compiler/transform/transform_permute_to_reshape.py
+++ b/python/aitemplate/compiler/transform/transform_permute_to_reshape.py
@@ -15,6 +15,7 @@
 """
 Transform permute to reshape wherever applicable.
 """
+
 from typing import List
 
 from aitemplate.compiler.base import IntImm, Operator, Tensor

--- a/python/aitemplate/compiler/transform/transform_special_ops.py
+++ b/python/aitemplate/compiler/transform/transform_special_ops.py
@@ -16,6 +16,7 @@
 Perform graph transformation specifically for gemm -> gemm_special.
 Check each transform function summary for specific pattern to be transformed.
 """
+
 from typing import Callable, List, Tuple, Type, Union
 
 from aitemplate.compiler import ops

--- a/python/aitemplate/compiler/transform/transform_strided_op_and_view_op.py
+++ b/python/aitemplate/compiler/transform/transform_strided_op_and_view_op.py
@@ -88,9 +88,7 @@ def _fuse_strided_op_and_view_op_single_pass(
                     tensor._attrs["src_ops"] = StableSet({src_op})
                     transform_utils.remove_tensor_from_sorted_graph(view_input_tensor)
                     break
-            assert (
-                found_tensor
-            ), f"Cannot find view_input_tensor {view_input_tensor} from src_op outputs {src_op._attrs['outputs']}!"
+            assert found_tensor, f"Cannot find view_input_tensor {view_input_tensor} from src_op outputs {src_op._attrs['outputs']}!"
         else:
             if tensor._attrs["is_output"]:
                 continue
@@ -115,9 +113,7 @@ def _fuse_strided_op_and_view_op_single_pass(
                         accessor.update_base_tensor_shape(view_input_tensor)
                         dst_op._attrs["inputs"][idx] = view_input_tensor
                         view_input_tensor._attrs["dst_ops"].add(dst_op)
-                assert (
-                    found_tensor
-                ), f"Cannot find tensor {tensor} from dst_op inputs {dst_op._attrs['inputs']}!"
+                assert found_tensor, f"Cannot find tensor {tensor} from dst_op inputs {dst_op._attrs['inputs']}!"
                 to_be_removed_dst_ops.add(dst_op)
             tensor._attrs["dst_ops"] = tensor._attrs["dst_ops"] - to_be_removed_dst_ops
             if len(tensor._attrs["dst_ops"]) == 0:

--- a/python/aitemplate/compiler/transform/transform_strided_ops.py
+++ b/python/aitemplate/compiler/transform/transform_strided_ops.py
@@ -15,6 +15,7 @@
 """
 Perform transformations on ops which support strided inputs / outputs.
 """
+
 import functools
 
 from typing import List

--- a/python/aitemplate/compiler/transform/transform_strided_slice.py
+++ b/python/aitemplate/compiler/transform/transform_strided_slice.py
@@ -15,6 +15,7 @@
 """
 Perform transformations on slice and strided ops.
 """
+
 import math
 
 from typing import List

--- a/python/aitemplate/frontend/nn/attention.py
+++ b/python/aitemplate/frontend/nn/attention.py
@@ -15,6 +15,7 @@
 """
 Frontend for attention module
 """
+
 from aitemplate.compiler import ops
 from aitemplate.compiler.ops import flash_attention
 from aitemplate.compiler.ops.common.epilogue import FuncEnum

--- a/python/aitemplate/frontend/nn/batch_norm.py
+++ b/python/aitemplate/frontend/nn/batch_norm.py
@@ -15,6 +15,7 @@
 """
 Frontend for attention module
 """
+
 from aitemplate.compiler.public import elementwise, FuncEnum, permute
 from aitemplate.frontend.nn.module import Module
 from aitemplate.frontend.nn.parameter import Parameter

--- a/python/aitemplate/frontend/nn/conv1d.py
+++ b/python/aitemplate/frontend/nn/conv1d.py
@@ -15,6 +15,7 @@
 """
 Conv1d Module.
 """
+
 from aitemplate.compiler.ops import conv2d, conv2d_bias, squeeze, unsqueeze
 from aitemplate.frontend import Tensor
 from aitemplate.frontend.nn.module import Module

--- a/python/aitemplate/frontend/nn/conv2d/__init__.py
+++ b/python/aitemplate/frontend/nn/conv2d/__init__.py
@@ -16,6 +16,7 @@
 """
 modules for conv2d
 """
+
 from aitemplate.frontend.nn.conv2d.conv2d import Conv2d
 from aitemplate.frontend.nn.conv2d.conv2d_bias import Conv2dBias
 from aitemplate.frontend.nn.conv2d.conv2d_bias_add_hardswish import (

--- a/python/aitemplate/frontend/nn/conv2d/common_conv2d_bias_act.py
+++ b/python/aitemplate/frontend/nn/conv2d/common_conv2d_bias_act.py
@@ -15,6 +15,7 @@
 """
 common module for conv_bias_act subgraph
 """
+
 from aitemplate.compiler import ops
 from aitemplate.frontend.nn.module import Module
 from aitemplate.frontend.nn.parameter import Parameter

--- a/python/aitemplate/frontend/nn/conv2d/common_conv2d_bias_add_act.py
+++ b/python/aitemplate/frontend/nn/conv2d/common_conv2d_bias_add_act.py
@@ -15,6 +15,7 @@
 """
 common module for conv2d bias act residual add
 """
+
 from aitemplate.compiler import ops
 from aitemplate.frontend.nn.module import Module
 from aitemplate.frontend.nn.parameter import Parameter

--- a/python/aitemplate/frontend/nn/conv2d/conv2d.py
+++ b/python/aitemplate/frontend/nn/conv2d/conv2d.py
@@ -15,6 +15,7 @@
 """
 conv2d Module.
 """
+
 from aitemplate.compiler.ops import conv2d
 from aitemplate.frontend.nn.module import Module
 from aitemplate.frontend.nn.parameter import Parameter

--- a/python/aitemplate/frontend/nn/conv2d/conv2d_bias.py
+++ b/python/aitemplate/frontend/nn/conv2d/conv2d_bias.py
@@ -15,6 +15,7 @@
 """
 conv2d bias module
 """
+
 from aitemplate.frontend.nn.conv2d.common_conv2d_bias_act import Conv2dBiasAct
 
 

--- a/python/aitemplate/frontend/nn/conv2d/conv2d_bias_add_hardswish.py
+++ b/python/aitemplate/frontend/nn/conv2d/conv2d_bias_add_hardswish.py
@@ -15,6 +15,7 @@
 """
 conv2d + bias + residual + hardswish
 """
+
 from aitemplate.frontend.nn.conv2d.common_conv2d_bias_add_act import Conv2dBiasAddAct
 
 

--- a/python/aitemplate/frontend/nn/conv2d/conv2d_bias_add_relu.py
+++ b/python/aitemplate/frontend/nn/conv2d/conv2d_bias_add_relu.py
@@ -15,6 +15,7 @@
 """
 General template module for conv2e + bias + residual + relu
 """
+
 from aitemplate.frontend.nn.conv2d.common_conv2d_bias_add_act import Conv2dBiasAddAct
 
 

--- a/python/aitemplate/frontend/nn/conv2d/conv2d_bias_few_channels.py
+++ b/python/aitemplate/frontend/nn/conv2d/conv2d_bias_few_channels.py
@@ -15,6 +15,7 @@
 """
 conv2d bias for few channels
 """
+
 from aitemplate.frontend.nn.conv2d.special_conv2d_bias_act import SpecialConv2dBiasAct
 
 

--- a/python/aitemplate/frontend/nn/conv2d/conv2d_bias_hardswish.py
+++ b/python/aitemplate/frontend/nn/conv2d/conv2d_bias_hardswish.py
@@ -15,6 +15,7 @@
 """
 conv bias hardswish module
 """
+
 from aitemplate.frontend.nn.conv2d.common_conv2d_bias_act import Conv2dBiasAct
 
 

--- a/python/aitemplate/frontend/nn/conv2d/conv2d_bias_hardswish_few_channels.py
+++ b/python/aitemplate/frontend/nn/conv2d/conv2d_bias_hardswish_few_channels.py
@@ -15,6 +15,7 @@
 """
 conv2d bias hardswish module for few channels
 """
+
 from aitemplate.frontend.nn.conv2d.special_conv2d_bias_act import SpecialConv2dBiasAct
 
 

--- a/python/aitemplate/frontend/nn/conv2d/conv2d_bias_relu.py
+++ b/python/aitemplate/frontend/nn/conv2d/conv2d_bias_relu.py
@@ -15,6 +15,7 @@
 """
 conv2d bias relu module
 """
+
 from aitemplate.frontend.nn.conv2d.common_conv2d_bias_act import Conv2dBiasAct
 
 

--- a/python/aitemplate/frontend/nn/conv2d/conv2d_bias_relu_few_channels.py
+++ b/python/aitemplate/frontend/nn/conv2d/conv2d_bias_relu_few_channels.py
@@ -15,6 +15,7 @@
 """
 conv2d bias relu for few channels
 """
+
 from aitemplate.frontend.nn.conv2d.special_conv2d_bias_act import SpecialConv2dBiasAct
 
 

--- a/python/aitemplate/frontend/nn/conv2d/conv2d_bias_sigmoid.py
+++ b/python/aitemplate/frontend/nn/conv2d/conv2d_bias_sigmoid.py
@@ -15,6 +15,7 @@
 """
 conv2d bias sigmoid module
 """
+
 from aitemplate.frontend.nn.conv2d.common_conv2d_bias_act import Conv2dBiasAct
 
 

--- a/python/aitemplate/frontend/nn/conv2d/conv2d_depthwise.py
+++ b/python/aitemplate/frontend/nn/conv2d/conv2d_depthwise.py
@@ -15,6 +15,7 @@
 """
 conv2d depthwise module
 """
+
 from aitemplate.compiler.ops import conv2d_depthwise
 from aitemplate.frontend.nn.conv2d.conv2d import Conv2d
 

--- a/python/aitemplate/frontend/nn/conv2d/conv2d_depthwise_bias.py
+++ b/python/aitemplate/frontend/nn/conv2d/conv2d_depthwise_bias.py
@@ -15,6 +15,7 @@
 """
 conv2d depthwise bias module
 """
+
 from aitemplate.frontend.nn.conv2d.common_conv2d_bias_act import Conv2dBiasAct
 
 

--- a/python/aitemplate/frontend/nn/conv2d/special_conv2d_bias_act.py
+++ b/python/aitemplate/frontend/nn/conv2d/special_conv2d_bias_act.py
@@ -15,6 +15,7 @@
 """
 common module for conv_bias_act subgraph
 """
+
 from aitemplate.compiler import ops
 from aitemplate.frontend.nn.module import Module
 from aitemplate.frontend.nn.parameter import Parameter

--- a/python/aitemplate/frontend/nn/conv2d/transposed_conv2d_bias_act.py
+++ b/python/aitemplate/frontend/nn/conv2d/transposed_conv2d_bias_act.py
@@ -15,6 +15,7 @@
 """
 common module for ConvTranspose2d_bias_act subgraph
 """
+
 from aitemplate.compiler import ops
 from aitemplate.frontend.nn.module import Module
 from aitemplate.frontend.nn.parameter import Parameter

--- a/python/aitemplate/frontend/nn/conv2d/transposed_conv2d_bias_relu.py
+++ b/python/aitemplate/frontend/nn/conv2d/transposed_conv2d_bias_relu.py
@@ -15,6 +15,7 @@
 """
 conv2d bias relu module
 """
+
 from aitemplate.frontend.nn.conv2d.transposed_conv2d_bias_act import (
     ConvTranspose2dBiasAct,
 )

--- a/python/aitemplate/frontend/nn/conv3d.py
+++ b/python/aitemplate/frontend/nn/conv3d.py
@@ -15,6 +15,7 @@
 """
 conv3d Module.
 """
+
 from aitemplate.compiler.ops import conv3d, conv3d_bias, depthwise_conv3d
 from aitemplate.compiler.ops.padding.ndhwc3to8 import ndhwc3to8
 from aitemplate.frontend.nn.module import Module

--- a/python/aitemplate/frontend/nn/dropout.py
+++ b/python/aitemplate/frontend/nn/dropout.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 #
 """Dropout/DropPath placeholder"""
+
 from aitemplate.frontend.nn.module import Module
 
 # pylint: disable=C0103

--- a/python/aitemplate/frontend/nn/dual_gemm.py
+++ b/python/aitemplate/frontend/nn/dual_gemm.py
@@ -15,6 +15,7 @@
 """
 Frontend for attention module
 """
+
 from aitemplate.compiler import ops
 from aitemplate.frontend.nn.linear import Linear
 from aitemplate.frontend.nn.module import Module

--- a/python/aitemplate/frontend/nn/fpn_proposal.py
+++ b/python/aitemplate/frontend/nn/fpn_proposal.py
@@ -15,6 +15,7 @@
 """
 FPNProposal module.
 """
+
 import numpy as np
 
 from aitemplate.compiler import ops

--- a/python/aitemplate/frontend/nn/group_norm.py
+++ b/python/aitemplate/frontend/nn/group_norm.py
@@ -15,6 +15,7 @@
 """
 GroupNorm module
 """
+
 from aitemplate.compiler import ops
 from aitemplate.frontend.nn.module import Module
 from aitemplate.frontend.nn.parameter import Parameter

--- a/python/aitemplate/frontend/nn/identity.py
+++ b/python/aitemplate/frontend/nn/identity.py
@@ -15,6 +15,7 @@
 """
 Identity module.
 """
+
 from aitemplate.frontend.nn.module import Module
 
 # pylint: disable=C0103

--- a/python/aitemplate/frontend/nn/layer_norm.py
+++ b/python/aitemplate/frontend/nn/layer_norm.py
@@ -15,6 +15,7 @@
 """
 LayerNorm module.
 """
+
 from aitemplate.compiler import ops
 from aitemplate.frontend.nn.module import Module
 from aitemplate.frontend.nn.parameter import Parameter

--- a/python/aitemplate/frontend/nn/linear.py
+++ b/python/aitemplate/frontend/nn/linear.py
@@ -15,6 +15,7 @@
 """
 Linear module.
 """
+
 from aitemplate.compiler import ops
 from aitemplate.frontend.nn.module import Module
 from aitemplate.frontend.nn.parameter import Parameter

--- a/python/aitemplate/frontend/nn/padding.py
+++ b/python/aitemplate/frontend/nn/padding.py
@@ -15,6 +15,7 @@
 """
 Padding related modules.
 """
+
 from aitemplate.compiler.ops import ndhwc3to8, nhwc3to8
 from aitemplate.frontend.nn.module import Module
 

--- a/python/aitemplate/frontend/nn/parameter.py
+++ b/python/aitemplate/frontend/nn/parameter.py
@@ -15,6 +15,7 @@
 """
 Parameter definition.
 """
+
 from aitemplate.compiler.base import Tensor
 
 

--- a/python/aitemplate/frontend/nn/patch_embed.py
+++ b/python/aitemplate/frontend/nn/patch_embed.py
@@ -15,6 +15,7 @@
 """
 patch_embed Module.
 """
+
 from typing import Callable, Tuple
 
 from aitemplate.compiler import ops

--- a/python/aitemplate/frontend/nn/pool2d.py
+++ b/python/aitemplate/frontend/nn/pool2d.py
@@ -15,6 +15,7 @@
 """
 pool2d-family modules.
 """
+
 from aitemplate.compiler.ops import avg_pool2d, max_pool2d
 from aitemplate.frontend.nn.module import Module
 

--- a/python/aitemplate/frontend/nn/pool3d.py
+++ b/python/aitemplate/frontend/nn/pool3d.py
@@ -15,6 +15,7 @@
 """
 pool3d-family modules.
 """
+
 from aitemplate.compiler.ops import max_pool2d
 from aitemplate.compiler.ops.common import reshape
 from aitemplate.frontend.nn.module import Module

--- a/python/aitemplate/frontend/nn/positional_encoding.py
+++ b/python/aitemplate/frontend/nn/positional_encoding.py
@@ -15,6 +15,7 @@
 """
 positional_encoding Modules.
 """
+
 import logging
 from typing import Tuple
 

--- a/python/aitemplate/frontend/nn/proposal.py
+++ b/python/aitemplate/frontend/nn/proposal.py
@@ -15,6 +15,7 @@
 """
 Proposal module.
 """
+
 import math
 
 import numpy as np

--- a/python/aitemplate/frontend/nn/roi_ops.py
+++ b/python/aitemplate/frontend/nn/roi_ops.py
@@ -15,6 +15,7 @@
 """
 RoiAlign-family modules.
 """
+
 from aitemplate.compiler.ops import multi_level_roi_align, roi_align
 from aitemplate.frontend.nn.module import Module
 

--- a/python/aitemplate/frontend/nn/softmax.py
+++ b/python/aitemplate/frontend/nn/softmax.py
@@ -15,6 +15,7 @@
 """
 softmax Module.
 """
+
 from typing import Optional
 
 from aitemplate.compiler import ops

--- a/python/aitemplate/frontend/nn/upsample.py
+++ b/python/aitemplate/frontend/nn/upsample.py
@@ -15,6 +15,7 @@
 """
 Unsampling2d module.
 """
+
 from aitemplate.compiler.ops import upsampling2d, upsampling2d_add
 from aitemplate.frontend.nn.module import Module
 

--- a/python/aitemplate/frontend/nn/vanilla_attention.py
+++ b/python/aitemplate/frontend/nn/vanilla_attention.py
@@ -15,6 +15,7 @@
 """
 Frontend for vanilla attention module
 """
+
 from functools import partial
 
 from aitemplate.compiler import ops

--- a/python/aitemplate/frontend/nn/view_ops.py
+++ b/python/aitemplate/frontend/nn/view_ops.py
@@ -15,6 +15,7 @@
 """
 View-related modules.
 """
+
 from aitemplate.compiler.ops import flatten, reshape
 from aitemplate.frontend.nn.module import Module
 

--- a/python/aitemplate/frontend/parameter.py
+++ b/python/aitemplate/frontend/parameter.py
@@ -15,6 +15,7 @@
 """
 Parameter definition.
 """
+
 from aitemplate.compiler.base import Tensor
 
 

--- a/python/aitemplate/testing/__init__.py
+++ b/python/aitemplate/testing/__init__.py
@@ -15,6 +15,7 @@
 """
 testing module
 """
+
 from aitemplate.testing import benchmark_ait, benchmark_pt
 from aitemplate.testing.detect_target import detect_target
 from aitemplate.testing.profile import profile_callable

--- a/python/aitemplate/testing/benchmark_trt.py
+++ b/python/aitemplate/testing/benchmark_trt.py
@@ -15,6 +15,7 @@
 """
 helper functions to benchmark fx-trt
 """
+
 from aitemplate.testing.benchmark_pt import benchmark_torch_function  # usort:skip
 from torch_tensorrt.fx import lower
 from torch_tensorrt.fx.utils import LowerPrecision

--- a/python/aitemplate/testing/detect_target.py
+++ b/python/aitemplate/testing/detect_target.py
@@ -15,6 +15,7 @@
 """
 Automatic detect target for testing
 """
+
 import logging
 import os
 from subprocess import PIPE, Popen

--- a/python/aitemplate/testing/jagged_utils.py
+++ b/python/aitemplate/testing/jagged_utils.py
@@ -370,9 +370,7 @@ def batched_dense_vec_jagged_2d_mul_ref(
     return torch.matmul(
         vectors.unsqueeze(dim=2),  # [B, H, 1, N]
         padded_matrices.permute([0, 2, 1, 3]),  # [B, H, N, D]
-    ).squeeze(
-        dim=2
-    )  # [B, H, D]
+    ).squeeze(dim=2)  # [B, H, D]
 
 
 def add_jagged_dense_ref(

--- a/python/aitemplate/testing/profile.py
+++ b/python/aitemplate/testing/profile.py
@@ -15,6 +15,7 @@
 """
 Torch module profiling utility.
 """
+
 import logging
 from operator import itemgetter
 from typing import Callable, List, Tuple

--- a/python/aitemplate/testing/test_utils.py
+++ b/python/aitemplate/testing/test_utils.py
@@ -15,6 +15,7 @@
 """
 Utils for unit tests.
 """
+
 import contextlib
 import itertools
 import os

--- a/python/aitemplate/utils/environ.py
+++ b/python/aitemplate/utils/environ.py
@@ -15,6 +15,7 @@
 """
 A common place for holding AIT-related env control variables
 """
+
 import logging
 import os
 from typing import Optional

--- a/python/aitemplate/utils/io.py
+++ b/python/aitemplate/utils/io.py
@@ -15,6 +15,7 @@
 """
 Util functions to handle file or network io
 """
+
 import hashlib
 import logging
 import os

--- a/python/aitemplate/utils/markdown_table.py
+++ b/python/aitemplate/utils/markdown_table.py
@@ -18,6 +18,7 @@ Markdown table generator
 Original Project: https://github.com/hvalev/markdownTable
 Accessed: Jul 16, 2022
 """
+
 import math
 
 

--- a/python/aitemplate/utils/misc.py
+++ b/python/aitemplate/utils/misc.py
@@ -15,6 +15,7 @@
 """
 miscellaneous utilities
 """
+
 import hashlib
 import logging
 import os

--- a/python/aitemplate/utils/mk_cutlass_lib/extra_conv_emit.py
+++ b/python/aitemplate/utils/mk_cutlass_lib/extra_conv_emit.py
@@ -15,6 +15,7 @@
 """
 Extra cutlass enum, mainly for epilogue
 """
+
 import jinja2
 
 CONV_TEMPLATE = jinja2.Template(

--- a/python/aitemplate/utils/mk_cutlass_lib/extra_cutlass_generator.py
+++ b/python/aitemplate/utils/mk_cutlass_lib/extra_cutlass_generator.py
@@ -15,6 +15,7 @@
 """
 Extra cutlass tiling configs for special problems
 """
+
 import jinja2
 
 SRC_TEMPLATE = jinja2.Template(

--- a/python/aitemplate/utils/mk_cutlass_lib/extra_enum.py
+++ b/python/aitemplate/utils/mk_cutlass_lib/extra_enum.py
@@ -15,6 +15,7 @@
 """
 Extra cutlass enum, mainly for epilogue
 """
+
 import jinja2
 
 SRC_TEMPLATE = jinja2.Template(

--- a/python/aitemplate/utils/mk_cutlass_lib/extra_gemm_emit.py
+++ b/python/aitemplate/utils/mk_cutlass_lib/extra_gemm_emit.py
@@ -15,6 +15,7 @@
 """
 Extra cutlass enum, mainly for epilogue
 """
+
 import jinja2
 
 

--- a/python/aitemplate/utils/serialization/serdes_code.py
+++ b/python/aitemplate/utils/serialization/serdes_code.py
@@ -15,6 +15,7 @@
 """
 Dump/Read sorted_graph to/from python code.
 """
+
 import copy
 import logging
 import os

--- a/python/aitemplate/utils/visualization/plot.py
+++ b/python/aitemplate/utils/visualization/plot.py
@@ -15,6 +15,7 @@
 """
 Graph visualization tool for AITemplate
 """
+
 import json
 import os
 

--- a/python/aitemplate/utils/visualization/pydot.py
+++ b/python/aitemplate/utils/visualization/pydot.py
@@ -17,6 +17,7 @@
 Original Project: https://github.com/pydot/pydot
 Accessed: Jul 25, 2022
 """
+
 import copy
 import errno
 import io

--- a/tests/lint/check_meta_header.py
+++ b/tests/lint/check_meta_header.py
@@ -12,8 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-"""Check Python source code contains Meta copyright header
-"""
+"""Check Python source code contains Meta copyright header"""
 
 from __future__ import annotations
 

--- a/tests/unittest/compiler/test_fuse_bmm_permute.py
+++ b/tests/unittest/compiler/test_fuse_bmm_permute.py
@@ -67,7 +67,6 @@ class FuseBmmPermuteCase(unittest.TestCase):
         orig_layout: str,
         dtype: str = "float16",
     ):
-
         is_row_major_a = orig_layout[0] == "r"
         is_row_major_b = orig_layout[1] == "r"
         is_row_major_c = orig_layout[2] == "r"

--- a/tests/unittest/compiler/test_fused_elementwise_complex_dependency.py
+++ b/tests/unittest/compiler/test_fused_elementwise_complex_dependency.py
@@ -15,6 +15,7 @@
 """
 Unittests for elementwise fusion with complex dependencies.
 """
+
 import unittest
 
 import torch

--- a/tests/unittest/compiler/test_fused_elementwise_out_of_order.py
+++ b/tests/unittest/compiler/test_fused_elementwise_out_of_order.py
@@ -15,6 +15,7 @@
 """
 Unittests for elementwise fusion out-of-order cases.
 """
+
 import unittest
 
 import torch

--- a/tests/unittest/compiler/test_strided_layernorm.py
+++ b/tests/unittest/compiler/test_strided_layernorm.py
@@ -158,7 +158,6 @@ class SliceLayerNormTestCase(unittest.TestCase):
         test_name="test_slice_layer_norm",
         use_welford_algorithm=False,
     ):
-
         input_rank = 1 + len(input_nonbatch_shape)
         if 1 == len(start_indices) and len(start_indices) != input_rank:
             start_indices = [start_indices[0]] * input_rank

--- a/tests/unittest/ops/test_activation.py
+++ b/tests/unittest/ops/test_activation.py
@@ -15,6 +15,7 @@
 """
 Unittests for special activation Operator.
 """
+
 import unittest
 
 import torch

--- a/tests/unittest/ops/test_argmax.py
+++ b/tests/unittest/ops/test_argmax.py
@@ -15,6 +15,7 @@
 """
 Unittests for argmax Operator.
 """
+
 import unittest
 
 import torch

--- a/tests/unittest/ops/test_argmax_sm80.py
+++ b/tests/unittest/ops/test_argmax_sm80.py
@@ -15,6 +15,7 @@
 """
 Unittests for argmax Operator.
 """
+
 import unittest
 
 import torch

--- a/tests/unittest/ops/test_attention.py
+++ b/tests/unittest/ops/test_attention.py
@@ -15,6 +15,7 @@
 """
 Unittests for flash_attention Operator.
 """
+
 import itertools
 import logging
 import math

--- a/tests/unittest/ops/test_b2b_bmm.py
+++ b/tests/unittest/ops/test_b2b_bmm.py
@@ -15,6 +15,7 @@
 """
 Unittests for b2b bmm Operators.
 """
+
 import itertools
 import logging
 import unittest

--- a/tests/unittest/ops/test_batch_gather.py
+++ b/tests/unittest/ops/test_batch_gather.py
@@ -15,6 +15,7 @@
 """
 Unittests for batch_gather Operator.
 """
+
 import unittest
 
 import torch
@@ -46,7 +47,6 @@ class batchGatherTestCase(gatherTestCase):
         test_name="gather",
         dtype="float16",
     ):
-
         in_shape = shape
 
         o_shape = list(in_shape)
@@ -133,7 +133,6 @@ class batchGatherTopkTestCase(gatherTestCase):
         test_name="topk",
         dtype="float16",
     ):
-
         m_shape = (N,) + shape
         n_shape = (topK,) + shape
 

--- a/tests/unittest/ops/test_batched_dense_vec_jagged_2d_mul.py
+++ b/tests/unittest/ops/test_batched_dense_vec_jagged_2d_mul.py
@@ -15,6 +15,7 @@
 """
 Unittests for batched_dense_vec_jagged_2d_mul Operator.
 """
+
 import unittest
 from typing import List
 

--- a/tests/unittest/ops/test_efficient_nms.py
+++ b/tests/unittest/ops/test_efficient_nms.py
@@ -15,6 +15,7 @@
 """
 Unittests for nms Operator.
 """
+
 import os
 import shutil
 import unittest

--- a/tests/unittest/ops/test_fused_elementwise_broadcast.py
+++ b/tests/unittest/ops/test_fused_elementwise_broadcast.py
@@ -15,6 +15,7 @@
 """
 Unittests for fused_elementwise broadcast.
 """
+
 import itertools
 import unittest
 

--- a/tests/unittest/ops/test_fused_elementwise_with_strided_outputs.py
+++ b/tests/unittest/ops/test_fused_elementwise_with_strided_outputs.py
@@ -15,6 +15,7 @@
 """
 Unittests for fused_elementwise Operator with strided outputs.
 """
+
 import unittest
 
 from typing import List

--- a/tests/unittest/ops/test_grouped_b2b_bmm.py
+++ b/tests/unittest/ops/test_grouped_b2b_bmm.py
@@ -15,6 +15,7 @@
 """
 Unittests for grouped b2b bmm Operators.
 """
+
 import itertools
 import logging
 import os

--- a/tests/unittest/ops/test_grouped_classic_b2b_bmm.py
+++ b/tests/unittest/ops/test_grouped_classic_b2b_bmm.py
@@ -15,6 +15,7 @@
 """
 Unittests for grouped b2b bmm Operators.
 """
+
 import logging
 import os
 

--- a/tests/unittest/ops/test_groupnorm.py
+++ b/tests/unittest/ops/test_groupnorm.py
@@ -15,6 +15,7 @@
 """
 Unittests for group norm Operator.
 """
+
 import logging
 import unittest
 

--- a/tests/unittest/ops/test_index_select.py
+++ b/tests/unittest/ops/test_index_select.py
@@ -15,6 +15,7 @@
 """
 Unittests for masked_select Operator.
 """
+
 import logging
 import random
 import unittest
@@ -57,7 +58,6 @@ class IndexSelectTest(unittest.TestCase):
         benchmark=False,
         dim_idxs=None,
     ):
-
         X1 = Tensor(
             shape=shape if x_shape is None else x_shape,
             dtype=dtype,

--- a/tests/unittest/ops/test_layernorm.py
+++ b/tests/unittest/ops/test_layernorm.py
@@ -15,6 +15,7 @@
 """
 Unittests for LayerNorm Operator.
 """
+
 import logging
 import unittest
 

--- a/tests/unittest/ops/test_layernorm_sigmoid_mul.py
+++ b/tests/unittest/ops/test_layernorm_sigmoid_mul.py
@@ -15,6 +15,7 @@
 """
 Unittests for FusedLayernormSigmoidMul Operator.
 """
+
 import logging
 import unittest
 
@@ -130,7 +131,7 @@ class FusedLayernormSigmoidMulTestCase(unittest.TestCase):
                     inputs["beta"] = x3_pt
                 x6 = torch.empty_like(x6_pt)
                 module.run_with_tensors(inputs, [x6])
-                torch.testing.assert_close(x6, x6_pt, atol=atol, rtol=rtol),
+                (torch.testing.assert_close(x6, x6_pt, atol=atol, rtol=rtol),)
 
     def test_fused_layernorm_sigmoid_mul_fp16(self):
         for eps in (1e-5, 1e-1):

--- a/tests/unittest/ops/test_masked_select.py
+++ b/tests/unittest/ops/test_masked_select.py
@@ -15,6 +15,7 @@
 """
 Unittests for masked_select Operator.
 """
+
 import unittest
 
 import torch

--- a/tests/unittest/ops/test_nms.py
+++ b/tests/unittest/ops/test_nms.py
@@ -15,6 +15,7 @@
 """
 Unittests for nms Operator.
 """
+
 import unittest
 from unittest import skipIf
 

--- a/tests/unittest/ops/test_perm102_bmm_rcr.py
+++ b/tests/unittest/ops/test_perm102_bmm_rcr.py
@@ -20,7 +20,6 @@ in torch it is
 #      self._1085_1133, _2905_2929, self._1084_1132) # baddbmm(bias, X, W)
 """
 
-
 import unittest
 
 import torch

--- a/tests/unittest/ops/test_perm102_bmm_rrr.py
+++ b/tests/unittest/ops/test_perm102_bmm_rrr.py
@@ -20,7 +20,6 @@ in torch it is
 #      self._1085_1133, _2905_2929, self._1084_1132) # baddbmm(bias, X, W)
 """
 
-
 import unittest
 
 import torch

--- a/tests/unittest/ops/test_softmax.py
+++ b/tests/unittest/ops/test_softmax.py
@@ -15,6 +15,7 @@
 """
 Unittests for LayerNorm Operator.
 """
+
 import json
 import math
 import tempfile

--- a/tests/unittest/ops/test_topk.py
+++ b/tests/unittest/ops/test_topk.py
@@ -15,6 +15,7 @@
 """
 Unittests for topk Operator.
 """
+
 import unittest
 
 import numpy as np
@@ -46,7 +47,6 @@ class topkTestCase(unittest.TestCase):
         copy_op=False,
         dtype="float16",
     ):
-
         o_shape = list(shape)
         o_shape[-1] = topK
 

--- a/tests/unittest/ops/test_vanilla_attention.py
+++ b/tests/unittest/ops/test_vanilla_attention.py
@@ -15,6 +15,7 @@
 """
 Unittests for vanilla_attention.
 """
+
 import logging
 import math
 import os

--- a/tests/unittest/test_stable_set.py
+++ b/tests/unittest/test_stable_set.py
@@ -15,6 +15,7 @@
 """
 Unittests for StableSet.
 """
+
 import unittest
 
 from aitemplate.compiler.stable_set import StableSet

--- a/tests/unittest/util/test_debug_utils.py
+++ b/tests/unittest/util/test_debug_utils.py
@@ -15,6 +15,7 @@
 """
 Unittests for debug utils.
 """
+
 import numpy as np
 import pytest
 

--- a/tests/unittest/util/test_serdes.py
+++ b/tests/unittest/util/test_serdes.py
@@ -15,6 +15,7 @@
 """
 Unittests for special activation Operator.
 """
+
 import logging
 import unittest
 


### PR DESCRIPTION
Summary:
Converts the directory specified to use the Ruff formatter in pyfmt

ruff_dog

If this diff causes merge conflicts when rebasing, please run
`hg status -n -0 --change . -I '**/*.{py,pyi}' | xargs -0 arc pyfmt`
on your diff, and amend any changes before rebasing onto latest.
That should help reduce or eliminate any merge conflicts.

allow-large-files

Reviewed By: yhcharles

Differential Revision: D66675542
