### PR TITLE
Removing Pipes Import

### DIFF
--- a/python/aitemplate/backend/cuda/target_def.py
+++ b/python/aitemplate/backend/cuda/target_def.py
@@ -19,13 +19,13 @@ CUDA target specialization
 import json
 import logging
 import os
-import pipes
 import re
 import shutil
 import sys
 import tempfile
 
 from pathlib import Path
+from shlex import quote
 from typing import List
 
 from aitemplate.backend import registry
@@ -41,7 +41,6 @@ from aitemplate.backend.target import (
 
 from aitemplate.utils import environ
 from aitemplate.utils.misc import is_debug, is_linux
-
 # pylint: disable=C0415,W0707,W0611,W0702,W1401
 
 
@@ -414,7 +413,7 @@ class FBCUDA(CUDA):
             pp_args = self.nvcc_options_json["pp_args"]
             with open(fb_include_path, "w") as fb_include:
                 for arg in pp_args:
-                    fb_include.write(pipes.quote(arg) + "\n")
+                    fb_include.write(quote(arg) + "\n")
 
             nvcc_arch = self._arch
             if nvcc_arch == "90":


### PR DESCRIPTION
Summary:
Per [PEP 594](https://peps.python.org/pep-0594/#pipes), pipes was removed as apart of the "Removing dead batteries from the standard library".

So any versions of python after 3.12 will break when using cuda utils. One nice thing is that the way it was being used, it was just essentially calling `pipes` which was just using `shlex`. Therefore I just cut out the middleman and use `shlex` directly which is supported in later versions, [3.13](https://www.internalfb.com/code/search?q=filepath%3A3.13%20repo%3Aall%20shlex) and [3.14](https://www.internalfb.com/code/search?q=filepath%3A3.14%20repo%3Aall%20shlex).

Reviewed By: czardoz, muchulee8

Differential Revision: D78750508


